### PR TITLE
Add Wacom GD-0405-U Config

### DIFF
--- a/OpenTabletDriver/Configurations/Wacom/GD-0405-U.json
+++ b/OpenTabletDriver/Configurations/Wacom/GD-0405-U.json
@@ -1,0 +1,51 @@
+{
+  "Name": "Wacom GD-0405-U",
+  "DigitizerIdentifiers": [
+    {
+      "Width": 127.0,
+      "Height": 106.0,
+      "MaxX": 25400.0,
+      "MaxY": 21200.0,
+      "MaxPressure": 2046,
+      "ActiveReportID": {
+        "Start": 0,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 1386,
+      "ProductID": 32,
+      "InputReportLength": 10,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
+      "FeatureInitReport": "AgI=",
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    },
+    {
+      "Width": 127.0,
+      "Height": 106.0,
+      "MaxX": 25400.0,
+      "MaxY": 21200.0,
+      "MaxPressure": 2046,
+      "ActiveReportID": {
+        "Start": 0,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 1386,
+      "ProductID": 32,
+      "InputReportLength": 11,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
+      "FeatureInitReport": "AgI=",
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {}
+}


### PR DESCRIPTION
First config I've made completely for one of my own tablets. Yay!

Everything works properly almost. 

To note:
It sends some weird values when going out of bounds of the tablet beyond where the normal range caps out. Sends high pressure and very high position values.

The hotkeys on the digitizer (not physical buttons) that I assume are meant to be tapped with the pen don't do anything or send any data when they're pressed and this tablet doesn't have any potential aux endpoints so I think these hotkeys were defined entirely by the wacom drivers based off a specific position and pressure so I wouldn't count this tablet as missing any features.