### PR TITLE
Fix lost data context on some context menu entries

### DIFF
--- a/OpenTabletDriver.UX/Controls/Area/AreaDisplay.cs
+++ b/OpenTabletDriver.UX/Controls/Area/AreaDisplay.cs
@@ -11,9 +11,14 @@ namespace OpenTabletDriver.UX.Controls.Area
 {
     public class AreaDisplay : TimedDrawable, IViewModelRoot<AreaViewModel>
     {
+        public AreaDisplay(AreaViewModel viewModel)
+        {
+            this.ViewModel = viewModel;
+        }
+
         public AreaViewModel ViewModel
         {
-            set => this.DataContext = value;
+            private set => this.DataContext = value;
             get => (AreaViewModel)this.DataContext;
         }
 

--- a/OpenTabletDriver.UX/Controls/Area/AreaEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Area/AreaEditor.cs
@@ -1,4 +1,3 @@
-using System;
 using Eto.Drawing;
 using Eto.Forms;
 using OpenTabletDriver.UX.Controls.Generic;
@@ -9,20 +8,9 @@ namespace OpenTabletDriver.UX.Controls.Area
 {
     public class AreaEditor : Panel, IViewModelRoot<AreaViewModel>
     {
-        public AreaViewModel ViewModel
+        public AreaEditor(AreaViewModel viewModel)
         {
-            set => this.DataContext = value;
-            get => (AreaViewModel)this.DataContext;
-        }
-
-        private MaskedTextBox<float> width, height, x, y, rotation;
-        private BooleanCommand lockToUsableArea;
-
-        protected AreaDisplay Display { set; get; }
-
-        protected override void OnLoadComplete(EventArgs e)
-        {
-            base.OnLoadComplete(e);
+            ViewModel = viewModel;
 
             StackLayout settingsPanel;
 
@@ -38,10 +26,7 @@ namespace OpenTabletDriver.UX.Controls.Area
                         Control = new Panel
                         {
                             Padding = new Padding(5),
-                            Content = this.Display ??= new AreaDisplay
-                            {
-                                ViewModel = this.ViewModel
-                            }
+                            Content = this.Display ??= new AreaDisplay(this.ViewModel)
                         }
                     },
                     new StackLayoutItem
@@ -227,6 +212,17 @@ namespace OpenTabletDriver.UX.Controls.Area
 
             BindAllToDataContext();
         }
+
+        public AreaViewModel ViewModel
+        {
+            private set => this.DataContext = value;
+            get => (AreaViewModel)this.DataContext;
+        }
+
+        private MaskedTextBox<float> width, height, x, y, rotation;
+        private BooleanCommand lockToUsableArea;
+
+        protected AreaDisplay Display { set; get; }
 
         public void BindAllToDataContext()
         {

--- a/OpenTabletDriver.UX/Controls/OutputModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/OutputModeEditor.cs
@@ -223,20 +223,17 @@ namespace OpenTabletDriver.UX.Controls
 
                     lockAr = new BooleanCommand
                     {
-                        MenuText = "Lock aspect ratio",
-                        DataContext = App.Settings
+                        MenuText = "Lock aspect ratio"
                     };
 
                     areaClipping = new BooleanCommand
                     {
-                        MenuText = "Area clipping",
-                        DataContext = App.Settings
+                        MenuText = "Area clipping"
                     };
 
                     ignoreOutsideArea = new BooleanCommand
                     {
-                        MenuText = "Ignore input outside area",
-                        DataContext = App.Settings
+                        MenuText = "Ignore input outside area"
                     };
 
                     base.ContextMenu.Items.AddRange(
@@ -266,6 +263,9 @@ namespace OpenTabletDriver.UX.Controls
 
                 public void Rebind(Settings settings)
                 {
+                    lockAr.DataContext = settings;
+                    areaClipping.DataContext = settings;
+                    ignoreOutsideArea.DataContext = settings;
                     this.Bind(c => c.ViewModel.Width, settings, m => m.TabletWidth);
                     this.Bind(c => c.ViewModel.Height, settings, m => m.TabletHeight);
                     this.Bind(c => c.ViewModel.X, settings, m => m.TabletX);

--- a/OpenTabletDriver.UX/IViewModelRoot.cs
+++ b/OpenTabletDriver.UX/IViewModelRoot.cs
@@ -4,6 +4,6 @@ namespace OpenTabletDriver.UX
 {
     public interface IViewModelRoot<T> where T : INotifyPropertyChanged
     {
-        T ViewModel { set; get; }
+        T ViewModel { get; }
     }
 }

--- a/OpenTabletDriver.UX/Windows/Greeter/Pages/AreaEditorPage.cs
+++ b/OpenTabletDriver.UX/Windows/Greeter/Pages/AreaEditorPage.cs
@@ -20,23 +20,20 @@ namespace OpenTabletDriver.UX.Windows.Greeter.Pages
                     Control = new Group
                     {
                         Text = "Demo Area Editor",
-                        Content = new AreaEditor
+                        Content = new AreaEditor(new AreaViewModel
                         {
-                            ViewModel = new AreaViewModel
+                            Width = 75,
+                            Height = 75,
+                            X = 75,
+                            Y = 75,
+                            Rotation = 15,
+                            Unit = "mm",
+                            EnableRotation = true,
+                            Background = new RectangleF[]
                             {
-                                Width = 75,
-                                Height = 75,
-                                X = 75,
-                                Y = 75,
-                                Rotation = 15,
-                                Unit = "mm",
-                                EnableRotation = true,
-                                Background = new RectangleF[]
-                                {
-                                    new RectangleF(0, 0, 150, 150)
-                                }
+                                new RectangleF(0, 0, 150, 150)
                             }
-                        }
+                        })
                     }
                 },
                 new StylizedText("This is the area editor.", SystemFonts.Bold(9), new Padding(0, 0, 0, 4)),


### PR DESCRIPTION
Fixes #818
Depends on #801

## Test

Save a separate settings with unlocked aspect ratio with non-matching ratio of display and tablet, lock aspect ratio then load the separate settings with `File -> Load Settings`

### Pre-PR

Some context menu don't update appropriately and is left pointing to the old Settings instance.

Affected:
- "Lock aspect ratio"
- "Area clipping"
- "Ignore input outside area"

### Post-PR

Works as expected.