### PR TITLE
Driver: emit DevicesChanged only if there are any changes

### DIFF
--- a/OpenTabletDriver/Devices/DevicesChangedEventArgs.cs
+++ b/OpenTabletDriver/Devices/DevicesChangedEventArgs.cs
@@ -18,5 +18,6 @@ namespace OpenTabletDriver.Devices
 
         public IEnumerable<HidDevice> Additions => Current.Except(Previous);
         public IEnumerable<HidDevice> Removals => Previous.Except(Current);
+        public bool Any() => Additions.Any() | Removals.Any();
     }
 }

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -20,11 +20,15 @@ namespace OpenTabletDriver
         {
             Info.GetDriverInstance = () => this;
 
-            DeviceList.Local.Changed += (sender, e) => 
+            DeviceList.Local.Changed += (sender, e) =>
             {
                 var newList = DeviceList.Local.GetHidDevices();
-                DevicesChanged?.Invoke(this, new DevicesChangedEventArgs(CurrentDevices, newList));
-                CurrentDevices = newList;
+                var changes = new DevicesChangedEventArgs(CurrentDevices, newList);
+                if (changes.Any())
+                {
+                    DevicesChanged?.Invoke(this, changes);
+                    CurrentDevices = newList;
+                }
             };
         }
         


### PR DESCRIPTION
Added a check for changes before emitting `DevicesChanged`.

In the case of multiple devices being added instantaneously, HidSharp fires `DeviceList.Local.Changed` for each addition, but since we are getting device list with `GetHidDevices()`, all the devices are already there by the time first event gets processed. 
This meant that subsequent events, when processed, emitted `DevicesChanged` events with no actual changes.

Resolves #857.