### PR TITLE
Add XP-Pen Star G960S Plus support

### DIFF
--- a/OpenTabletDriver/Configurations/XP-Pen/Star G960S Plus.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/Star G960S Plus.json
@@ -1,0 +1,30 @@
+{
+  "Name": "XP-Pen Star G960S Plus",
+  "DigitizerIdentifiers": [
+    {
+      "Width": 228.8,
+      "Height": 152.6,
+      "MaxX": 22860.0,
+      "MaxY": 15240.0,
+      "MaxPressure": 8191,
+      "ActiveReportID": {
+        "Start": 0,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 10429,
+      "ProductID": 2328,
+      "InputReportLength": 12,
+      "OutputReportLength": 12,
+      "ReportParser": "OpenTabletDriver.Vendors.XP_Pen.XP_PenTiltReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": "ArAE",
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -50,7 +50,8 @@ namespace OpenTabletDriver
             { typeof(Vendors.Wacom.IntuosV3ReportParser).FullName, () => new Vendors.Wacom.IntuosV3ReportParser() },
             { typeof(Vendors.Wacom.WacomDriverIntuosV2ReportParser).FullName, () => new Vendors.Wacom.WacomDriverIntuosV2ReportParser() },
             { typeof(Vendors.Wacom.WacomDriverIntuosV3ReportParser).FullName, () => new Vendors.Wacom.WacomDriverIntuosV3ReportParser() },
-            { typeof(Vendors.XP_Pen.XP_PenReportParser).FullName, () => new Vendors.XP_Pen.XP_PenReportParser() }
+            { typeof(Vendors.XP_Pen.XP_PenReportParser).FullName, () => new Vendors.XP_Pen.XP_PenReportParser() },
+            { typeof(Vendors.XP_Pen.XP_PenTiltReportParser).FullName, () => new Vendors.XP_Pen.XP_PenTiltReportParser() }
         };
 
         protected IEnumerable<HidDevice> CurrentDevices { set; get; } = DeviceList.Local.GetHidDevices();

--- a/OpenTabletDriver/Vendors/XP_Pen/XP_PenTiltReportParser.cs
+++ b/OpenTabletDriver/Vendors/XP_Pen/XP_PenTiltReportParser.cs
@@ -1,0 +1,17 @@
+using OpenTabletDriver.Tablet;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Vendors.XP_Pen
+{
+    public class XP_PenTiltReportParser : IReportParser<IDeviceReport>
+    {
+        public IDeviceReport Parse(byte[] data)
+        {
+            var isAuxReport = ((data[1] & (1 << 5)) != 0) & ((data[1] & (1 << 6)) != 0);
+            if (isAuxReport)
+                return new XP_PenAuxReport(data);
+            else
+                return new XP_PenTiltTabletReport(data);
+        }
+    }
+}

--- a/OpenTabletDriver/Vendors/XP_Pen/XP_PenTiltTabletReport.cs
+++ b/OpenTabletDriver/Vendors/XP_Pen/XP_PenTiltTabletReport.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Numerics;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Vendors.XP_Pen
+{
+    public struct XP_PenTiltTabletReport : ITabletReport, ITiltReport, IEraserReport
+    {
+        internal XP_PenTiltTabletReport(byte[] report)
+        {
+            Raw = report;
+
+            ReportID = (uint)report[1] >> 1;
+            Position = new Vector2
+            {
+                X = BitConverter.ToUInt16(report, 2),
+                Y = BitConverter.ToUInt16(report, 4)
+            };
+            Tilt = new Vector2
+            {
+                X = (sbyte)report[8],
+                Y = (sbyte)report[9]
+            };
+            Pressure = BitConverter.ToUInt16(report, 6);
+            Eraser = (report[1] & (1 << 3)) != 0;
+            PenButtons = new bool[]
+            {
+                (report[1] & (1 << 1)) != 0,
+                (report[1] & (1 << 2)) != 0
+            };
+        }
+
+        public byte[] Raw { set; get; }
+        public uint ReportID { set; get; }
+        public Vector2 Position { set; get; }
+        public Vector2 Tilt { set; get; }
+        public uint Pressure { set; get; }
+        public bool Eraser { set; get; }
+        public bool[] PenButtons { set; get; }
+    }
+}


### PR DESCRIPTION
Side note is that tilt seems weird, but it seems to be a hardware glitch that is fixed by replugging the tablet.