### PR TITLE
Fix area resize

### DIFF
--- a/OpenTabletDriver.Desktop/Settings.cs
+++ b/OpenTabletDriver.Desktop/Settings.cs
@@ -20,7 +20,7 @@ namespace OpenTabletDriver.Desktop
 
         private float _dW, _dH, _dX, _dY, _tW, _tH, _tX, _tY, _r, _xS, _yS, _relRot, _tP;
         private TimeSpan _rT;
-        private bool _lockar, _sizeChanging, _autoHook, _clipping, _areaLimiting, _lockUsableAreaDisplay, _lockUsableAreaTablet, _updateTAreatoDArea;
+        private bool _lockar, _sizeChanging, _autoHook, _clipping, _areaLimiting, _lockUsableAreaDisplay, _lockUsableAreaTablet;
         private PluginSettingStore _outputMode, _tipButton;
 
         private PluginSettingStoreCollection _filters = new PluginSettingStoreCollection(),
@@ -77,8 +77,7 @@ namespace OpenTabletDriver.Desktop
             {
                 var prevValue = DisplayWidth;
                 RaiseAndSetIfChanged(ref _dW, value);
-                if (UpdateTabletAreaToDisplayChanges)
-                    TabletWidth *= DisplayWidth / prevValue;
+                TabletWidth *= DisplayWidth / prevValue;
             }
             get => _dW;
         }
@@ -90,8 +89,7 @@ namespace OpenTabletDriver.Desktop
             {
                 var prevValue = DisplayHeight;
                 RaiseAndSetIfChanged(ref _dH, value);
-                if (UpdateTabletAreaToDisplayChanges)
-                    TabletHeight *= DisplayHeight / prevValue;
+                TabletHeight *= DisplayHeight / prevValue;
             }
             get => _dH;
         }
@@ -187,13 +185,6 @@ namespace OpenTabletDriver.Desktop
                     TabletHeight = DisplayHeight / DisplayWidth * TabletWidth;
             }
             get => _lockar;
-        }
-
-        [JsonProperty("UpdateTabletAreaToDisplayChanges")]
-        public bool UpdateTabletAreaToDisplayChanges
-        {
-            set => RaiseAndSetIfChanged(ref _updateTAreatoDArea, value);
-            get => _updateTAreatoDArea;
         }
 
         #endregion

--- a/OpenTabletDriver.Desktop/Settings.cs
+++ b/OpenTabletDriver.Desktop/Settings.cs
@@ -20,7 +20,7 @@ namespace OpenTabletDriver.Desktop
 
         private float _dW, _dH, _dX, _dY, _tW, _tH, _tX, _tY, _r, _xS, _yS, _relRot, _tP;
         private TimeSpan _rT;
-        private bool _lockar, _sizeChanging, _autoHook, _clipping, _areaLimiting, _lockUsableAreaDisplay, _lockUsableAreaTablet;
+        private bool _lockar, _sizeChanging, _autoHook, _clipping, _areaLimiting, _lockUsableAreaDisplay, _lockUsableAreaTablet, _updateTAreatoDArea;
         private PluginSettingStore _outputMode, _tipButton;
 
         private PluginSettingStoreCollection _filters = new PluginSettingStoreCollection(),
@@ -75,9 +75,10 @@ namespace OpenTabletDriver.Desktop
         {
             set
             {
+                var prevValue = DisplayWidth;
                 RaiseAndSetIfChanged(ref _dW, value);
-                if (LockAspectRatio)
-                    TabletHeight = DisplayHeight / DisplayWidth * TabletWidth;
+                if (UpdateTabletAreaToDisplayChanges)
+                    TabletWidth *= DisplayWidth / prevValue;
             }
             get => _dW;
         }
@@ -87,9 +88,10 @@ namespace OpenTabletDriver.Desktop
         {
             set
             {
+                var prevValue = DisplayHeight;
                 RaiseAndSetIfChanged(ref _dH, value);
-                if (LockAspectRatio)
-                    TabletWidth = DisplayWidth / DisplayHeight * TabletHeight;
+                if (UpdateTabletAreaToDisplayChanges)
+                    TabletHeight *= DisplayHeight / prevValue;
             }
             get => _dH;
         }
@@ -185,6 +187,13 @@ namespace OpenTabletDriver.Desktop
                     TabletHeight = DisplayHeight / DisplayWidth * TabletWidth;
             }
             get => _lockar;
+        }
+
+        [JsonProperty("UpdateTabletAreaToDisplayChanges")]
+        public bool UpdateTabletAreaToDisplayChanges
+        {
+            set => RaiseAndSetIfChanged(ref _updateTAreatoDArea, value);
+            get => _updateTAreatoDArea;
         }
 
         #endregion

--- a/OpenTabletDriver.UX/Controls/OutputModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/OutputModeEditor.cs
@@ -258,7 +258,7 @@ namespace OpenTabletDriver.UX.Controls
                     this.ToolTip = "You can right click the area editor to enable aspect ratio locking, adjust alignment, or resize the area.";
                 }
 
-                private BooleanCommand lockAr, areaClipping, ignoreOutsideArea, updateOnDisplayChange;
+                private BooleanCommand lockAr, areaClipping, ignoreOutsideArea;
 
                 public void Rebind(Settings settings)
                 {
@@ -271,7 +271,6 @@ namespace OpenTabletDriver.UX.Controls
                     lockAr?.CheckedBinding.BindDataContext<Settings>(m => m.LockAspectRatio);
                     areaClipping?.CheckedBinding.BindDataContext<Settings>(m => m.EnableClipping);
                     ignoreOutsideArea?.CheckedBinding.BindDataContext<Settings>(m => m.EnableAreaLimiting);
-                    updateOnDisplayChange?.CheckedBinding.BindDataContext<Settings>(m => m.UpdateTabletAreaToDisplayChanges);
                 }
 
                 protected override void OnLoadComplete(EventArgs e)
@@ -298,19 +297,12 @@ namespace OpenTabletDriver.UX.Controls
                         DataContext = App.Settings
                     };
 
-                    updateOnDisplayChange = new BooleanCommand
-                    {
-                        MenuText = "Update proportionally to display area change",
-                        DataContext = App.Settings
-                    };
-
                     base.ContextMenu.Items.AddRange(
                         new Command[]
                         {
                             lockAr,
                             areaClipping,
-                            ignoreOutsideArea,
-                            updateOnDisplayChange
+                            ignoreOutsideArea
                         }
                     );
 

--- a/OpenTabletDriver.UX/Controls/OutputModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/OutputModeEditor.cs
@@ -255,9 +255,10 @@ namespace OpenTabletDriver.UX.Controls
                 public TabletAreaEditor()
                     : base()
                 {
-                    this.ToolTip = "You can right click the area editor to enable aspect ratio locking, adjust alignment, or resize the area.";                }
+                    this.ToolTip = "You can right click the area editor to enable aspect ratio locking, adjust alignment, or resize the area.";
+                }
 
-                private BooleanCommand lockAr, areaClipping, ignoreOutsideArea;
+                private BooleanCommand lockAr, areaClipping, ignoreOutsideArea, updateOnDisplayChange;
 
                 public void Rebind(Settings settings)
                 {
@@ -270,6 +271,7 @@ namespace OpenTabletDriver.UX.Controls
                     lockAr?.CheckedBinding.BindDataContext<Settings>(m => m.LockAspectRatio);
                     areaClipping?.CheckedBinding.BindDataContext<Settings>(m => m.EnableClipping);
                     ignoreOutsideArea?.CheckedBinding.BindDataContext<Settings>(m => m.EnableAreaLimiting);
+                    updateOnDisplayChange?.CheckedBinding.BindDataContext<Settings>(m => m.UpdateTabletAreaToDisplayChanges);
                 }
 
                 protected override void OnLoadComplete(EventArgs e)
@@ -296,12 +298,19 @@ namespace OpenTabletDriver.UX.Controls
                         DataContext = App.Settings
                     };
 
+                    updateOnDisplayChange = new BooleanCommand
+                    {
+                        MenuText = "Update proportionally to display area change",
+                        DataContext = App.Settings
+                    };
+
                     base.ContextMenu.Items.AddRange(
                         new Command[]
                         {
                             lockAr,
                             areaClipping,
-                            ignoreOutsideArea
+                            ignoreOutsideArea,
+                            updateOnDisplayChange
                         }
                     );
 


### PR DESCRIPTION
## Changes

- Add "Update proportionally to display area change" on tablet area editor context menu.
- Fix "Tablet area resize is performed in reverse when changing display area size".

## Test

1. Enable Lock Aspect Ratio (required for Pre-PR to trigger the bug)
2. Change display area to quarter area (manual editing or changing mapped monitor of different resolution also triggers the bug)

### Pre-PR

The tablet area becomes bigger instead of smaller to maintain the *feel* or physical distance travelled to reach the same point on screen.

### Post-PR

Tablet area resizes to a quarter of its original size, reflecting the changes that happened on display area.