### PR TITLE
Add pressure visualization to tablet debugger

### DIFF
--- a/OpenTabletDriver.Desktop/AppInfo.cs
+++ b/OpenTabletDriver.Desktop/AppInfo.cs
@@ -27,6 +27,7 @@ namespace OpenTabletDriver.Desktop
         }
 
         public string SettingsFile => Path.Join(AppDataDirectory, "settings.json");
+        public string SettingsStoreDirectory => Path.Join(AppDataDirectory, "SettingsStore");
         public string PluginDirectory => Path.Join(AppDataDirectory, "Plugins");
         public string TemporaryDirectory => Path.Join(AppDataDirectory, "Temp");
         public string CacheDirectory => Path.Join(AppDataDirectory, "Cache");

--- a/OpenTabletDriver.UX/App.cs
+++ b/OpenTabletDriver.UX/App.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Reflection;
@@ -15,6 +16,7 @@ namespace OpenTabletDriver.UX
 {
     public static class App
     {
+        public static List<Settings> SettingsStore = new List<Settings>();
         public static void Run(string platform, string[] args)
         {
             var root = new RootCommand("OpenTabletDriver UX")
@@ -34,6 +36,8 @@ namespace OpenTabletDriver.UX
             int code = root.Invoke(args);
             if (code != 0)
                 Environment.Exit(code);
+
+
 
             var app = new Application(platform);
             var mainForm = new MainForm();

--- a/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
+++ b/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
@@ -192,6 +192,11 @@ namespace OpenTabletDriver.UX.Windows.Tablet
                     var circleSize = 5 + tabletReport.Pressure / tablet.Digitizer.MaxPressure;
                     var drawRect = RectangleF.FromCenter(position, new SizeF(circleSize, circleSize));
                     graphics.FillEllipse(AccentColor, drawRect);
+
+                    float angle = (tabletReport.Pressure / tablet.Digitizer.MaxPressure) * 180;
+                    SolidBrush b = new SolidBrush(AccentColor);
+                    Pen p = new Pen(b, 5);
+                    graphics.DrawArc(p, graphics.ClipBounds, 0, angle);
                 }
             }
         }

--- a/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
+++ b/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
@@ -194,8 +194,7 @@ namespace OpenTabletDriver.UX.Windows.Tablet
                     graphics.FillEllipse(AccentColor, drawRect);
 
                     float angle = (tabletReport.Pressure / tablet.Digitizer.MaxPressure) * 180;
-                    SolidBrush b = new SolidBrush(AccentColor);
-                    Pen p = new Pen(b, 5);
+                    Pen p = new Pen(AccentColor, 5);
                     graphics.DrawArc(p, graphics.ClipBounds, 0, angle);
                 }
             }

--- a/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
+++ b/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
@@ -189,7 +189,8 @@ namespace OpenTabletDriver.UX.Windows.Tablet
                     var tabletScale = tabletMm / tabletPx * scale;
                     var position = new PointF(tabletReport.Position.X, tabletReport.Position.Y) * tabletScale;
 
-                    var drawRect = RectangleF.FromCenter(position, new SizeF(5, 5));
+                    var circleSize = 5 + tabletReport.Pressure / tablet.Digitizer.MaxPressure;
+                    var drawRect = RectangleF.FromCenter(position, new SizeF(circleSize, circleSize));
                     graphics.FillEllipse(AccentColor, drawRect);
                 }
             }

--- a/OpenTabletDriver/OpenTabletDriver.csproj
+++ b/OpenTabletDriver/OpenTabletDriver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Project Properties">
-    <TargetFrameworks>net5</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <VersionPrefix>0.5.2</VersionPrefix>
     <NoWarn>VSTHRD100; VSTHRD101; VSTHRD110; VSTHRD200</NoWarn>


### PR DESCRIPTION
The tablet debugger now shows the pressure data in the visualizer.
It is scaled to the maximum pressure for the tablet.
When the pressure is 0, the circle size remains 5 as before.