### PR TITLE
Add default device report, fix wacom CTx-x90

### DIFF
--- a/OpenTabletDriver/Tablet/DeviceReport.cs
+++ b/OpenTabletDriver/Tablet/DeviceReport.cs
@@ -1,0 +1,14 @@
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Tablet
+{
+    public struct DeviceReport : IDeviceReport
+    {
+        internal DeviceReport(byte[] report)
+        {
+            Raw = report;
+        }
+
+        public byte[] Raw { set; get; }
+    }
+}

--- a/OpenTabletDriver/Vendors/Wacom/IntuosV2ReportParser.cs
+++ b/OpenTabletDriver/Vendors/Wacom/IntuosV2ReportParser.cs
@@ -1,4 +1,5 @@
 ﻿using OpenTabletDriver.Plugin.Tablet;
+using OpenTabletDriver.Tablet;
 
 namespace OpenTabletDriver.Vendors.Wacom
 {
@@ -9,8 +10,9 @@ namespace OpenTabletDriver.Vendors.Wacom
             return data[0] switch
             {
                 0x2 => new IntuosV2TabletReport(data),
+                0x10 => new IntuosV2TabletReport(data),
                 0x3 => new IntuosV2AuxReport(data),
-                _ => null
+                _ => new DeviceReport(data)
             };
         }
     }

--- a/OpenTabletDriver/Vendors/Wacom/IntuosV3ReportParser.cs
+++ b/OpenTabletDriver/Vendors/Wacom/IntuosV3ReportParser.cs
@@ -1,4 +1,5 @@
 using OpenTabletDriver.Plugin.Tablet;
+using OpenTabletDriver.Tablet;
 
 namespace OpenTabletDriver.Vendors.Wacom
 {
@@ -10,7 +11,7 @@ namespace OpenTabletDriver.Vendors.Wacom
             {
                 0x10 => new IntuosV3Report(data),
                 0x11 => new IntuosV3AuxReport(data),
-                _ => null
+                _ => new DeviceReport(data)
             };
         }
     }


### PR DESCRIPTION
Default device report is needed to show all reports in debugger, even if they were not interpreted.

9th gen consumer wacoms seem to report tablet data with 0x10 as the first byte, added that to intuosv2 parser

Closes #849.