### PR TITLE
Add FinalizeConfiguration to filters/interpolators

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -239,7 +239,10 @@ namespace OpenTabletDriver.Daemon
                 select filter;
             outputMode.Filters = filters.ToList();
 
-            if (outputMode.Filters != null && outputMode.Filters.Count() > 0)
+            foreach (var filter in outputMode.Filters)
+                filter.FinalizeConfiguration();
+
+            if (outputMode.Filters != null && outputMode.Filters.Count > 0)
                 Log.Write("Settings", $"Filters: {string.Join(", ", outputMode.Filters)}");
         }
 
@@ -355,7 +358,13 @@ namespace OpenTabletDriver.Daemon
                         where filter.FilterStage == FilterStage.PreInterpolate
                         select filter;
 
-                    interpolator.Filters = filters.ToList();
+                    var filterList = filters.ToList();
+                    foreach (var filter in filterList)
+                        filter.FinalizeConfiguration();
+
+                    interpolator.Filters = filterList;
+                    interpolator.FinalizeConfiguration();
+
                     interpolator.Enabled = true;
                     Driver.Interpolators.Add(interpolator);
                     Log.Write("Settings", $"Interpolator: {interpolator}");

--- a/OpenTabletDriver.Plugin/Tablet/IFilter.cs
+++ b/OpenTabletDriver.Plugin/Tablet/IFilter.cs
@@ -5,6 +5,7 @@ namespace OpenTabletDriver.Plugin.Tablet
     public interface IFilter
     {
         Vector2 Filter(Vector2 point);
+        void FinalizeConfiguration();
         FilterStage FilterStage { get; }
     }
 }

--- a/OpenTabletDriver.Plugin/Tablet/Interpolator/Interpolator.cs
+++ b/OpenTabletDriver.Plugin/Tablet/Interpolator/Interpolator.cs
@@ -54,6 +54,11 @@ namespace OpenTabletDriver.Plugin.Tablet.Interpolator
 
         public IList<IFilter> Filters { get; set; }
 
+        public virtual void FinalizeConfiguration()
+        {
+
+        }
+
         protected void HandleReport(object _, IDeviceReport report)
         {
             if (report is ITabletReport tabletReport && !(report is ISyntheticReport))

--- a/OpenTabletDriver.Plugin/Tablet/Interpolator/Interpolator.cs
+++ b/OpenTabletDriver.Plugin/Tablet/Interpolator/Interpolator.cs
@@ -56,7 +56,6 @@ namespace OpenTabletDriver.Plugin.Tablet.Interpolator
 
         public virtual void FinalizeConfiguration()
         {
-
         }
 
         protected void HandleReport(object _, IDeviceReport report)


### PR DESCRIPTION
Allows filters or interpolators to check their own properties for validity or perform a routine that only have to be done once after all properties are set.