### PR TITLE
Update XP-Pen report parser

### DIFF
--- a/OpenTabletDriver/Vendors/XP_Pen/XP_PenAuxReport.cs
+++ b/OpenTabletDriver/Vendors/XP_Pen/XP_PenAuxReport.cs
@@ -1,3 +1,4 @@
+using System.Collections.Specialized;
 using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Vendors.XP_Pen
@@ -7,20 +8,19 @@ namespace OpenTabletDriver.Vendors.XP_Pen
         public XP_PenAuxReport(byte[] report)
         {
             Raw = report;
-            var ReportID = (uint)report[1] >> 1;
-            AuxButtons = new bool[6];
-            if (ReportID == 120) 
+
+            var bitVector = new BitVector32(report[2]);
+            AuxButtons = new bool[]
             {
-                AuxButtons = new bool[] 
-                {
-                    (report[2] & (1 << 0)) != 0,
-                    (report[2] & (1 << 1)) != 0,
-                    (report[2] & (1 << 2)) != 0,
-                    (report[2] & (1 << 3)) != 0,
-                    (report[2] & (1 << 4)) != 0,
-                    (report[2] & (1 << 5)) != 0
-                };
-            }
+                bitVector[1 << 0],
+                bitVector[1 << 1],
+                bitVector[1 << 2],
+                bitVector[1 << 3],
+                bitVector[1 << 4],
+                bitVector[1 << 5],
+                bitVector[1 << 6],
+                bitVector[1 << 7]
+            };
         }
 
         public bool[] AuxButtons { set; get; }

--- a/OpenTabletDriver/Vendors/XP_Pen/XP_PenReportParser.cs
+++ b/OpenTabletDriver/Vendors/XP_Pen/XP_PenReportParser.cs
@@ -7,11 +7,7 @@ namespace OpenTabletDriver.Vendors.XP_Pen
     {
         public IDeviceReport Parse(byte[] data)
         {
-            var isAuxReport = ((data[1] & (1 << 5)) != 0) & ((data[1] & (1 << 6)) != 0);
-            if (isAuxReport)
-                return new XP_PenAuxReport(data);
-            else
-                return new TabletReport(data);
+            return (data[1] & 0xc0) == 0xc0 ? new XP_PenAuxReport(data) : new TabletReport(data);
         }
     }
 }

--- a/OpenTabletDriver/Vendors/XP_Pen/XP_PenTiltReportParser.cs
+++ b/OpenTabletDriver/Vendors/XP_Pen/XP_PenTiltReportParser.cs
@@ -1,4 +1,3 @@
-using OpenTabletDriver.Tablet;
 using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Vendors.XP_Pen
@@ -7,11 +6,7 @@ namespace OpenTabletDriver.Vendors.XP_Pen
     {
         public IDeviceReport Parse(byte[] data)
         {
-            var isAuxReport = ((data[1] & (1 << 5)) != 0) & ((data[1] & (1 << 6)) != 0);
-            if (isAuxReport)
-                return new XP_PenAuxReport(data);
-            else
-                return new XP_PenTiltTabletReport(data);
+            return (data[1] & 0xc0) == 0xc0 ? new XP_PenAuxReport(data) : new XP_PenTiltTabletReport(data);
         }
     }
 }

--- a/OpenTabletDriver/Vendors/XP_Pen/XP_PenTiltTabletReport.cs
+++ b/OpenTabletDriver/Vendors/XP_Pen/XP_PenTiltTabletReport.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Specialized;
 using System.Numerics;
 using System.Runtime.CompilerServices;

--- a/OpenTabletDriver/Vendors/XP_Pen/XP_PenTiltTabletReport.cs
+++ b/OpenTabletDriver/Vendors/XP_Pen/XP_PenTiltTabletReport.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Specialized;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Vendors.XP_Pen
@@ -10,23 +12,24 @@ namespace OpenTabletDriver.Vendors.XP_Pen
         {
             Raw = report;
 
+            var bitVector = new BitVector32(report[1]);
             ReportID = (uint)report[1] >> 1;
             Position = new Vector2
             {
-                X = BitConverter.ToUInt16(report, 2),
-                Y = BitConverter.ToUInt16(report, 4)
+                X = Unsafe.ReadUnaligned<ushort>(ref report[2]),
+                Y = Unsafe.ReadUnaligned<ushort>(ref report[4])
             };
             Tilt = new Vector2
             {
                 X = (sbyte)report[8],
                 Y = (sbyte)report[9]
             };
-            Pressure = BitConverter.ToUInt16(report, 6);
-            Eraser = (report[1] & (1 << 3)) != 0;
+            Pressure = Unsafe.ReadUnaligned<ushort>(ref report[6]);
+            Eraser = bitVector[1 << 3];
             PenButtons = new bool[]
             {
-                (report[1] & (1 << 1)) != 0,
-                (report[1] & (1 << 2)) != 0
+                bitVector[1 << 1],
+                bitVector[1 << 2]
             };
         }
 


### PR DESCRIPTION
## Changes

- Support 8 buttons
- Use `BitVector32` wherever profitable
- Simplify aux report detection
  - Remove redundant check on `XP_PenAuxReport` (already performed in `XP_PenReportParser`)
- Skip BitConverter's unneeded safety checks by directly calling `Unsafe.ReadUnaligned<T>()`
  > We know in advance that the bytes we're parsing are complete