### PR TITLE
Rename CTL-6100 to CTL-6100WL

### DIFF
--- a/OpenTabletDriver/Configurations/Wacom/CTL-6100WL.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-6100WL.json
@@ -1,5 +1,5 @@
 {
-  "Name": "Wacom CTL-6100",
+  "Name": "Wacom CTL-6100WL",
   "DigitizerIdentifiers": [
     {
       "Width": 216.0,


### PR DESCRIPTION
CTL-6100 doesn't exist its only CTL-6100WL.