### PR TITLE
Add better usage of git references in alternate plugin repository dialog

### DIFF
--- a/OpenTabletDriver.Desktop/Reflection/Metadata/PluginMetadataCollection.cs
+++ b/OpenTabletDriver.Desktop/Reflection/Metadata/PluginMetadataCollection.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using ICSharpCode.SharpZipLib.GZip;
 using ICSharpCode.SharpZipLib.Tar;
@@ -27,6 +28,7 @@ namespace OpenTabletDriver.Desktop.Reflection.Metadata
 
         public const string REPOSITORY_OWNER = "OpenTabletDriver";
         public const string REPOSITORY_NAME = "Plugin-Repository";
+        public const string GIT_REF_REGEX = @"(.+?):(.+$)";
 
         protected static GitHubClient GitHub { get; } = new GitHubClient(new ProductHeaderValue("OpenTabletDriver"));
 
@@ -44,9 +46,13 @@ namespace OpenTabletDriver.Desktop.Reflection.Metadata
             return await DownloadAsync(REPOSITORY_OWNER, REPOSITORY_NAME);
         }
 
-        public static async Task<PluginMetadataCollection> DownloadAsync(string owner, string name, string gitRef = null)
+        public static async Task<PluginMetadataCollection> DownloadAsync(string branchRef, string repoName)
         {
-            string archiveUrl = $"https://api.github.com/repos/{owner}/{name}/tarball/{gitRef}";
+            var match = Regex.Match(branchRef, GIT_REF_REGEX);
+            string owner = match.Success ? match.Groups[1].Value : branchRef;
+            string gitRef = match.Success ? match.Groups[2].Value : null;
+
+            string archiveUrl = $"https://api.github.com/repos/{owner}/{repoName}/tarball/{gitRef}";
             return await DownloadAsync(archiveUrl);
         }
 

--- a/OpenTabletDriver.UX/Dialogs/RepositoryDialog.cs
+++ b/OpenTabletDriver.UX/Dialogs/RepositoryDialog.cs
@@ -23,19 +23,15 @@ namespace OpenTabletDriver.UX.Dialogs
         {
             base.OnLoadComplete(e);
 
-            var owner = new TextBoxGroup("Owner")
-            {
-                DefaultInputText = PluginMetadataCollection.REPOSITORY_OWNER
-            };
-
             var repo = new TextBoxGroup("Name")
             {
                 DefaultInputText = PluginMetadataCollection.REPOSITORY_NAME
             };
 
-            var gitRef = new TextBoxGroup("Ref")
+            var branchRef = new TextBoxGroup("Git Reference")
             {
-                DefaultInputText = "master"
+                ToolTip = "{Owner}:{GitRef}",
+                DefaultInputText = $"{PluginMetadataCollection.REPOSITORY_OWNER}:master"
             };
 
             var actions = new StackLayout
@@ -56,7 +52,7 @@ namespace OpenTabletDriver.UX.Dialogs
                     new StackLayoutItem
                     {
                         Expand = true,
-                        Control = new Button((sender, e) => Return(owner, repo, gitRef))
+                        Control = new Button((sender, e) => Return(branchRef, repo))
                         {
                             Text = "Apply"
                         }
@@ -71,18 +67,17 @@ namespace OpenTabletDriver.UX.Dialogs
                 Spacing = 5,
                 Items =
                 {
-                    new StackLayoutItem(owner),
                     new StackLayoutItem(repo),
-                    new StackLayoutItem(gitRef),
+                    new StackLayoutItem(branchRef),
                     new StackLayoutItem(null, true),
                     new StackLayoutItem(actions)
                 }
             };
         }
 
-        protected async void Return(TextBoxGroup owner, TextBoxGroup repo, TextBoxGroup gitRef)
+        protected async void Return(TextBoxGroup branchRef, TextBoxGroup repoName)
         {
-            var collection = await PluginMetadataCollection.DownloadAsync(owner.InputText, repo.InputText, gitRef.InputText);
+            var collection = await PluginMetadataCollection.DownloadAsync(branchRef, repoName);
             Close(collection);
         }
 
@@ -126,6 +121,8 @@ namespace OpenTabletDriver.UX.Dialogs
                     }
                 };
             }
+
+            public static implicit operator string(TextBoxGroup grp) => grp.InputText;
         }
     }
 }


### PR DESCRIPTION
# Changes

- Adds the ability to use the git reference provided in plugin manager pull requests directly instead of manually splitting them.

## Examples

- `OpenTabletDriver:master` will pull https://github.com/OpenTabletDriver/Plugin-Repository/tree/master
- `adryzz:audiotogglev0.4` will pull https://github.com/adryzz/Plugin-Repository/tree/audiotogglev0.4