### PR TITLE
Fix bogus HID reports breaking tablet detection

### DIFF
--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -330,14 +330,28 @@ namespace OpenTabletDriver
 
         private IEnumerable<HidDevice> FindMatches(DeviceIdentifier identifier)
         {
-            return from device in DeviceList.Local.GetHidDevices()
-                where identifier.VendorID == device.VendorID
-                where identifier.ProductID == device.ProductID
-                where device.CanOpen
-                where identifier.InputReportLength == null || identifier.InputReportLength == device.GetMaxInputReportLength()
-                where identifier.OutputReportLength == null || identifier.OutputReportLength == device.GetMaxOutputReportLength()
-                where DeviceMatchesAllStrings(device, identifier)
-                select device;
+            foreach (HidDevice device in DeviceList.Local.GetHidDevices().ToList())
+            {
+                try
+                {
+                    if (identifier.VendorID != device.VendorID ||
+                        identifier.ProductID != device.ProductID ||
+                        !device.CanOpen ||
+                        (identifier.InputReportLength != null && identifier.InputReportLength != device.GetMaxInputReportLength()) ||
+                        (identifier.OutputReportLength != null && identifier.OutputReportLength != device.GetMaxOutputReportLength()) ||
+                        !DeviceMatchesAllStrings(device, identifier))
+                    {
+                        continue;
+                    }
+                }
+                catch (Exception e)
+                {
+                    Log.Exception(e);
+                    continue;
+                }
+
+                yield return device;
+            }
         }
 
         private bool DigitizerMatchesAttribute(HidDevice device, Dictionary<string, string> attributes)

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -331,9 +331,9 @@ namespace OpenTabletDriver
         private IEnumerable<HidDevice> FindMatches(DeviceIdentifier identifier)
         {
             return from device in DeviceList.Local.GetHidDevices()
-                where device.CanOpen
                 where identifier.VendorID == device.VendorID
                 where identifier.ProductID == device.ProductID
+                where device.CanOpen
                 where identifier.InputReportLength == null || identifier.InputReportLength == device.GetMaxInputReportLength()
                 where identifier.OutputReportLength == null || identifier.OutputReportLength == device.GetMaxOutputReportLength()
                 where DeviceMatchesAllStrings(device, identifier)

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -344,13 +344,13 @@ namespace OpenTabletDriver
         private IEnumerable<HidDevice> FindMatches(DeviceIdentifier identifier)
         {
             return from device in DeviceList.Local.GetHidDevices()
-                   where identifier.VendorID == device.VendorID
-                   where identifier.ProductID == device.ProductID
-                   where TryDeviceOpen(device)
-                   where identifier.InputReportLength == null || identifier.InputReportLength == device.GetMaxInputReportLength()
-                   where identifier.OutputReportLength == null || identifier.OutputReportLength == device.GetMaxOutputReportLength()
-                   where DeviceMatchesAllStrings(device, identifier)
-                   select device;
+                where identifier.VendorID == device.VendorID
+                where identifier.ProductID == device.ProductID
+                where TryDeviceOpen(device)
+                where identifier.InputReportLength == null || identifier.InputReportLength == device.GetMaxInputReportLength()
+                where identifier.OutputReportLength == null || identifier.OutputReportLength == device.GetMaxOutputReportLength()
+                where DeviceMatchesAllStrings(device, identifier)
+                select device;
         }
 
         private bool DigitizerMatchesAttribute(HidDevice device, Dictionary<string, string> attributes)


### PR DESCRIPTION
This fix prevents devices from aborting the tablet detection prematurely.

The fix mainly applies to cases like #960 where another USB device hands out bogus HID reports with `CanOpen` set to `true`.
So we filter the `IEnumerable<HidDevice>` in `OpenTabletDrivers.Drivers.FindMatches` before we even check for a `CanOpen`.
This way we rule out broken third party devices that are not the tablets we are interested in.