### PR TITLE
Fix wrong physical size on various configs from bad lpi calculations

### DIFF
--- a/OpenTabletDriver/Configurations/Gaomon/M10K.json
+++ b/OpenTabletDriver/Configurations/Gaomon/M10K.json
@@ -3,7 +3,7 @@
     "DigitizerIdentifiers": [
       {
         "Width": 254.0,
-        "Height": 158.8,
+        "Height": 158.75,
         "MaxX": 50800.0,
         "MaxY": 31750.0,
         "MaxPressure": 8191,

--- a/OpenTabletDriver/Configurations/Huion/H1161.json
+++ b/OpenTabletDriver/Configurations/Huion/H1161.json
@@ -3,7 +3,7 @@
   "DigitizerIdentifiers": [
     {
       "Width": 279.4,
-      "Height": 174.6,
+      "Height": 174.625,
       "MaxX": 55880.0,
       "MaxY": 34925.0,
       "MaxPressure": 8191,

--- a/OpenTabletDriver/Configurations/Huion/H950P.json
+++ b/OpenTabletDriver/Configurations/Huion/H950P.json
@@ -2,8 +2,8 @@
   "Name": "Huion H950P",
   "DigitizerIdentifiers": [
     {
-      "Width": 221.8,
-      "Height": 138.8,
+      "Width": 221.0,
+      "Height": 138.0,
       "MaxX": 44200.0,
       "MaxY": 27600.0,
       "MaxPressure": 8191,
@@ -28,8 +28,8 @@
       ]
     },
     {
-      "Width": 221.8,
-      "Height": 138.8,
+      "Width": 221.0,
+      "Height": 138.0,
       "MaxX": 44200.0,
       "MaxY": 27600.0,
       "MaxPressure": 8191,

--- a/OpenTabletDriver/Configurations/Huion/HS610.json
+++ b/OpenTabletDriver/Configurations/Huion/HS610.json
@@ -3,7 +3,7 @@
   "DigitizerIdentifiers": [
     {
       "Width": 254.0,
-      "Height": 160.0,
+      "Height": 158.75,
       "MaxX": 50800.0,
       "MaxY": 31750.0,
       "MaxPressure": 8191,

--- a/OpenTabletDriver/Configurations/Huion/Inspiroy Q11K.json
+++ b/OpenTabletDriver/Configurations/Huion/Inspiroy Q11K.json
@@ -2,8 +2,8 @@
   "Name": "Huion Inspiroy Q11K",
   "DigitizerIdentifiers": [
     {
-      "Width": 279.4,
-      "Height": 146.6,
+      "Width": 258.4,
+      "Height": 165.1,
       "MaxX": 51680.0,
       "MaxY": 33020.0,
       "MaxPressure": 8191,

--- a/OpenTabletDriver/Configurations/Huion/Kamvas 13.json
+++ b/OpenTabletDriver/Configurations/Huion/Kamvas 13.json
@@ -2,7 +2,7 @@
     "Name": "Huion Kamvas 13",
     "DigitizerIdentifiers": [
       {
-        "Width": 293.775,
+        "Width": 293.76,
         "Height": 165.24,
         "MaxX": 58752.0,
         "MaxY": 33048.0,

--- a/OpenTabletDriver/Configurations/Wacom/CTE-440.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTE-440.json
@@ -2,8 +2,8 @@
   "Name": "Wacom CTE-440",
   "DigitizerIdentifiers": [
     {
-      "Width": 102.08,
-      "Height": 74.24,
+      "Width": 127.6,
+      "Height": 92.8,
       "MaxX": 10208.0,
       "MaxY": 7424.0,
       "MaxPressure": 511,
@@ -24,8 +24,8 @@
       "InitializationStrings": []
     },
     {
-      "Width": 102.08,
-      "Height": 74.24,
+      "Width": 127.6,
+      "Height": 92.8,
       "MaxX": 10208.0,
       "MaxY": 7424.0,
       "MaxPressure": 511,

--- a/OpenTabletDriver/Configurations/Wacom/CTL-680.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-680.json
@@ -3,7 +3,7 @@
   "DigitizerIdentifiers": [
     {
       "Width": 216.0,
-      "Height": 315.0,
+      "Height": 135.0,
       "MaxX": 21600.0,
       "MaxY": 13500.0,
       "MaxPressure": 1023,
@@ -25,7 +25,7 @@
     },
     {
       "Width": 216.0,
-      "Height": 315.0,
+      "Height": 135.0,
       "MaxX": 21600.0,
       "MaxY": 13500.0,
       "MaxPressure": 1023,

--- a/OpenTabletDriver/Configurations/Wacom/FT-0405-U.json
+++ b/OpenTabletDriver/Configurations/Wacom/FT-0405-U.json
@@ -2,8 +2,8 @@
   "Name": "Wacom FT-0405-U",
   "DigitizerIdentifiers": [
     {
-      "Width": 129.6416,
-      "Height": 94.2848,
+      "Width": 127.6,
+      "Height": 92.8,
       "MaxX": 5104.0,
       "MaxY": 3712.0,
       "MaxPressure": 511,
@@ -24,8 +24,8 @@
       "InitializationStrings": []
     },
     {
-      "Width": 129.6416,
-      "Height": 94.2848,
+      "Width": 127.6,
+      "Height": 92.8,
       "MaxX": 5104.0,
       "MaxY": 3712.0,
       "MaxPressure": 511,

--- a/OpenTabletDriver/Configurations/Wacom/PTH-451.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTH-451.json
@@ -2,8 +2,8 @@
   "Name": "Wacom PTH-451",
   "DigitizerIdentifiers": [
     {
-      "Width": 157.0,
-      "Height": 98.0,
+      "Width": 157.48,
+      "Height": 98.425,
       "MaxX": 31496.0,
       "MaxY": 19685.0,
       "MaxPressure": 2047,
@@ -24,8 +24,8 @@
       "InitializationStrings": []
     },
     {
-      "Width": 157.0,
-      "Height": 98.0,
+      "Width": 157.48,
+      "Height": 98.425,
       "MaxX": 31496.0,
       "MaxY": 19685.0,
       "MaxPressure": 2047,

--- a/OpenTabletDriver/Configurations/XP-Pen/G540 Pro.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/G540 Pro.json
@@ -2,8 +2,8 @@
   "Name": "XP-Pen G540 Pro",
   "DigitizerIdentifiers": [
     {
-      "Width": 147.0,
-      "Height": 101.6,
+      "Width": 136.8,
+      "Height": 73.025,
       "MaxX": 54720.0,
       "MaxY": 29210.0,
       "MaxPressure": 8191,

--- a/OpenTabletDriver/Configurations/XP-Pen/G960 v2.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/G960 v2.json
@@ -2,8 +2,8 @@
   "Name": "XP-Pen G960 v2",
   "DigitizerIdentifiers": [
     {
-      "Width": 212.0,
-      "Height": 135.0,
+      "Width": 223.52,
+      "Height": 139.7,
       "MaxX": 22352.0,
       "MaxY": 13970.0,
       "MaxPressure": 8191,

--- a/OpenTabletDriver/Configurations/XP-Pen/Star G960S Plus.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/Star G960S Plus.json
@@ -2,8 +2,8 @@
   "Name": "XP-Pen Star G960S Plus",
   "DigitizerIdentifiers": [
     {
-      "Width": 228.8,
-      "Height": 152.6,
+      "Width": 228.6,
+      "Height": 152.4,
       "MaxX": 22860.0,
       "MaxY": 15240.0,
       "MaxPressure": 8191,


### PR DESCRIPTION
lpi/lpmm of all tablet configs that were calculated wrong:

M10K - 5080/200

H1161 - 5080/200
H950P - 5080/200
HS610 - 5080/200
Inspiroy Q11K - 5080/200
Kamvas 13 - 5080/200

CTE-440 - 2032/80
CTL-680 - 2540/100
FT-0405-U - 1016/40
PTH-451 - 5080/200

G540 Pro - 10160/400 (xp-pen claims it's 5080/200 but the tablet reports otherwise)
G960 v2 - 2540/100
Star G960S Plus - 2540/100