### PR TITLE
Trigger bounds check on manual input

### DIFF
--- a/OpenTabletDriver.UX/Controls/Area/AreaDisplay.cs
+++ b/OpenTabletDriver.UX/Controls/Area/AreaDisplay.cs
@@ -295,10 +295,10 @@ namespace OpenTabletDriver.UX.Controls.Area
 
                 var corners = new PointF[]
                 {
-                            PointF.Rotate(rect.TopLeft, viewModel.Rotation),
-                            PointF.Rotate(rect.TopRight, viewModel.Rotation),
-                            PointF.Rotate(rect.BottomRight, viewModel.Rotation),
-                            PointF.Rotate(rect.BottomLeft, viewModel.Rotation)
+                    PointF.Rotate(rect.TopLeft, viewModel.Rotation),
+                    PointF.Rotate(rect.TopRight, viewModel.Rotation),
+                    PointF.Rotate(rect.BottomRight, viewModel.Rotation),
+                    PointF.Rotate(rect.BottomLeft, viewModel.Rotation)
                 };
                 var pseudoArea = new RectangleF(
                     PointF.Min(corners[0], PointF.Min(corners[1], PointF.Min(corners[2], corners[3]))),


### PR DESCRIPTION
Fixes #879

PR works well with manual changes to Width and Height, but if X and Y is manually changed, the view model performs the bounds checking correctly but fails to propagate the new value back to input box.