### PR TITLE
Improve border visibility on WPF

### DIFF
--- a/OpenTabletDriver.UX/Controls/Area/AreaDisplay.cs
+++ b/OpenTabletDriver.UX/Controls/Area/AreaDisplay.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using System.Numerics;
 using Eto.Drawing;
 using Eto.Forms;
+using OpenTabletDriver.Interop;
+using OpenTabletDriver.Plugin;
 using OpenTabletDriver.UX.Controls.Generic;
 
 namespace OpenTabletDriver.UX.Controls.Area
@@ -21,7 +23,12 @@ namespace OpenTabletDriver.UX.Controls.Area
         private static readonly Brush TextBrush = new SolidBrush(SystemColors.ControlText);
 
         private readonly Color AccentColor = SystemColors.Highlight;
-        private readonly Color AreaBoundsBorderColor = SystemColors.Control;
+        private readonly Color AreaBoundsBorderColor = SystemInterop.CurrentPlatform switch
+        {
+            PluginPlatform.Windows => new Color(64, 64, 64),
+            _                      => SystemColors.Control
+        };
+
         private readonly Color AreaBoundsFillColor = SystemColors.ControlBackground;
 
         private bool mouseDragging;
@@ -188,6 +195,7 @@ namespace OpenTabletDriver.UX.Controls.Area
             foreach (var rect in ViewModel.Background)
             {
                 var scaledRect = rect * scale;
+                scaledRect.Height -= 1; // Workaround bottom border not showing up on Windows
                 graphics.FillRectangle(AreaBoundsFillColor, scaledRect);
                 graphics.DrawRectangle(AreaBoundsBorderColor, scaledRect);
             }

--- a/OpenTabletDriver.UX/Controls/Area/AreaDisplay.cs
+++ b/OpenTabletDriver.UX/Controls/Area/AreaDisplay.cs
@@ -195,7 +195,6 @@ namespace OpenTabletDriver.UX.Controls.Area
             foreach (var rect in ViewModel.Background)
             {
                 var scaledRect = rect * scale;
-                scaledRect.Height -= 1; // Workaround bottom border not showing up on Windows
                 graphics.FillRectangle(AreaBoundsFillColor, scaledRect);
                 graphics.DrawRectangle(AreaBoundsBorderColor, scaledRect);
             }
@@ -272,8 +271,8 @@ namespace OpenTabletDriver.UX.Controls.Area
 
         private float CalculateScale(RectangleF rect)
         {
-            float scaleX = this.ClientSize.Width / rect.Width;
-            float scaleY = this.ClientSize.Height / rect.Height;
+            float scaleX = (this.ClientSize.Width - 2) / rect.Width;
+            float scaleY = (this.ClientSize.Height - 2) / rect.Height;
             return scaleX > scaleY ? scaleY : scaleX;
         }
 


### PR DESCRIPTION
Also fixes issues with missing bottom border (probably WPF-only issue) by scaling down the rectangle to fit the border to `Panel`.

![image](https://user-images.githubusercontent.com/10338031/109341065-d34de800-78a4-11eb-96d5-802f1bc7cb56.png)