### PR TITLE
Fix intuosv2

### DIFF
--- a/OpenTabletDriver/Configurations/Wacom/CTH-490.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTH-490.json
@@ -8,7 +8,7 @@
       "MaxY": 9500.0,
       "MaxPressure": 2047,
       "ActiveReportID": {
-        "Start": 0,
+        "Start": 1,
         "StartInclusive": false,
         "End": null,
         "EndInclusive": false
@@ -30,7 +30,7 @@
       "MaxY": 9500.0,
       "MaxPressure": 2047,
       "ActiveReportID": {
-        "Start": 0,
+        "Start": 1,
         "StartInclusive": false,
         "End": null,
         "EndInclusive": false

--- a/OpenTabletDriver/Configurations/Wacom/CTH-690.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTH-690.json
@@ -8,7 +8,7 @@
       "MaxY": 13500.0,
       "MaxPressure": 2047,
       "ActiveReportID": {
-        "Start": 16,
+        "Start": 1,
         "StartInclusive": false,
         "End": null,
         "EndInclusive": false
@@ -30,7 +30,7 @@
       "MaxY": 13500.0,
       "MaxPressure": 2047,
       "ActiveReportID": {
-        "Start": 16,
+        "Start": 1,
         "StartInclusive": false,
         "End": null,
         "EndInclusive": false

--- a/OpenTabletDriver/Configurations/Wacom/CTL-490.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-490.json
@@ -8,7 +8,7 @@
       "MaxY": 9500.0,
       "MaxPressure": 2047,
       "ActiveReportID": {
-        "Start": 0,
+        "Start": 1,
         "StartInclusive": false,
         "End": null,
         "EndInclusive": false
@@ -30,7 +30,7 @@
       "MaxY": 9500.0,
       "MaxPressure": 2047,
       "ActiveReportID": {
-        "Start": 0,
+        "Start": 1,
         "StartInclusive": false,
         "End": null,
         "EndInclusive": false

--- a/OpenTabletDriver/Configurations/Wacom/CTL-690.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-690.json
@@ -8,7 +8,7 @@
       "MaxY": 13500.0,
       "MaxPressure": 2047,
       "ActiveReportID": {
-        "Start": 16,
+        "Start": 1,
         "StartInclusive": false,
         "End": null,
         "EndInclusive": false
@@ -30,7 +30,7 @@
       "MaxY": 13500.0,
       "MaxPressure": 2047,
       "ActiveReportID": {
-        "Start": 16,
+        "Start": 1,
         "StartInclusive": false,
         "End": null,
         "EndInclusive": false

--- a/OpenTabletDriver/Configurations/Wacom/GD-0608-U.json
+++ b/OpenTabletDriver/Configurations/Wacom/GD-0608-U.json
@@ -1,0 +1,51 @@
+{
+  "Name": "Wacom GD-0608-U",
+  "DigitizerIdentifiers": [
+    {
+      "Width": 203.2,
+      "Height": 162.4,
+      "MaxX": 40640.0,
+      "MaxY": 32480.0,
+      "MaxPressure": 2046,
+      "ActiveReportID": {
+        "Start": 0,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 1386,
+      "ProductID": 33,
+      "InputReportLength": 10,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
+      "FeatureInitReport": "AgI=",
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    },
+    {
+      "Width": 203.2,
+      "Height": 162.4,
+      "MaxX": 40640.0,
+      "MaxY": 32480.0,
+      "MaxPressure": 2046,
+      "ActiveReportID": {
+        "Start": 0,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 1386,
+      "ProductID": 33,
+      "InputReportLength": 11,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
+      "FeatureInitReport": "AgI=",
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {}
+}

--- a/OpenTabletDriver/Configurations/Wacom/GD-0912-U.json
+++ b/OpenTabletDriver/Configurations/Wacom/GD-0912-U.json
@@ -1,0 +1,51 @@
+{
+  "Name": "Wacom GD-0912-U",
+  "DigitizerIdentifiers": [
+    {
+      "Width": 304.8,
+      "Height": 240.6,
+      "MaxX": 60960.0,
+      "MaxY": 48120.0,
+      "MaxPressure": 2046,
+      "ActiveReportID": {
+        "Start": 0,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 1386,
+      "ProductID": 34,
+      "InputReportLength": 10,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
+      "FeatureInitReport": "AgI=",
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    },
+    {
+      "Width": 304.8,
+      "Height": 240.6,
+      "MaxX": 60960.0,
+      "MaxY": 48120.0,
+      "MaxPressure": 2046,
+      "ActiveReportID": {
+        "Start": 0,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 1386,
+      "ProductID": 34,
+      "InputReportLength": 11,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
+      "FeatureInitReport": "AgI=",
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {}
+}

--- a/OpenTabletDriver/Configurations/Wacom/GD-1212-U.json
+++ b/OpenTabletDriver/Configurations/Wacom/GD-1212-U.json
@@ -1,0 +1,51 @@
+{
+  "Name": "Wacom GD-1212-U",
+  "DigitizerIdentifiers": [
+    {
+      "Width": 304.8,
+      "Height": 316.8,
+      "MaxX": 60960.0,
+      "MaxY": 63360.0,
+      "MaxPressure": 2046,
+      "ActiveReportID": {
+        "Start": 0,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 1386,
+      "ProductID": 35,
+      "InputReportLength": 10,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
+      "FeatureInitReport": "AgI=",
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    },
+    {
+      "Width": 304.8,
+      "Height": 316.8,
+      "MaxX": 60960.0,
+      "MaxY": 63360.0,
+      "MaxPressure": 2046,
+      "ActiveReportID": {
+        "Start": 0,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 1386,
+      "ProductID": 35,
+      "InputReportLength": 11,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
+      "FeatureInitReport": "AgI=",
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {}
+}

--- a/OpenTabletDriver/Configurations/Wacom/GD-1218-U.json
+++ b/OpenTabletDriver/Configurations/Wacom/GD-1218-U.json
@@ -1,0 +1,51 @@
+{
+  "Name": "Wacom GD-1218-U",
+  "DigitizerIdentifiers": [
+    {
+      "Width": 457.2,
+      "Height": 316.8,
+      "MaxX": 91440.0,
+      "MaxY": 63360.0,
+      "MaxPressure": 2046,
+      "ActiveReportID": {
+        "Start": 0,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 1386,
+      "ProductID": 36,
+      "InputReportLength": 10,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
+      "FeatureInitReport": "AgI=",
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    },
+    {
+      "Width": 457.2,
+      "Height": 316.8,
+      "MaxX": 91440.0,
+      "MaxY": 63360.0,
+      "MaxPressure": 2046,
+      "ActiveReportID": {
+        "Start": 0,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 1386,
+      "ProductID": 36,
+      "InputReportLength": 11,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
+      "FeatureInitReport": "AgI=",
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {}
+}

--- a/OpenTabletDriver/Configurations/Wacom/PTH-450.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTH-450.json
@@ -1,5 +1,5 @@
 {
-  "Name": "Wacom PTH-451",
+  "Name": "Wacom PTH-450",
   "DigitizerIdentifiers": [
     {
       "Width": 157.48,
@@ -14,7 +14,7 @@
         "EndInclusive": false
       },
       "VendorID": 1386,
-      "ProductID": 788,
+      "ProductID": 38,
       "InputReportLength": 10,
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
@@ -36,7 +36,7 @@
         "EndInclusive": false
       },
       "VendorID": 1386,
-      "ProductID": 788,
+      "ProductID": 38,
       "InputReportLength": 11,
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.Wacom64bAuxReportParser",
@@ -49,7 +49,7 @@
   "AuxilaryDeviceIdentifiers": [
     {
       "VendorID": 1386,
-      "ProductID": 788,
+      "ProductID": 38,
       "InputReportLength": 64,
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.Wacom64bAuxReportParser",

--- a/OpenTabletDriver/Configurations/Wacom/PTH-650.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTH-650.json
@@ -9,7 +9,7 @@
       "MaxPressure": 2047,
       "ActiveReportID": {
         "Start": 0,
-        "StartInclusive": true,
+        "StartInclusive": false,
         "End": null,
         "EndInclusive": false
       },
@@ -31,7 +31,7 @@
       "MaxPressure": 2047,
       "ActiveReportID": {
         "Start": 0,
-        "StartInclusive": true,
+        "StartInclusive": false,
         "End": null,
         "EndInclusive": false
       },

--- a/OpenTabletDriver/Configurations/Wacom/PTH-850.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTH-850.json
@@ -8,7 +8,7 @@
       "MaxY": 40640.0,
       "MaxPressure": 2047,
       "ActiveReportID": {
-        "Start": 1,
+        "Start": 0,
         "StartInclusive": false,
         "End": null,
         "EndInclusive": false
@@ -30,7 +30,7 @@
       "MaxY": 40640.0,
       "MaxPressure": 2047,
       "ActiveReportID": {
-        "Start": 1,
+        "Start": 0,
         "StartInclusive": false,
         "End": null,
         "EndInclusive": false

--- a/OpenTabletDriver/Configurations/Wacom/PTH-851.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTH-851.json
@@ -1,11 +1,11 @@
 {
-  "Name": "Wacom PTH-451",
+  "Name": "Wacom PTH-851",
   "DigitizerIdentifiers": [
     {
-      "Width": 157.48,
-      "Height": 98.425,
-      "MaxX": 31496.0,
-      "MaxY": 19685.0,
+      "Width": 325.12,
+      "Height": 203.2,
+      "MaxX": 65024.0,
+      "MaxY": 40640.0,
       "MaxPressure": 2047,
       "ActiveReportID": {
         "Start": 0,
@@ -14,7 +14,7 @@
         "EndInclusive": false
       },
       "VendorID": 1386,
-      "ProductID": 788,
+      "ProductID": 317,
       "InputReportLength": 10,
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
@@ -24,10 +24,10 @@
       "InitializationStrings": []
     },
     {
-      "Width": 157.48,
-      "Height": 98.425,
-      "MaxX": 31496.0,
-      "MaxY": 19685.0,
+      "Width": 325.12,
+      "Height": 203.2,
+      "MaxX": 65024.0,
+      "MaxY": 40640.0,
       "MaxPressure": 2047,
       "ActiveReportID": {
         "Start": 0,
@@ -36,10 +36,10 @@
         "EndInclusive": false
       },
       "VendorID": 1386,
-      "ProductID": 788,
+      "ProductID": 317,
       "InputReportLength": 11,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Vendors.Wacom.Wacom64bAuxReportParser",
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": "AgI=",
       "OutputInitReport": null,
       "DeviceStrings": {},
@@ -49,7 +49,7 @@
   "AuxilaryDeviceIdentifiers": [
     {
       "VendorID": 1386,
-      "ProductID": 788,
+      "ProductID": 317,
       "InputReportLength": 64,
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.Wacom64bAuxReportParser",

--- a/OpenTabletDriver/Configurations/Wacom/PTK-1240.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTK-1240.json
@@ -8,9 +8,9 @@
       "MaxY": 60960.0,
       "MaxPressure": 2047,
       "ActiveReportID": {
-        "Start": 1,
+        "Start": 0,
         "StartInclusive": false,
-        "End": 62,
+        "End": null,
         "EndInclusive": false
       },
       "VendorID": 1386,
@@ -30,9 +30,9 @@
       "MaxY": 60960.0,
       "MaxPressure": 2047,
       "ActiveReportID": {
-        "Start": 1,
+        "Start": 0,
         "StartInclusive": false,
-        "End": 62,
+        "End": null,
         "EndInclusive": false
       },
       "VendorID": 1386,

--- a/OpenTabletDriver/Configurations/Wacom/PTK-440.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTK-440.json
@@ -9,7 +9,7 @@
       "MaxPressure": 2047,
       "ActiveReportID": {
         "Start": 0,
-        "StartInclusive": true,
+        "StartInclusive": false,
         "End": null,
         "EndInclusive": false
       },
@@ -31,7 +31,7 @@
       "MaxPressure": 2047,
       "ActiveReportID": {
         "Start": 0,
-        "StartInclusive": true,
+        "StartInclusive": false,
         "End": null,
         "EndInclusive": false
       },

--- a/OpenTabletDriver/Configurations/Wacom/PTK-450.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTK-450.json
@@ -1,5 +1,5 @@
 {
-  "Name": "Wacom PTH-451",
+  "Name": "Wacom PTK-450",
   "DigitizerIdentifiers": [
     {
       "Width": 157.48,
@@ -14,7 +14,7 @@
         "EndInclusive": false
       },
       "VendorID": 1386,
-      "ProductID": 788,
+      "ProductID": 41,
       "InputReportLength": 10,
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
@@ -36,7 +36,7 @@
         "EndInclusive": false
       },
       "VendorID": 1386,
-      "ProductID": 788,
+      "ProductID": 41,
       "InputReportLength": 11,
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.Wacom64bAuxReportParser",
@@ -46,18 +46,6 @@
       "InitializationStrings": []
     }
   ],
-  "AuxilaryDeviceIdentifiers": [
-    {
-      "VendorID": 1386,
-      "ProductID": 788,
-      "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Vendors.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": []
-    }
-  ],
+  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {}
 }

--- a/OpenTabletDriver/Configurations/Wacom/PTK-540WL.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTK-540WL.json
@@ -10,7 +10,7 @@
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,
-        "End": 62,
+        "End": null,
         "EndInclusive": false
       },
       "VendorID": 1386,
@@ -32,7 +32,7 @@
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,
-        "End": 62,
+        "End": null,
         "EndInclusive": false
       },
       "VendorID": 1386,

--- a/OpenTabletDriver/Configurations/Wacom/PTK-640.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTK-640.json
@@ -46,18 +46,6 @@
       "InitializationStrings": []
     }
   ],
-  "AuxilaryDeviceIdentifiers": [
-    {
-      "VendorID": 1386,
-      "ProductID": 185,
-      "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Tablet.AuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": []
-    }
-  ],
+  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {}
 }

--- a/OpenTabletDriver/Configurations/Wacom/PTK-650.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTK-650.json
@@ -1,11 +1,11 @@
 {
-  "Name": "Wacom PTH-451",
+  "Name": "Wacom PTK-650",
   "DigitizerIdentifiers": [
     {
-      "Width": 157.48,
-      "Height": 98.425,
-      "MaxX": 31496.0,
-      "MaxY": 19685.0,
+      "Width": 223.52,
+      "Height": 139.7,
+      "MaxX": 44704.0,
+      "MaxY": 27940.0,
       "MaxPressure": 2047,
       "ActiveReportID": {
         "Start": 0,
@@ -14,7 +14,7 @@
         "EndInclusive": false
       },
       "VendorID": 1386,
-      "ProductID": 788,
+      "ProductID": 42,
       "InputReportLength": 10,
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
@@ -24,10 +24,10 @@
       "InitializationStrings": []
     },
     {
-      "Width": 157.48,
-      "Height": 98.425,
-      "MaxX": 31496.0,
-      "MaxY": 19685.0,
+      "Width": 223.52,
+      "Height": 139.7,
+      "MaxX": 44704.0,
+      "MaxY": 27940.0,
       "MaxPressure": 2047,
       "ActiveReportID": {
         "Start": 0,
@@ -36,28 +36,16 @@
         "EndInclusive": false
       },
       "VendorID": 1386,
-      "ProductID": 788,
+      "ProductID": 42,
       "InputReportLength": 11,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Vendors.Wacom.Wacom64bAuxReportParser",
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": "AgI=",
       "OutputInitReport": null,
       "DeviceStrings": {},
       "InitializationStrings": []
     }
   ],
-  "AuxilaryDeviceIdentifiers": [
-    {
-      "VendorID": 1386,
-      "ProductID": 788,
-      "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Vendors.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": []
-    }
-  ],
+  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {}
 }

--- a/OpenTabletDriver/Configurations/Wacom/PTK-840.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTK-840.json
@@ -1,11 +1,11 @@
 {
-  "Name": "Wacom PTH-451",
+  "Name": "Wacom PTK-840",
   "DigitizerIdentifiers": [
     {
-      "Width": 157.48,
-      "Height": 98.425,
-      "MaxX": 31496.0,
-      "MaxY": 19685.0,
+      "Width": 325.12,
+      "Height": 203.2,
+      "MaxX": 65024.0,
+      "MaxY": 40640.0,
       "MaxPressure": 2047,
       "ActiveReportID": {
         "Start": 0,
@@ -14,7 +14,7 @@
         "EndInclusive": false
       },
       "VendorID": 1386,
-      "ProductID": 788,
+      "ProductID": 186,
       "InputReportLength": 10,
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
@@ -24,10 +24,10 @@
       "InitializationStrings": []
     },
     {
-      "Width": 157.48,
-      "Height": 98.425,
-      "MaxX": 31496.0,
-      "MaxY": 19685.0,
+      "Width": 325.12,
+      "Height": 203.2,
+      "MaxX": 65024.0,
+      "MaxY": 40640.0,
       "MaxPressure": 2047,
       "ActiveReportID": {
         "Start": 0,
@@ -36,28 +36,16 @@
         "EndInclusive": false
       },
       "VendorID": 1386,
-      "ProductID": 788,
+      "ProductID": 186,
       "InputReportLength": 11,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Vendors.Wacom.Wacom64bAuxReportParser",
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": "AgI=",
       "OutputInitReport": null,
       "DeviceStrings": {},
       "InitializationStrings": []
     }
   ],
-  "AuxilaryDeviceIdentifiers": [
-    {
-      "VendorID": 1386,
-      "ProductID": 788,
-      "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Vendors.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": []
-    }
-  ],
+  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {}
 }

--- a/OpenTabletDriver/Configurations/Wacom/PTZ-1230.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTZ-1230.json
@@ -1,12 +1,12 @@
 {
-  "Name": "Wacom PTH-451",
+  "Name": "Wacom PTZ-1230",
   "DigitizerIdentifiers": [
     {
-      "Width": 157.48,
-      "Height": 98.425,
-      "MaxX": 31496.0,
-      "MaxY": 19685.0,
-      "MaxPressure": 2047,
+      "Width": 304.8,
+      "Height": 304.8,
+      "MaxX": 60960.0,
+      "MaxY": 60960.0,
+      "MaxPressure": 2046,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,
@@ -14,7 +14,7 @@
         "EndInclusive": false
       },
       "VendorID": 1386,
-      "ProductID": 788,
+      "ProductID": 179,
       "InputReportLength": 10,
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
@@ -24,11 +24,11 @@
       "InitializationStrings": []
     },
     {
-      "Width": 157.48,
-      "Height": 98.425,
-      "MaxX": 31496.0,
-      "MaxY": 19685.0,
-      "MaxPressure": 2047,
+      "Width": 304.8,
+      "Height": 304.8,
+      "MaxX": 60960.0,
+      "MaxY": 60960.0,
+      "MaxPressure": 2046,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,
@@ -36,28 +36,16 @@
         "EndInclusive": false
       },
       "VendorID": 1386,
-      "ProductID": 788,
+      "ProductID": 179,
       "InputReportLength": 11,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Vendors.Wacom.Wacom64bAuxReportParser",
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": "AgI=",
       "OutputInitReport": null,
       "DeviceStrings": {},
       "InitializationStrings": []
     }
   ],
-  "AuxilaryDeviceIdentifiers": [
-    {
-      "VendorID": 1386,
-      "ProductID": 788,
-      "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Vendors.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": []
-    }
-  ],
+  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {}
 }

--- a/OpenTabletDriver/Configurations/Wacom/PTZ-1231W.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTZ-1231W.json
@@ -1,12 +1,12 @@
 {
-  "Name": "Wacom PTH-451",
+  "Name": "Wacom PTZ-1231W",
   "DigitizerIdentifiers": [
     {
-      "Width": 157.48,
-      "Height": 98.425,
-      "MaxX": 31496.0,
-      "MaxY": 19685.0,
-      "MaxPressure": 2047,
+      "Width": 487.68,
+      "Height": 304.8,
+      "MaxX": 97536.0,
+      "MaxY": 60960.0,
+      "MaxPressure": 2046,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,
@@ -14,7 +14,7 @@
         "EndInclusive": false
       },
       "VendorID": 1386,
-      "ProductID": 788,
+      "ProductID": 180,
       "InputReportLength": 10,
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
@@ -24,11 +24,11 @@
       "InitializationStrings": []
     },
     {
-      "Width": 157.48,
-      "Height": 98.425,
-      "MaxX": 31496.0,
-      "MaxY": 19685.0,
-      "MaxPressure": 2047,
+      "Width": 487.68,
+      "Height": 304.8,
+      "MaxX": 97536.0,
+      "MaxY": 60960.0,
+      "MaxPressure": 2046,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,
@@ -36,28 +36,16 @@
         "EndInclusive": false
       },
       "VendorID": 1386,
-      "ProductID": 788,
+      "ProductID": 180,
       "InputReportLength": 11,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Vendors.Wacom.Wacom64bAuxReportParser",
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": "AgI=",
       "OutputInitReport": null,
       "DeviceStrings": {},
       "InitializationStrings": []
     }
   ],
-  "AuxilaryDeviceIdentifiers": [
-    {
-      "VendorID": 1386,
-      "ProductID": 788,
-      "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Vendors.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": []
-    }
-  ],
+  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {}
 }

--- a/OpenTabletDriver/Configurations/Wacom/PTZ-430.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTZ-430.json
@@ -1,12 +1,12 @@
 {
-  "Name": "Wacom PTH-451",
+  "Name": "Wacom PTZ-430",
   "DigitizerIdentifiers": [
     {
-      "Width": 157.48,
-      "Height": 98.425,
-      "MaxX": 31496.0,
-      "MaxY": 19685.0,
-      "MaxPressure": 2047,
+      "Width": 127.0,
+      "Height": 101.6,
+      "MaxX": 25400.0,
+      "MaxY": 20320.0,
+      "MaxPressure": 2046,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,
@@ -14,7 +14,7 @@
         "EndInclusive": false
       },
       "VendorID": 1386,
-      "ProductID": 788,
+      "ProductID": 176,
       "InputReportLength": 10,
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
@@ -24,11 +24,11 @@
       "InitializationStrings": []
     },
     {
-      "Width": 157.48,
-      "Height": 98.425,
-      "MaxX": 31496.0,
-      "MaxY": 19685.0,
-      "MaxPressure": 2047,
+      "Width": 127.0,
+      "Height": 101.6,
+      "MaxX": 25400.0,
+      "MaxY": 20320.0,
+      "MaxPressure": 2046,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,
@@ -36,28 +36,16 @@
         "EndInclusive": false
       },
       "VendorID": 1386,
-      "ProductID": 788,
+      "ProductID": 176,
       "InputReportLength": 11,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Vendors.Wacom.Wacom64bAuxReportParser",
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": "AgI=",
       "OutputInitReport": null,
       "DeviceStrings": {},
       "InitializationStrings": []
     }
   ],
-  "AuxilaryDeviceIdentifiers": [
-    {
-      "VendorID": 1386,
-      "ProductID": 788,
-      "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Vendors.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": []
-    }
-  ],
+  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {}
 }

--- a/OpenTabletDriver/Configurations/Wacom/PTZ-431W.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTZ-431W.json
@@ -1,12 +1,12 @@
 {
-  "Name": "Wacom PTH-451",
+  "Name": "Wacom PTZ-431W",
   "DigitizerIdentifiers": [
     {
       "Width": 157.48,
       "Height": 98.425,
       "MaxX": 31496.0,
       "MaxY": 19685.0,
-      "MaxPressure": 2047,
+      "MaxPressure": 2046,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,
@@ -14,7 +14,7 @@
         "EndInclusive": false
       },
       "VendorID": 1386,
-      "ProductID": 788,
+      "ProductID": 183,
       "InputReportLength": 10,
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
@@ -28,7 +28,7 @@
       "Height": 98.425,
       "MaxX": 31496.0,
       "MaxY": 19685.0,
-      "MaxPressure": 2047,
+      "MaxPressure": 2046,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,
@@ -36,28 +36,16 @@
         "EndInclusive": false
       },
       "VendorID": 1386,
-      "ProductID": 788,
+      "ProductID": 183,
       "InputReportLength": 11,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Vendors.Wacom.Wacom64bAuxReportParser",
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": "AgI=",
       "OutputInitReport": null,
       "DeviceStrings": {},
       "InitializationStrings": []
     }
   ],
-  "AuxilaryDeviceIdentifiers": [
-    {
-      "VendorID": 1386,
-      "ProductID": 788,
-      "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Vendors.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": []
-    }
-  ],
+  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {}
 }

--- a/OpenTabletDriver/Configurations/Wacom/PTZ-631W.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTZ-631W.json
@@ -1,12 +1,12 @@
 {
-  "Name": "Wacom PTH-451",
+  "Name": "Wacom PTZ-631W",
   "DigitizerIdentifiers": [
     {
-      "Width": 157.48,
-      "Height": 98.425,
-      "MaxX": 31496.0,
-      "MaxY": 19685.0,
-      "MaxPressure": 2047,
+      "Width": 271.02,
+      "Height": 158.75,
+      "MaxX": 54204.0,
+      "MaxY": 31750.0,
+      "MaxPressure": 2046,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,
@@ -14,7 +14,7 @@
         "EndInclusive": false
       },
       "VendorID": 1386,
-      "ProductID": 788,
+      "ProductID": 181,
       "InputReportLength": 10,
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
@@ -24,11 +24,11 @@
       "InitializationStrings": []
     },
     {
-      "Width": 157.48,
-      "Height": 98.425,
-      "MaxX": 31496.0,
-      "MaxY": 19685.0,
-      "MaxPressure": 2047,
+      "Width": 271.02,
+      "Height": 158.75,
+      "MaxX": 54204.0,
+      "MaxY": 31750.0,
+      "MaxPressure": 2046,
       "ActiveReportID": {
         "Start": 0,
         "StartInclusive": false,
@@ -36,28 +36,16 @@
         "EndInclusive": false
       },
       "VendorID": 1386,
-      "ProductID": 788,
+      "ProductID": 181,
       "InputReportLength": 11,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Vendors.Wacom.Wacom64bAuxReportParser",
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": "AgI=",
       "OutputInitReport": null,
       "DeviceStrings": {},
       "InitializationStrings": []
     }
   ],
-  "AuxilaryDeviceIdentifiers": [
-    {
-      "VendorID": 1386,
-      "ProductID": 788,
-      "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Vendors.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": []
-    }
-  ],
+  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {}
 }

--- a/OpenTabletDriver/Configurations/Wacom/XD-0405-U.json
+++ b/OpenTabletDriver/Configurations/Wacom/XD-0405-U.json
@@ -1,0 +1,50 @@
+{
+  "Name": "Wacom XD-0405-U",
+  "DigitizerIdentifiers": [
+    {
+      "Width": 127.0,
+      "Height": 106.0,
+      "MaxX": 25400.0,
+      "MaxY": 21200.0,
+      "MaxPressure": 1023,
+      "ActiveReportID": {
+        "Start": 0,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 1386,
+      "ProductID": 65,
+      "InputReportLength": 10,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
+      "FeatureInitReport": "AgI=",
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    },
+    {
+      "Width": 127.0,
+      "Height": 106.0,
+      "MaxX": 25400.0,
+      "MaxY": 21200.0,
+      "MaxPressure": 1023,
+      "ActiveReportID": {
+        "Start": 0,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 1386,
+      "ProductID": 65,
+      "InputReportLength": 11,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
+      "FeatureInitReport": "AgI=",
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {}
+}

--- a/OpenTabletDriver/Configurations/Wacom/XD-0912-U.json
+++ b/OpenTabletDriver/Configurations/Wacom/XD-0912-U.json
@@ -1,0 +1,50 @@
+{
+  "Name": "Wacom XD-0912-U",
+  "DigitizerIdentifiers": [
+    {
+      "Width": 304.8,
+      "Height": 240.6,
+      "MaxX": 60960.0,
+      "MaxY": 48120.0,
+      "MaxPressure": 1023,
+      "ActiveReportID": {
+        "Start": 0,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 1386,
+      "ProductID": 67,
+      "InputReportLength": 10,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
+      "FeatureInitReport": "AgI=",
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    },
+    {
+      "Width": 304.8,
+      "Height": 240.6,
+      "MaxX": 60960.0,
+      "MaxY": 48120.0,
+      "MaxPressure": 1023,
+      "ActiveReportID": {
+        "Start": 0,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 1386,
+      "ProductID": 67,
+      "InputReportLength": 11,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
+      "FeatureInitReport": "AgI=",
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {}
+}

--- a/OpenTabletDriver/Configurations/Wacom/XD-1212-U.json
+++ b/OpenTabletDriver/Configurations/Wacom/XD-1212-U.json
@@ -1,0 +1,50 @@
+{
+  "Name": "Wacom XD-1212-U",
+  "DigitizerIdentifiers": [
+    {
+      "Width": 304.8,
+      "Height": 316.8,
+      "MaxX": 60960.0,
+      "MaxY": 63360.0,
+      "MaxPressure": 1023,
+      "ActiveReportID": {
+        "Start": 0,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 1386,
+      "ProductID": 68,
+      "InputReportLength": 10,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
+      "FeatureInitReport": "AgI=",
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    },
+    {
+      "Width": 304.8,
+      "Height": 316.8,
+      "MaxX": 60960.0,
+      "MaxY": 63360.0,
+      "MaxPressure": 1023,
+      "ActiveReportID": {
+        "Start": 0,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 1386,
+      "ProductID": 68,
+      "InputReportLength": 11,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
+      "FeatureInitReport": "AgI=",
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {}
+}

--- a/OpenTabletDriver/Configurations/Wacom/XD-1218-U.json
+++ b/OpenTabletDriver/Configurations/Wacom/XD-1218-U.json
@@ -1,0 +1,50 @@
+{
+  "Name": "Wacom XD-1218-U",
+  "DigitizerIdentifiers": [
+    {
+      "Width": 457.2,
+      "Height": 316.8,
+      "MaxX": 91440.0,
+      "MaxY": 63360.0,
+      "MaxPressure": 1023,
+      "ActiveReportID": {
+        "Start": 0,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 1386,
+      "ProductID": 69,
+      "InputReportLength": 10,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
+      "FeatureInitReport": "AgI=",
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    },
+    {
+      "Width": 457.2,
+      "Height": 316.8,
+      "MaxX": 91440.0,
+      "MaxY": 63360.0,
+      "MaxPressure": 1023,
+      "ActiveReportID": {
+        "Start": 0,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 1386,
+      "ProductID": 69,
+      "InputReportLength": 11,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
+      "FeatureInitReport": "AgI=",
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {}
+}

--- a/OpenTabletDriver/Vendors/Wacom/IntuosV2Report.cs
+++ b/OpenTabletDriver/Vendors/Wacom/IntuosV2Report.cs
@@ -9,8 +9,13 @@ namespace OpenTabletDriver.Vendors.Wacom
         public IntuosV2TabletReport(byte[] report)
         {
             Raw = report;
-
-            ReportID = (uint)report[9] >> 2;
+            ReportID = report[1] switch
+            {
+                0x80 => 0u, // 0x80 is pen out of range report,
+                0xC2 => 0u, // <- should fix the GD 0405 U,
+                0x20 => 1u, // this should be excluded from IntuosHT2
+                _ => 2u     // everything else should have position data.
+            };
             Position = new Vector2
             {
                 X = (report[3] | report[2] << 8) << 1 | ((report[9] >> 1) & 1),
@@ -27,7 +32,7 @@ namespace OpenTabletDriver.Vendors.Wacom
                 (report[1] & (1 << 1)) != 0,
                 (report[1] & (1 << 2)) != 0
             };
-            NearProximity = (report[1] & (1 << 7)) != 0;
+            NearProximity = (report[1] & (1 << 6)) != 0;
             HoverDistance = (uint)report[9] >> 2;
         }
 


### PR DESCRIPTION
Depends on #962, because 64 byte endpoints shouldn't be opened with IntuosV2ReportParser.

~~CTx-x90 tablets need to be tested.~~ [CTL490 works, so other IntuosHT2 should work too](https://discord.com/channels/615607687467761684/628651971267788800/829070161721950238)