### PR TITLE
Implement tablet driver detection

### DIFF
--- a/OpenTabletDriver.Benchmarks/Misc/DriverInfoBenchmark.cs
+++ b/OpenTabletDriver.Benchmarks/Misc/DriverInfoBenchmark.cs
@@ -1,0 +1,15 @@
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using OpenTabletDriver.SystemDrivers;
+
+namespace OpenTabletDriver.Benchmarks.Misc
+{
+    public class DriverInfoBenchmark
+    {
+        [Benchmark]
+        public DriverInfo[] GetDriverInfos()
+        {
+            return DriverInfo.GetDriverInfos().ToArray();
+        }
+    }
+}

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -14,6 +14,7 @@ using OpenTabletDriver.Desktop.Profiles;
 using OpenTabletDriver.Desktop.Reflection;
 using OpenTabletDriver.Desktop.Reflection.Metadata;
 using OpenTabletDriver.Desktop.RPC;
+using OpenTabletDriver.SystemDrivers;
 using OpenTabletDriver.Devices;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Logging;
@@ -42,6 +43,15 @@ namespace OpenTabletDriver.Daemon
                     await SetSettings(Settings);
                 }
             };
+
+            foreach (var driverInfo in DriverInfo.GetDriverInfos())
+            {
+                Log.Write("Detect", $"Another tablet driver found: {driverInfo.Name}", LogLevel.Warning);
+                if (driverInfo.IsBlockingDriver)
+                    Log.Write("Detect", $"Detection for {driverInfo.Name} tablets might be impaired", LogLevel.Warning);
+                else if (driverInfo.IsSendingInput)
+                    Log.Write("Detect", $"Detected input coming from {driverInfo.Name} driver", LogLevel.Error);
+            }
 
             LoadUserSettings();
         }

--- a/OpenTabletDriver/Instance.cs
+++ b/OpenTabletDriver/Instance.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 
 namespace OpenTabletDriver
@@ -7,13 +9,16 @@ namespace OpenTabletDriver
     {
         public Instance(string name)
         {
-            this.mutex = new Mutex(true, $"{prefix}{name}", out bool createdNew);
+            this.mutex = new Mutex(true, $"{MUTEX_PREFIX}{name}", out bool createdNew);
+            this.Name = name;
             AlreadyExists = !createdNew;
+            if (createdNew)
+                ownedInstances.Add(this);
         }
 
         public static bool Exists(string name)
         {
-            var result = Mutex.TryOpenExisting($"{prefix}{name}", out var mutex);
+            var result = Mutex.TryOpenExisting($"{MUTEX_PREFIX}{name}", out var mutex);
             using (mutex)
             {
                 mutex?.Close();
@@ -21,8 +26,17 @@ namespace OpenTabletDriver
             }
         }
 
-        private const string prefix = @"Global\";
+        public static bool IsOwnerOf(string name)
+        {
+            return ownedInstances.Any(i => i.Name == name);
+        }
+
+        private const string MUTEX_PREFIX = @"Global\";
+        private readonly static List<Instance> ownedInstances = new List<Instance>();
+
         private Mutex mutex;
+
+        public string Name { get; }
         public bool AlreadyExists { protected set; get; }
 
         public void Dispose()

--- a/OpenTabletDriver/SystemDrivers/DriverInfo.cs
+++ b/OpenTabletDriver/SystemDrivers/DriverInfo.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using OpenTabletDriver.SystemDrivers.InfoProviders;
+
+namespace OpenTabletDriver.SystemDrivers
+{
+    /// <summary>
+    /// Contains information and hints about an installed tablet driver.
+    /// </summary>
+    /// <remarks>
+    /// See <see cref="GetDriverInfos"/> to get all the currently active tablet drivers.
+    /// </remarks>
+    public class DriverInfo
+    {
+        /// <summary>
+        /// The human-friendly name of the driver.
+        /// </summary>
+        public string Name { get; internal set; }
+
+        /// <summary>
+        /// Running processes that might be associated with the driver.
+        /// </summary>
+        /// <remarks>
+        /// This is set to null when there is no associated process.
+        /// </remarks>
+        public Process[] Processes { get; internal set; }
+
+        /// <summary>
+        /// Provides hints of whether this driver might interfere with OTD's detection mechanism, or prevent OTD from accessing the tablet.
+        /// </summary>
+        public bool IsBlockingDriver { get; internal set; }
+
+        /// <summary>
+        /// Returns true if this driver sends input to the operating system.
+        /// </summary>
+        public bool IsSendingInput { get; internal set; }
+
+        /// <summary>
+        /// Retrieves all the currently active tablet drivers.
+        /// </summary>
+        public static IEnumerable<DriverInfo> GetDriverInfos()
+        {
+            var providers = new IDriverInfoProvider[]
+            {
+                new WacomDriverInfoProvider(),
+                new GaomonDriverInfoProvider(),
+                new HuionDriverInfoProvider(),
+                new XPPenDriverInfoProvider(),
+                new VeikkDriverInfoDriver(),
+                new OpenTabletDriverInfoProvider(),
+                new TabletDriverInfoProvider()
+            };
+
+            SystemProcesses = Process.GetProcesses();
+            ProcessModuleQueryableDriverInfoProvider.Refresh();
+
+            // Remove "UC Logic" duplicates
+            return providers.Select(provider => provider.GetDriverInfo())
+                .Where(i => i != null)
+                .GroupBy(i => i.Name)
+                .Select(g => g.First());
+        }
+
+        internal static Process[] SystemProcesses { get; private set; }
+    }
+}

--- a/OpenTabletDriver/SystemDrivers/IDriverInfoProvider.cs
+++ b/OpenTabletDriver/SystemDrivers/IDriverInfoProvider.cs
@@ -1,0 +1,7 @@
+namespace OpenTabletDriver.SystemDrivers
+{
+    internal interface IDriverInfoProvider
+    {
+        DriverInfo GetDriverInfo();
+    }
+}

--- a/OpenTabletDriver/SystemDrivers/Providers/GaomonDriverInfoProvider.cs
+++ b/OpenTabletDriver/SystemDrivers/Providers/GaomonDriverInfoProvider.cs
@@ -1,0 +1,21 @@
+namespace OpenTabletDriver.SystemDrivers.InfoProviders
+{
+    internal class GaomonDriverInfoProvider : ProcessModuleQueryableDriverInfoProvider
+    {
+        protected override string FriendlyName => "Gaomon";
+
+        protected override string LinuxFriendlyName => "UC Logic";
+
+        protected override string LinuxModuleName => "hid_uclogic";
+
+        protected override string[] WinProcessNames { get; } = new string[]
+        {
+            "TabletDriverCore"
+        };
+
+        protected override string[] Heuristics { get; } = new string[]
+        {
+            "Gaomon"
+        };
+    }
+}

--- a/OpenTabletDriver/SystemDrivers/Providers/HuionDriverInfoProvider.cs
+++ b/OpenTabletDriver/SystemDrivers/Providers/HuionDriverInfoProvider.cs
@@ -1,0 +1,21 @@
+namespace OpenTabletDriver.SystemDrivers.InfoProviders
+{
+    internal class HuionDriverInfoProvider : ProcessModuleQueryableDriverInfoProvider
+    {
+        protected override string FriendlyName => "Huion";
+
+        protected override string LinuxFriendlyName => "UC Logic";
+
+        protected override string LinuxModuleName => "hid_uclogic";
+
+        protected override string[] WinProcessNames { get; } = new string[]
+        {
+            "TabletDriverCore"
+        };
+
+        protected override string[] Heuristics { get; } = new string[]
+        {
+            "Huion"
+        };
+    }
+}

--- a/OpenTabletDriver/SystemDrivers/Providers/OpenTabletDriverInfoProvider.cs
+++ b/OpenTabletDriver/SystemDrivers/Providers/OpenTabletDriverInfoProvider.cs
@@ -1,0 +1,20 @@
+namespace OpenTabletDriver.SystemDrivers.InfoProviders
+{
+    public class OpenTabletDriverInfoProvider : IDriverInfoProvider
+    {
+        public DriverInfo GetDriverInfo()
+        {
+            var daemonInstanceName = "OpenTabletDriver.Daemon";
+            if (Instance.Exists(daemonInstanceName) && !Instance.IsOwnerOf(daemonInstanceName))
+            {
+                return new DriverInfo
+                {
+                    Name = "OpenTabletDriver",
+                    IsSendingInput = true
+                };
+            }
+
+            return null;
+        }
+    }
+}

--- a/OpenTabletDriver/SystemDrivers/Providers/ProcessModuleQueryableDriverInfoProvider.cs
+++ b/OpenTabletDriver/SystemDrivers/Providers/ProcessModuleQueryableDriverInfoProvider.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using OpenTabletDriver.Interop;
+using OpenTabletDriver.Plugin;
+
+namespace OpenTabletDriver.SystemDrivers.InfoProviders
+{
+    internal abstract class ProcessModuleQueryableDriverInfoProvider : IDriverInfoProvider
+    {
+        protected abstract string FriendlyName { get; }
+        protected abstract string LinuxFriendlyName { get; }
+        protected abstract string LinuxModuleName { get; }
+        protected abstract string[] WinProcessNames { get; }
+        protected abstract string[] Heuristics { get; }
+
+        private static string PnpUtil;
+        private static string LinuxModules;
+
+        public DriverInfo GetDriverInfo()
+        {
+            return SystemInterop.CurrentPlatform switch
+            {
+                PluginPlatform.Windows => GetWinDriverInfo(),
+                PluginPlatform.Linux => GetLinuxDriverInfo(),
+                _ => null
+            };
+        }
+
+        protected virtual DriverInfo GetWinDriverInfo()
+        {
+            IEnumerable<Process> processes;
+            var match = Heuristics.Any(name => Regex.IsMatch(PnpUtil, name, RegexOptions.IgnoreCase));
+            if (match)
+            {
+                processes = DriverInfo.SystemProcesses
+                    .Where(p => WinProcessNames.Concat(Heuristics)
+                    .Any(n => Regex.IsMatch(p.ProcessName, n, RegexOptions.IgnoreCase)));
+
+                return new DriverInfo
+                {
+                    Name = FriendlyName,
+                    Processes = processes.Any() ? processes.ToArray() : null,
+                    IsBlockingDriver = true,
+                    IsSendingInput = processes.Any()
+                };
+            }
+
+            return null;
+        }
+
+        protected virtual DriverInfo GetLinuxDriverInfo()
+        {
+            if (Regex.IsMatch(LinuxModules, LinuxModuleName))
+            {
+                return new DriverInfo
+                {
+                    Name = LinuxFriendlyName,
+                    IsBlockingDriver = true,
+                    IsSendingInput = true
+                };
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        internal static void Refresh()
+        {
+            switch (SystemInterop.CurrentPlatform)
+            {
+                case PluginPlatform.Windows:
+                {
+                    var pnputilProc = new Process
+                    {
+                        StartInfo = new ProcessStartInfo
+                        {
+                            FileName = "pnputil.exe",
+                            Arguments = "-e",
+                            UseShellExecute = false,
+                            RedirectStandardOutput = true
+                        }
+                    };
+
+                    pnputilProc.Start();
+                    PnpUtil = pnputilProc.StandardOutput.ReadToEnd();
+                    break;
+                }
+                case PluginPlatform.Linux:
+                {
+                    LinuxModules = File.ReadAllText("/proc/modules");
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/OpenTabletDriver/SystemDrivers/Providers/ProcessModuleQueryableDriverInfoProvider.cs
+++ b/OpenTabletDriver/SystemDrivers/Providers/ProcessModuleQueryableDriverInfoProvider.cs
@@ -16,8 +16,8 @@ namespace OpenTabletDriver.SystemDrivers.InfoProviders
         protected abstract string[] WinProcessNames { get; }
         protected abstract string[] Heuristics { get; }
 
-        private static string PnpUtil;
-        private static string LinuxModules;
+        private static string pnpUtil;
+        private static string linuxModules;
 
         public DriverInfo GetDriverInfo()
         {
@@ -32,7 +32,7 @@ namespace OpenTabletDriver.SystemDrivers.InfoProviders
         protected virtual DriverInfo GetWinDriverInfo()
         {
             IEnumerable<Process> processes;
-            var match = Heuristics.Any(name => Regex.IsMatch(PnpUtil, name, RegexOptions.IgnoreCase));
+            var match = Heuristics.Any(name => Regex.IsMatch(pnpUtil, name, RegexOptions.IgnoreCase));
             if (match)
             {
                 processes = DriverInfo.SystemProcesses
@@ -53,7 +53,7 @@ namespace OpenTabletDriver.SystemDrivers.InfoProviders
 
         protected virtual DriverInfo GetLinuxDriverInfo()
         {
-            if (Regex.IsMatch(LinuxModules, LinuxModuleName))
+            if (Regex.IsMatch(linuxModules, LinuxModuleName))
             {
                 return new DriverInfo
                 {
@@ -86,12 +86,12 @@ namespace OpenTabletDriver.SystemDrivers.InfoProviders
                     };
 
                     pnputilProc.Start();
-                    PnpUtil = pnputilProc.StandardOutput.ReadToEnd();
+                    pnpUtil = pnputilProc.StandardOutput.ReadToEnd();
                     break;
                 }
                 case PluginPlatform.Linux:
                 {
-                    LinuxModules = File.ReadAllText("/proc/modules");
+                    linuxModules = File.ReadAllText("/proc/modules");
                     break;
                 }
             }

--- a/OpenTabletDriver/SystemDrivers/Providers/TabletDriverInfoProvider.cs
+++ b/OpenTabletDriver/SystemDrivers/Providers/TabletDriverInfoProvider.cs
@@ -1,0 +1,35 @@
+using System.Linq;
+using OpenTabletDriver.Interop;
+using OpenTabletDriver.Plugin;
+
+namespace OpenTabletDriver.SystemDrivers.InfoProviders
+{
+    internal class TabletDriverInfoProvider : IDriverInfoProvider
+    {
+        private readonly string[] ProcessNames = new string[]
+        {
+            "TabletDriverGUI",
+            "TabletDriverService"
+        };
+
+        public DriverInfo GetDriverInfo()
+        {
+            if (SystemInterop.CurrentPlatform == PluginPlatform.Windows)
+            {
+                var processes = DriverInfo.SystemProcesses.Where(p => ProcessNames.Contains(p.ProcessName)).ToArray();
+                if (processes.Any())
+                {
+                    return new DriverInfo
+                    {
+                        Name = "TabletDriver",
+                        Processes = processes,
+                        IsBlockingDriver = true, // TabletDriver opens tablets in exclusive mode by default
+                        IsSendingInput = true
+                    };
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/OpenTabletDriver/SystemDrivers/Providers/VeikkDriverInfoProvider.cs
+++ b/OpenTabletDriver/SystemDrivers/Providers/VeikkDriverInfoProvider.cs
@@ -1,0 +1,22 @@
+namespace OpenTabletDriver.SystemDrivers.InfoProviders
+{
+    internal class VeikkDriverInfoDriver : ProcessModuleQueryableDriverInfoProvider
+    {
+        protected override string FriendlyName => "Veikk";
+
+        protected override string LinuxFriendlyName => "UC Logic";
+
+        protected override string LinuxModuleName => "hid_uclogic";
+
+        protected override string[] WinProcessNames { get; } = new string[]
+        {
+            "TabletDriverCenter",
+            "TabletDriverSetting"
+        };
+
+        protected override string[] Heuristics { get; } = new string[]
+        {
+            "Veikk"
+        };
+    }
+}

--- a/OpenTabletDriver/SystemDrivers/Providers/WacomDriverInfoProvider.cs
+++ b/OpenTabletDriver/SystemDrivers/Providers/WacomDriverInfoProvider.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace OpenTabletDriver.SystemDrivers.InfoProviders
+{
+    internal class WacomDriverInfoProvider : ProcessModuleQueryableDriverInfoProvider
+    {
+        protected override string FriendlyName => "Wacom";
+
+        protected override string LinuxFriendlyName => FriendlyName;
+
+        protected override string LinuxModuleName => "wacom";
+
+        protected override string[] WinProcessNames { get; } = Array.Empty<string>();
+
+        protected override string[] Heuristics { get; } = new string[]
+        {
+            "Wacom"
+        };
+
+        protected override DriverInfo GetWinDriverInfo()
+        {
+            var info = base.GetWinDriverInfo();
+            if (info != null)
+                info.IsBlockingDriver = false;
+
+            return info;
+        }
+
+        protected override DriverInfo GetLinuxDriverInfo()
+        {
+            var info = base.GetLinuxDriverInfo();
+            if (info != null)
+                info.IsBlockingDriver = false;
+
+            return info;
+        }
+    }
+}

--- a/OpenTabletDriver/SystemDrivers/Providers/XPPenDriverInfoProvider.cs
+++ b/OpenTabletDriver/SystemDrivers/Providers/XPPenDriverInfoProvider.cs
@@ -1,0 +1,58 @@
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace OpenTabletDriver.SystemDrivers.InfoProviders
+{
+    internal class XPPenDriverInfoProvider : ProcessModuleQueryableDriverInfoProvider
+    {
+        protected override string FriendlyName => "XP-Pen";
+
+        protected override string LinuxFriendlyName => "UC Logic";
+
+        protected override string LinuxModuleName => "hid_uclogic";
+
+        protected override string[] WinProcessNames => new string[]
+        {
+            "PentabletService",
+            "PentabletUIService",
+            "PenTablet"
+        };
+
+        protected override string[] Heuristics { get; } = new string[]
+        {
+            "XP[ _-]*Pen",
+            "Pentablet"
+        };
+
+        private string[] Exclusions = new string[]
+        {
+            "OpenTabletDriver",
+            "Huion",
+            "Gaomon",
+            "Veikk"
+        };
+
+        protected override DriverInfo GetWinDriverInfo()
+        {
+            var processes = DriverInfo.SystemProcesses
+                .Where(p => WinProcessNames.Concat(Heuristics)
+                .Any(n => Regex.IsMatch(p.ProcessName, n, RegexOptions.IgnoreCase)));
+
+            var falsePositive = processes.Any(p => Exclusions.Any(ex => Regex.IsMatch(p.ProcessName, ex)));
+
+            if (processes.Any() && !falsePositive)
+            {
+                return new DriverInfo
+                {
+                    Name = FriendlyName,
+                    Processes = processes.ToArray(),
+                    IsSendingInput = true
+                };
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Changes

- Add `DriverInfo`
- Make OTD daemon aware of other tablet drivers ~~(self-detection on another PR for osu! lazer and OTD)~~

Supports detection for the following drivers:

- Wacom
- Huion
- XP-Pen
- Gaomon
- VEIKK
- OpenTabletDriver
- TabletDriver (Hawku/InfinityGhost/Devocub)

> Note: MacOS is not supported yet.