### PR TITLE
Revert single file publishing on Windows to avoid false positive

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -74,7 +74,7 @@ jobs:
           runtime: win-x64
           framework: net5
         run: |
-          $options= @('--configuration', 'Release', '-p:PublishSingleFile=true', '-p:DebugType=embedded', '--self-contained', 'false')
+          $options= @('--configuration', 'Release', '-p:DebugType=embedded', '--self-contained', 'false')
           dotnet publish OpenTabletDriver.Daemon $options --runtime $ENV:runtime --framework $ENV:framework -o build/$ENV:runtime
           dotnet publish OpenTabletDriver.Console $options --runtime $ENV:runtime --framework $ENV:framework -o build/$ENV:runtime
           dotnet publish OpenTabletDriver.UX.Wpf $options --runtime $ENV:runtime --framework $ENV:framework-windows -o build/$ENV:runtime


### PR DESCRIPTION
## Verification
[Octokit.dll](https://www.virustotal.com/gui/file/37a57f40eeee607a52b4a5415415273d6f7a17033816a398ff02c5454bba95a0/detection) (contains network code)
[OpenTabletDriver.Desktop.dll](https://www.virustotal.com/gui/file/e21bf028c312a061976da34a63d16c7af6e996f515b10fb6ef679fbfbcb52f3e/detection) (references Octokit, and contains assembly loading code)
[OpenTabletDriver.Daemon.dll](https://www.virustotal.com/gui/file/6c7cd0947ea55c06de2b94c065da99a657f514d366b79418a9f0da14a2a82e04/detection) (references OpenTabletDriver.Desktop.dll)
[OpenTabletDriver.Daemon.exe](https://www.virustotal.com/gui/file/29f45645ca05a347cefbae2c614ee2074889a740b91ff6172e9b3d78f449afc4/detection) (loads OpenTabletDriver.Daemon.dll)