### PR TITLE
Fix multiple null references and null checks

### DIFF
--- a/OpenTabletDriver.Desktop/Migration/SettingsMigrator.cs
+++ b/OpenTabletDriver.Desktop/Migration/SettingsMigrator.cs
@@ -59,9 +59,9 @@ namespace OpenTabletDriver.Desktop.Migration
         private static PluginSettingStore SafeMigrateNamespace(PluginSettingStore store, PluginSettingStore defaultStore = null)
         {
             MigrateNamespace(store);
-            if ((store == null || PluginSettingStore.FromPath(store?.Path) == null) && defaultStore != null)
+            if (store != null && PluginSettingStore.FromPath(store.Path) == null && defaultStore != null)
             {
-                Log.Write("Settings", $"Invalid plugin path '{store?.Path ?? "null"}' has been changed to '{defaultStore.Path}'", LogLevel.Warning);
+                Log.Write("Settings", $"Invalid plugin path '{store.Path ?? "null"}' has been changed to '{defaultStore.Path}'", LogLevel.Warning);
                 store = defaultStore;
             }
             return store;

--- a/OpenTabletDriver.UX/Controls/OutputModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/OutputModeEditor.cs
@@ -154,7 +154,7 @@ namespace OpenTabletDriver.UX.Controls
 
             public void UpdateSelectedMode(PluginSettingStore store)
             {
-                var typeReference = store.GetPluginReference().GetTypeReference();
+                var typeReference = store?.GetPluginReference().GetTypeReference();
                 this.SelectedValue = typeReference;
             }
         }


### PR DESCRIPTION
- Fixed #842
- Fixed #837
  - Default behavior now only defaults it when the path itself is invalid