### PR TITLE
Make use of all the bit flags to detect aux

### DIFF
--- a/OpenTabletDriver/Vendors/XP_Pen/XP_PenReportParser.cs
+++ b/OpenTabletDriver/Vendors/XP_Pen/XP_PenReportParser.cs
@@ -7,7 +7,7 @@ namespace OpenTabletDriver.Vendors.XP_Pen
     {
         public IDeviceReport Parse(byte[] data)
         {
-            return (data[1] & 0xc0) == 0xc0 ? new XP_PenAuxReport(data) : new TabletReport(data);
+            return (data[1] & 0xf0) == 0xf0 ? new XP_PenAuxReport(data) : new TabletReport(data);
         }
     }
 }

--- a/OpenTabletDriver/Vendors/XP_Pen/XP_PenTiltReportParser.cs
+++ b/OpenTabletDriver/Vendors/XP_Pen/XP_PenTiltReportParser.cs
@@ -6,7 +6,7 @@ namespace OpenTabletDriver.Vendors.XP_Pen
     {
         public IDeviceReport Parse(byte[] data)
         {
-            return (data[1] & 0xc0) == 0xc0 ? new XP_PenAuxReport(data) : new XP_PenTiltTabletReport(data);
+            return (data[1] & 0xf0) == 0xf0 ? new XP_PenAuxReport(data) : new XP_PenTiltTabletReport(data);
         }
     }
 }


### PR DESCRIPTION
```
Aux:      b11110000 F0
OOR:      b00110000 C0
Previous: b00110000 C0
PR:       b11110000 F0
```
Previous method matches both the OutOfRange report and Aux (the problem was worked around before by performing two separate checks)