### PR TITLE
Fix PTK-440 reportID end

### DIFF
--- a/OpenTabletDriver/Configurations/Wacom/PTK-440.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTK-440.json
@@ -11,7 +11,7 @@
         "Start": 0,
         "StartInclusive": true,
         "End": 62,
-        "EndInclusive": false
+        "EndInclusive": true
       },
       "VendorID": 1386,
       "ProductID": 184,

--- a/OpenTabletDriver/Configurations/Wacom/PTK-440.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTK-440.json
@@ -10,8 +10,8 @@
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": true,
-        "End": 62,
-        "EndInclusive": true
+        "End": null,
+        "EndInclusive": false
       },
       "VendorID": 1386,
       "ProductID": 184,
@@ -32,7 +32,7 @@
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": true,
-        "End": 62,
+        "End": null,
         "EndInclusive": false
       },
       "VendorID": 1386,


### PR DESCRIPTION
The PTK-440 config needs to include reportID 62 instead of excluding it. ReportID 62 is the highest reportID from the PTK-440 when the pen is detected and contains all proper report info with no issues.

Changed reportID end to just be null