### PR TITLE
Add Kamvas 16 Config

### DIFF
--- a/OpenTabletDriver/Configurations/Huion/Kamvas 16.json
+++ b/OpenTabletDriver/Configurations/Huion/Kamvas 16.json
@@ -1,0 +1,35 @@
+{
+    "Name": "Huion Kamvas 16",
+    "DigitizerIdentifiers": [
+      {
+        "Width": 344.2,
+        "Height": 193.6,
+        "MaxX": 68840.0,
+        "MaxY": 38720.0,
+        "MaxPressure": 8191,
+        "ActiveReportID": {
+          "Start": 64,
+          "StartInclusive": true,
+          "End": null,
+          "EndInclusive": false
+        },
+        "VendorID": 9580,
+        "ProductID": 109,
+        "InputReportLength": 12,
+        "OutputReportLength": null,
+        "ReportParser": "OpenTabletDriver.Vendors.Huion.GianoReportParser",
+        "FeatureInitReport": null,
+        "OutputInitReport": null,
+      "DeviceStrings": {
+        "201": "HUION_M18e_\\d{6}$"
+      },
+        "InitializationStrings": [
+          200
+        ]
+      }
+    ],
+    "AuxilaryDeviceIdentifiers": [],
+    "Attributes": {
+      "libinputoverride": "1"
+    }
+} 


### PR DESCRIPTION
Verification:
[discord](https://discord.com/channels/615607687467761684/615611007951306863/818270440401141780)
[discord](https://discord.com/channels/615607687467761684/615611007951306863/818271198797627412)

Note: this tablet uses the huion giano report parser because it goes over 65k. So maybe it shouldn't be named the giano parser?