### PR TITLE
Reduce PluginManager ctor time

### DIFF
--- a/OpenTabletDriver.Desktop/Reflection/DesktopPluginManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/DesktopPluginManager.cs
@@ -108,9 +108,8 @@ namespace OpenTabletDriver.Desktop.Reflection
 
                 try
                 {
-                    var pluginTypeInfo = type.GetTypeInfo();
-                    if (!pluginTypes.Contains(pluginTypeInfo))
-                        pluginTypes.Add(pluginTypeInfo);
+                    if (!pluginTypes.Contains(type))
+                        pluginTypes.Add(type);
                 }
                 catch
                 {
@@ -217,9 +216,7 @@ namespace OpenTabletDriver.Desktop.Reflection
         {
             try
             {
-                var types = from type in asm.GetTypes()
-                    select type.GetTypeInfo();
-                pluginTypes = new ConcurrentBag<Type>(pluginTypes.Except(types));
+                pluginTypes = new ConcurrentBag<Type>(pluginTypes.Except(asm.ExportedTypes));
                 return true;
             }
             catch (Exception ex)

--- a/OpenTabletDriver.Desktop/Reflection/DesktopPluginManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/DesktopPluginManager.cs
@@ -92,11 +92,9 @@ namespace OpenTabletDriver.Desktop.Reflection
 
         protected void ImportTypes(PluginContext context)
         {
-            var types = from asm in context.Assemblies
-                where IsLoadable(asm)
-                from type in asm.GetExportedTypes()
-                where IsPluginType(type)
-                select type;
+            var types = context.Assemblies
+                .SelectMany(asm => SafeGetTypes(asm))
+                .Where(type => IsPluginType(type));
 
             types.AsParallel().ForAll(type =>
             {
@@ -221,7 +219,7 @@ namespace OpenTabletDriver.Desktop.Reflection
             {
                 var types = from type in asm.GetTypes()
                     select type.GetTypeInfo();
-                pluginTypes = new ConcurrentBag<TypeInfo>(pluginTypes.Except(types));
+                pluginTypes = new ConcurrentBag<Type>(pluginTypes.Except(types));
                 return true;
             }
             catch (Exception ex)

--- a/OpenTabletDriver.Desktop/Reflection/DesktopPluginManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/DesktopPluginManager.cs
@@ -122,7 +122,7 @@ namespace OpenTabletDriver.Desktop.Reflection
 
                 if (!pluginTypes.Contains(type))
                     pluginTypes.Add(type);
-            };
+            }
         }
 
         public bool InstallPlugin(string filePath)

--- a/OpenTabletDriver.UX/Controls/Generic/TypeDropDown.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/TypeDropDown.cs
@@ -12,13 +12,13 @@ namespace OpenTabletDriver.UX.Controls.Generic
     {
         public TypeDropDown()
         {
-            this.ItemTextBinding = Binding.Property<TypeInfo, string>(t => GetFriendlyName(t));
-            this.ItemKeyBinding = Binding.Property<TypeInfo, string>(t => t.FullName);
+            this.ItemTextBinding = Binding.Property<Type, string>(t => GetFriendlyName(t));
+            this.ItemKeyBinding = Binding.Property<Type, string>(t => t.FullName);
 
             Refresh();
         }
 
-        public IEnumerable<TypeInfo> Types { protected set; get; }
+        public IEnumerable<Type> Types { protected set; get; }
 
         public void Refresh()
         {
@@ -27,10 +27,10 @@ namespace OpenTabletDriver.UX.Controls.Generic
                 select type;
         }
 
-        public TypeInfo SelectedType
+        public Type SelectedType
         {
             set => this.SelectedValue = value;
-            get => (TypeInfo)this.SelectedValue;
+            get => (Type)this.SelectedValue;
         }
 
         public T ConstructSelectedType(params object[] args)
@@ -46,7 +46,7 @@ namespace OpenTabletDriver.UX.Controls.Generic
 
         public void Select(Func<T, bool> predicate)
         {
-            foreach (TypeInfo type in Types)
+            foreach (Type type in Types)
             {
                 var obj = AppInfo.PluginManager.ConstructObject<T>(type.FullName);
                 if (predicate(obj))
@@ -57,7 +57,7 @@ namespace OpenTabletDriver.UX.Controls.Generic
             }
         }
 
-        protected string GetFriendlyName(TypeInfo t)
+        protected string GetFriendlyName(Type t)
         {
             return t.GetCustomAttribute<PluginNameAttribute>()?.Name ?? t.FullName;
         }

--- a/OpenTabletDriver/Reflection/PluginManager.cs
+++ b/OpenTabletDriver/Reflection/PluginManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Attributes;
@@ -11,34 +12,33 @@ namespace OpenTabletDriver.Reflection
 {
     public class PluginManager
     {
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public PluginManager()
         {
-            var internalTypes = from asm in AssemblyLoadContext.Default.Assemblies
-                where IsLoadable(asm)
-                from type in asm.DefinedTypes
-                where type.IsPublic && !(type.IsInterface || type.IsAbstract)
-                where IsPluginType(type)
-                where IsPlatformSupported(type)
-                select type;
+            var internalTypes = AssemblyLoadContext.Default.Assemblies
+                .Where(asm => asm != pluginAsm)
+                .SelectMany(asm => SafeGetTypes(asm))
+                .Where(type => type.IsPublic && !(type.IsInterface || type.IsAbstract))
+                .Where(type => IsPluginType(type) && IsPlatformSupported(type));
 
-            pluginTypes = new ConcurrentBag<TypeInfo>(internalTypes);
+            pluginTypes = new ConcurrentBag<Type>(internalTypes);
         }
 
-        public IReadOnlyCollection<TypeInfo> PluginTypes => pluginTypes;
-        protected ConcurrentBag<TypeInfo> pluginTypes;
+        public IReadOnlyCollection<Type> PluginTypes => pluginTypes;
+        protected ConcurrentBag<Type> pluginTypes;
 
-        protected readonly static IEnumerable<Type> libTypes =
-            from type in Assembly.GetAssembly(typeof(IDriver)).GetExportedTypes()
-                where type.IsAbstract || type.IsInterface
-                select type;
+        protected readonly static Assembly pluginAsm = Assembly.GetAssembly(typeof(IDriver));
+        protected readonly static Type[] libTypes = pluginAsm.ExportedTypes
+            .Where(type => type.IsAbstract | type.IsInterface)
+            .ToArray();
 
-        public virtual PluginReference GetPluginReference(string path) => new PluginReference(this, path);
-        public virtual PluginReference GetPluginReference(Type type) => GetPluginReference(type.FullName);
-        public virtual PluginReference GetPluginReference(object obj) => GetPluginReference(obj.GetType());
+        public PluginReference GetPluginReference(string path) => new PluginReference(this, path);
+        public PluginReference GetPluginReference(Type type) => GetPluginReference(type.FullName);
+        public PluginReference GetPluginReference(object obj) => GetPluginReference(obj.GetType());
 
-        public virtual T ConstructObject<T>(string name, object[] args = null) where T : class
+        public T ConstructObject<T>(string name, object[] args = null) where T : class
         {
-            args ??= new object[0];
+            args ??= Array.Empty<object>();
             if (!string.IsNullOrWhiteSpace(name))
             {
                 try
@@ -64,7 +64,7 @@ namespace OpenTabletDriver.Reflection
             return null;
         }
 
-        public virtual IReadOnlyCollection<TypeInfo> GetChildTypes<T>()
+        public IReadOnlyCollection<Type> GetChildTypes<T>()
         {
             var children = from type in PluginTypes
                 where typeof(T).IsAssignableFrom(type)
@@ -73,7 +73,7 @@ namespace OpenTabletDriver.Reflection
             return children.ToArray();
         }
 
-        protected virtual bool IsValidParameterFor(object[] args, ParameterInfo[] parameters)
+        protected bool IsValidParameterFor(object[] args, ParameterInfo[] parameters)
         {
             for (int i = 0; i < parameters.Length; i++)
             {
@@ -85,36 +85,35 @@ namespace OpenTabletDriver.Reflection
             return true;
         }
 
-        protected virtual bool IsPluginType(Type type)
+        protected bool IsPluginType(Type type)
         {
-            return !type.IsAbstract && !type.IsInterface &&
+            return !type.IsAbstract & !type.IsInterface &&
                 libTypes.Any(t => t.IsAssignableFrom(type) ||
                     type.GetInterfaces().Any(x => x.IsGenericType && x.GetGenericTypeDefinition() == t));
         }
 
-        protected virtual bool IsPlatformSupported(Type type)
+        protected bool IsPlatformSupported(Type type)
         {
-            var attr = (SupportedPlatformAttribute)type.GetCustomAttribute(typeof(SupportedPlatformAttribute), false);
+            var attr = type.GetCustomAttribute<SupportedPlatformAttribute>(false);
             return attr?.IsCurrentPlatform ?? true;
         }
 
-        protected virtual bool IsPluginIgnored(Type type)
+        protected bool IsPluginIgnored(Type type)
         {
-            return type.GetCustomAttributes(false).Any(a => a.GetType() == typeof(PluginIgnoreAttribute));
+            return type.GetCustomAttribute<PluginIgnoreAttribute>(false) is PluginIgnoreAttribute;
         }
 
-        protected virtual bool IsLoadable(Assembly asm)
+        protected IEnumerable<Type> SafeGetTypes(Assembly asm)
         {
             try
             {
-                _ = asm.DefinedTypes;
-                return true;
+                return asm.ExportedTypes;
             }
             catch
             {
                 var asmName = asm.GetName();
                 Log.Write("Plugin", $"Plugin '{asmName.Name}, Version={asmName.Version}' can't be loaded and is likely out of date.", LogLevel.Warning);
-                return false;
+                return Array.Empty<Type>();
             }
         }
     }

--- a/OpenTabletDriver/Reflection/PluginManager.cs
+++ b/OpenTabletDriver/Reflection/PluginManager.cs
@@ -15,11 +15,20 @@ namespace OpenTabletDriver.Reflection
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public PluginManager()
         {
-            var internalTypes = AssemblyLoadContext.Default.Assemblies
-                .Where(asm => asm != pluginAsm)
-                .SelectMany(asm => SafeGetTypes(asm))
-                .Where(type => type.IsPublic && !(type.IsInterface || type.IsAbstract))
-                .Where(type => IsPluginType(type) && IsPlatformSupported(type));
+            Type[] internalTypes;
+            try
+            {
+                internalTypes = AssemblyLoadContext.Default.Assemblies
+                    .Where(asm => asm != pluginAsm)
+                    .SelectMany(asm => asm.Modules)
+                    .Where(module => module.Name.Contains("OpenTabletDriver"))
+                    .SelectMany(module => module.FindTypes(internalPluginFilter, null))
+                    .ToArray();
+            }
+            catch (ReflectionTypeLoadException e)
+            {
+                internalTypes = e.Types.Where(t => t != null).ToArray();
+            }
 
             pluginTypes = new ConcurrentBag<Type>(internalTypes);
         }
@@ -27,10 +36,10 @@ namespace OpenTabletDriver.Reflection
         public IReadOnlyCollection<Type> PluginTypes => pluginTypes;
         protected ConcurrentBag<Type> pluginTypes;
 
-        protected readonly static Assembly pluginAsm = Assembly.GetAssembly(typeof(IDriver));
-        protected readonly static Type[] libTypes = pluginAsm.ExportedTypes
-            .Where(type => type.IsAbstract | type.IsInterface)
-            .ToArray();
+        private readonly static Assembly pluginAsm = Assembly.GetAssembly(typeof(IDriver));
+        private readonly static Type[] libTypes = pluginAsm.Modules
+            .Where(module => module.Name.Contains("OpenTabletDriver"))
+            .SelectMany(module => module.FindTypes(libTypeFilter, null)).ToArray();
 
         public PluginReference GetPluginReference(string path) => new PluginReference(this, path);
         public PluginReference GetPluginReference(Type type) => GetPluginReference(type.FullName);
@@ -73,7 +82,7 @@ namespace OpenTabletDriver.Reflection
             return children.ToArray();
         }
 
-        protected bool IsValidParameterFor(object[] args, ParameterInfo[] parameters)
+        protected static bool IsValidParameterFor(object[] args, ParameterInfo[] parameters)
         {
             for (int i = 0; i < parameters.Length; i++)
             {
@@ -85,36 +94,32 @@ namespace OpenTabletDriver.Reflection
             return true;
         }
 
-        protected bool IsPluginType(Type type)
+        protected static bool IsPluginType(Type type)
         {
-            return !type.IsAbstract & !type.IsInterface &&
+            return type.IsPublic & !type.IsAbstract & !type.IsInterface &&
                 libTypes.Any(t => t.IsAssignableFrom(type) ||
                     type.GetInterfaces().Any(x => x.IsGenericType && x.GetGenericTypeDefinition() == t));
         }
 
-        protected bool IsPlatformSupported(Type type)
+        protected static bool IsPlatformSupported(Type type)
         {
             var attr = type.GetCustomAttribute<SupportedPlatformAttribute>(false);
             return attr?.IsCurrentPlatform ?? true;
         }
 
-        protected bool IsPluginIgnored(Type type)
+        protected static bool IsPluginIgnored(Type type)
         {
             return type.GetCustomAttribute<PluginIgnoreAttribute>(false) is PluginIgnoreAttribute;
         }
 
-        protected IEnumerable<Type> SafeGetTypes(Assembly asm)
+        private static bool libTypeFilter(Type type, object _)
         {
-            try
-            {
-                return asm.ExportedTypes;
-            }
-            catch
-            {
-                var asmName = asm.GetName();
-                Log.Write("Plugin", $"Plugin '{asmName.Name}, Version={asmName.Version}' can't be loaded and is likely out of date.", LogLevel.Warning);
-                return Array.Empty<Type>();
-            }
+            return type.IsAbstract | type.IsInterface;
+        }
+
+        private bool internalPluginFilter(Type type, object _)
+        {
+            return IsPluginType(type) && IsPlatformSupported(type);
         }
     }
 }

--- a/OpenTabletDriver/Reflection/PluginManager.cs
+++ b/OpenTabletDriver/Reflection/PluginManager.cs
@@ -21,7 +21,7 @@ namespace OpenTabletDriver.Reflection
                 internalTypes = AssemblyLoadContext.Default.Assemblies
                     .Where(asm => asm != pluginAsm)
                     .SelectMany(asm => asm.Modules)
-                    .Where(module => module.Name.Contains("OpenTabletDriver"))
+                    .Where(module => module.ScopeName.Contains("OpenTabletDriver"))
                     .SelectMany(module => module.FindTypes(internalPluginFilter, null))
                     .ToArray();
             }
@@ -38,7 +38,7 @@ namespace OpenTabletDriver.Reflection
 
         private readonly static Assembly pluginAsm = Assembly.GetAssembly(typeof(IDriver));
         private readonly static Type[] libTypes = pluginAsm.Modules
-            .Where(module => module.Name.Contains("OpenTabletDriver"))
+            .Where(module => module.ScopeName.Contains("OpenTabletDriver"))
             .SelectMany(module => module.FindTypes(libTypeFilter, null)).ToArray();
 
         public PluginReference GetPluginReference(string path) => new PluginReference(this, path);

--- a/OpenTabletDriver/Reflection/PluginManager.cs
+++ b/OpenTabletDriver/Reflection/PluginManager.cs
@@ -43,7 +43,7 @@ namespace OpenTabletDriver.Reflection
             {
                 try
                 {
-                    if (PluginTypes.FirstOrDefault(t => t.FullName == name) is TypeInfo type)
+                    if (PluginTypes.FirstOrDefault(t => t.FullName == name) is Type type)
                     {
                         var matchingConstructors = from ctor in type.GetConstructors()
                         let parameters = ctor.GetParameters()

--- a/OpenTabletDriver/Reflection/PluginReference.cs
+++ b/OpenTabletDriver/Reflection/PluginReference.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.Reflection;
 using OpenTabletDriver.Plugin.Attributes;
 
 namespace OpenTabletDriver.Reflection
@@ -25,7 +24,7 @@ namespace OpenTabletDriver.Reflection
 
         protected string GetName(string path)
         {
-            if (PluginManager.PluginTypes.FirstOrDefault(t => t.FullName == path) is TypeInfo plugin)
+            if (PluginManager.PluginTypes.FirstOrDefault(t => t.FullName == path) is Type plugin)
             {
                 var attrs = plugin.GetCustomAttributes(true);
                 var nameattr = attrs.FirstOrDefault(t => t.GetType() == typeof(PluginNameAttribute));
@@ -47,12 +46,12 @@ namespace OpenTabletDriver.Reflection
             return PluginManager.ConstructObject<T>(Path, args);
         }
 
-        public TypeInfo GetTypeReference<T>()
+        public Type GetTypeReference<T>()
         {
             return PluginManager.GetChildTypes<T>().FirstOrDefault(t => t.FullName == this.Path);
         }
 
-        public TypeInfo GetTypeReference()
+        public Type GetTypeReference()
         {
             return PluginManager.PluginTypes.FirstOrDefault(t => t.FullName == this.Path);
         }


### PR DESCRIPTION
### Before
|            Method |     Mean | Error |
|------------------ |---------:|------:|
| PluginManagerCtor | 425.5 ms |    NA |

### After
|            Method |     Mean | Error |
|------------------ |---------:|------:|
| PluginManagerCtor | 104.8 ms |    NA |

> `[MethodImpl(MethodImplOptions.AggressiveOptimization)]` staves off an extra 50ms

## Changes

- Avoided unnecessary use of `TypeInfo`
- Retrieve OTD plugin library type from just the OTD plugin module/assembly
- Retrieve OTD internally implemented plugins from just the OTD module/assembly
- As a side-effect of the changes, we can also now load types from a not `IsLoadable` assembly
  - If the type can't really be loaded, we can also now log which type, and for what reason