### PR TITLE
Add Wacom Bamboo report parsing

### DIFF
--- a/OpenTabletDriver/Configurations/Wacom/MTE-450.json
+++ b/OpenTabletDriver/Configurations/Wacom/MTE-450.json
@@ -39,7 +39,7 @@
       "ProductID": 101,
       "InputReportLength": 9,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Tablet.TabletReportParser",
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.BambooReportParser",
       "FeatureInitReport": "AgI=",
       "OutputInitReport": null,
       "DeviceStrings": {},

--- a/OpenTabletDriver/Vendors/Wacom/BambooReport.cs
+++ b/OpenTabletDriver/Vendors/Wacom/BambooReport.cs
@@ -17,7 +17,7 @@ namespace OpenTabletDriver.Vendors.Wacom
                 Y = BitConverter.ToUInt16(report, 4)
             };
             Pressure = (uint)(report[6] | ((report[7] & 0x01) << 8));
-            Eraser = ((report[1] >> 1) & (1 << 4)) != 0;
+            Eraser = (report[1] & (1 << 5)) != 0;
 
             PenButtons = new bool[]
             {
@@ -26,10 +26,10 @@ namespace OpenTabletDriver.Vendors.Wacom
             };
             AuxButtons = new bool[]
             {
-                ((report[7] >> 3) & (1 << 0)) != 0,
-                ((report[7] >> 3) & (1 << 1)) != 0,
-                ((report[7] >> 3) & (1 << 2)) != 0,
-                ((report[7] >> 3) & (1 << 3)) != 0
+                (report[7] & (1 << 3)) != 0,
+                (report[7] & (1 << 4)) != 0,
+                (report[7] & (1 << 5)) != 0,
+                (report[7] & (1 << 6)) != 0
             };
         }
 

--- a/OpenTabletDriver/Vendors/Wacom/BambooReport.cs
+++ b/OpenTabletDriver/Vendors/Wacom/BambooReport.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Numerics;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Vendors.Wacom
+{
+    public struct BambooReport : ITabletReport, IAuxReport, IEraserReport
+    {
+        public BambooReport(byte[] report)
+        {
+            Raw = report;
+
+            ReportID = (uint)report[1] >> 1;
+            Position = new Vector2
+            {
+                X = BitConverter.ToUInt16(report, 2),
+                Y = BitConverter.ToUInt16(report, 4)
+            };
+            Pressure = (uint)(report[6] | ((report[7] & 0x01) << 8));
+            Eraser = ((report[1] >> 1) & (1 << 4)) != 0;
+
+            PenButtons = new bool[]
+            {
+                (report[1] & (1 << 1)) != 0,
+                (report[1] & (1 << 2)) != 0
+            };
+            AuxButtons = new bool[]
+            {
+                ((report[7] >> 3) & (1 << 0)) != 0,
+                ((report[7] >> 3) & (1 << 1)) != 0,
+                ((report[7] >> 3) & (1 << 2)) != 0,
+                ((report[7] >> 3) & (1 << 3)) != 0
+            };
+        }
+
+        public byte[] Raw { set; get; }
+        public uint ReportID { set; get; }
+        public Vector2 Position { set; get; }
+        public uint Pressure { set; get; }
+        public bool[] PenButtons { set; get; }
+        public bool[] AuxButtons { set; get; }
+        public bool Eraser { set; get; }
+    }
+}

--- a/OpenTabletDriver/Vendors/Wacom/BambooReportParser.cs
+++ b/OpenTabletDriver/Vendors/Wacom/BambooReportParser.cs
@@ -1,0 +1,12 @@
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Vendors.Wacom
+{
+    public class BambooReportParser : IReportParser<IDeviceReport>
+    {
+        public IDeviceReport Parse(byte[] report)
+        {
+            return new BambooReport(report);
+        }
+    }
+}


### PR DESCRIPTION
- Added `IAuxReport` and `IEraserReport` support to old Wacom Bamboo tablets' report parser.