### PR TITLE
Fix PreInterpolate Filters getting applied twice when an Interpolator is active

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -239,7 +239,7 @@ namespace OpenTabletDriver.Daemon
                 Log.Write("Settings", $"Filters: {string.Join(", ", outputMode.Filters)}");
 
             outputMode.Tablet = Driver.Tablet;
-            outputMode.InterpolatorActive = Settings.Interpolators.Any();
+            outputMode.InterpolatorActive = Settings.Interpolators.Any(interp => interp.Enable);
         }
 
         private void SetAbsoluteModeSettings(AbsoluteOutputMode absoluteMode)

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -239,6 +239,7 @@ namespace OpenTabletDriver.Daemon
                 Log.Write("Settings", $"Filters: {string.Join(", ", outputMode.Filters)}");
 
             outputMode.Tablet = Driver.Tablet;
+            outputMode.InterpolatorActive = Settings.Interpolators.Any();
         }
 
         private void SetAbsoluteModeSettings(AbsoluteOutputMode absoluteMode)

--- a/OpenTabletDriver.Plugin/IDriver.cs
+++ b/OpenTabletDriver.Plugin/IDriver.cs
@@ -1,6 +1,5 @@
 using System;
 using OpenTabletDriver.Plugin.Output;
-using OpenTabletDriver.Plugin.Platform.Display;
 using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Plugin
@@ -12,7 +11,6 @@ namespace OpenTabletDriver.Plugin
         event EventHandler<TabletState> TabletChanged;
 
         bool EnableInput { set; get; }
-        bool InterpolatorActive { get; }
         TabletState Tablet { get; }
         IOutputMode OutputMode { set; get; }
 

--- a/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using OpenTabletDriver.Plugin.Attributes;
-using OpenTabletDriver.Plugin.Platform.Display;
 using OpenTabletDriver.Plugin.Platform.Pointer;
 using OpenTabletDriver.Plugin.Tablet;
 
@@ -21,7 +20,7 @@ namespace OpenTabletDriver.Plugin.Output
             set
             {
                 this.filters = value ?? Array.Empty<IFilter>();
-                if (Info.Driver.InterpolatorActive)
+                if (InterpolatorActive)
                     this.preFilters = Filters.Where(t => t.FilterStage == FilterStage.PreTranspose).ToList();
                 else
                     this.preFilters = Filters.Where(t => t.FilterStage == FilterStage.PreTranspose || t.FilterStage == FilterStage.PreInterpolate).ToList();
@@ -67,6 +66,7 @@ namespace OpenTabletDriver.Plugin.Output
 
         public bool AreaClipping { set; get; }
         public bool AreaLimiting { set; get; }
+        public bool InterpolatorActive { set; get; }
 
         protected void UpdateTransformMatrix()
         {

--- a/OpenTabletDriver.Plugin/Output/IOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/IOutputMode.cs
@@ -9,5 +9,6 @@ namespace OpenTabletDriver.Plugin.Output
         void Read(IDeviceReport report);
         IList<IFilter> Filters { set; get; }
         TabletState Tablet { set; get; }
+        bool InterpolatorActive { set; get; }
     }
 }

--- a/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
@@ -23,7 +23,7 @@ namespace OpenTabletDriver.Plugin.Output
             set
             {
                 this.filters = value ?? Array.Empty<IFilter>();
-                if (Info.Driver.InterpolatorActive)
+                if (InterpolatorActive)
                     this.preFilters = Filters.Where(t => t.FilterStage == FilterStage.PreTranspose).ToList();
                 else
                     this.preFilters = Filters.Where(t => t.FilterStage == FilterStage.PreTranspose || t.FilterStage == FilterStage.PreInterpolate).ToList();
@@ -80,6 +80,7 @@ namespace OpenTabletDriver.Plugin.Output
         }
 
         public TimeSpan ResetTime { set; get; }
+        public bool InterpolatorActive { set; get; }
 
         public virtual void Read(IDeviceReport report)
         {

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using HidSharp;
 using OpenTabletDriver.Devices;
@@ -40,7 +39,6 @@ namespace OpenTabletDriver
         protected virtual PluginManager PluginManager { get; } = new PluginManager();
         
         public bool EnableInput { set; get; }
-        public bool InterpolatorActive => Interpolators.Any();
 
         private TabletState tablet;
         public TabletState Tablet


### PR DESCRIPTION
Since we are early disposing interpolators now, the previous `InterpolatorActive` is now broken with where it is used.  This PR solves it by checking the `PluginSettingStoreCollection Interpolators` for any active interpolator instead of instances of interpolators (which is to be constructed later)

**Pre-PR**

PreInterpolate filters get applied twice when an interpolator is active, since InterpolatorActive is always false during `Filter { set; }`
It exists on both interpolator's Filter list and the output mode's preFilter list.

**Post-PR**

PreInterpolate filters applied only once when an interpolator is active.
It properly exists on just the interpolator's Filter list.