### PR TITLE
Add featureinit to CTL-X90 tablets

### DIFF
--- a/OpenTabletDriver/Configurations/Wacom/CTL-490.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-490.json
@@ -18,7 +18,7 @@
       "InputReportLength": 10,
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
-      "FeatureInitReport": null,
+      "FeatureInitReport": "AgI=",
       "OutputInitReport": null,
       "DeviceStrings": {},
       "InitializationStrings": []
@@ -40,7 +40,7 @@
       "InputReportLength": 11,
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
-      "FeatureInitReport": null,
+      "FeatureInitReport": "AgI=",
       "OutputInitReport": null,
       "DeviceStrings": {},
       "InitializationStrings": []

--- a/OpenTabletDriver/Configurations/Wacom/CTL-690.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-690.json
@@ -18,7 +18,7 @@
       "InputReportLength": 10,
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
-      "FeatureInitReport": null,
+      "FeatureInitReport": "AgI=",
       "OutputInitReport": null,
       "DeviceStrings": {},
       "InitializationStrings": []
@@ -40,7 +40,7 @@
       "InputReportLength": 11,
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
-      "FeatureInitReport": null,
+      "FeatureInitReport": "AgI=",
       "OutputInitReport": null,
       "DeviceStrings": {},
       "InitializationStrings": []


### PR DESCRIPTION
Verification:
[discord](https://discord.com/channels/615607687467761684/615611007951306863/827960116187234305)
[discord](https://discord.com/channels/615607687467761684/615611007951306863/827961186666414161)

Not sure why these didnt already have an init but they're supposed to have one.