### PR TITLE
XP-PenAuxReport: Allow multiple buttons being pressed simultaneously

### DIFF
--- a/OpenTabletDriver/Vendors/XP_Pen/XP_PenAuxReport.cs
+++ b/OpenTabletDriver/Vendors/XP_Pen/XP_PenAuxReport.cs
@@ -8,18 +8,17 @@ namespace OpenTabletDriver.Vendors.XP_Pen
         {
             Raw = report;
             var ReportID = (uint)report[1] >> 1;
-            var ButtonInt = (uint)report[2];
             AuxButtons = new bool[6];
             if (ReportID == 120) 
             {
                 AuxButtons = new bool[] 
                 {
-                    ButtonInt == 1,
-                    ButtonInt == 2,
-                    ButtonInt == 4,
-                    ButtonInt == 8,
-                    ButtonInt == 16,
-                    ButtonInt == 32
+                    (report[2] & (1 << 0)) != 0,
+                    (report[2] & (1 << 1)) != 0,
+                    (report[2] & (1 << 2)) != 0,
+                    (report[2] & (1 << 3)) != 0,
+                    (report[2] & (1 << 4)) != 0,
+                    (report[2] & (1 << 5)) != 0
                 };
             }
         }


### PR DESCRIPTION
Before PR:
Pushing multiple auxiliary buttons simultaneously results in all buttons being released, until only 1 button remains pressed again. This has the side effect of reclicking the last button (as it transitions from False -> True).

After PR:
Pushing multiple auxiliary buttons now keeps the correct buttons activated as appropriate

This is a potentially breaking change for XP-Pen G640s and XP-Pen Star 06C owners, but it is confirmed working with a XP-Pen G960S Plus.