### PR TITLE
Add multi-key binding support

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -125,7 +125,6 @@ namespace OpenTabletDriver.Daemon
                     Settings = SettingsMigrator.Migrate(Settings);
 
                 // Add services to inject on plugin construction
-                pluginManager.ResetServices();
                 pluginManager.AddService<IDriver>(() => this.Driver);
             }
             else

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -126,13 +126,7 @@ namespace OpenTabletDriver.Daemon
 
                 // Add services to inject on plugin construction
                 pluginManager.ResetServices();
-                pluginManager.AddService<IServiceProvider>(() => pluginManager);
                 pluginManager.AddService<IDriver>(() => this.Driver);
-                pluginManager.AddService(() => DesktopInterop.Timer);
-                pluginManager.AddService(() => DesktopInterop.AbsolutePointer);
-                pluginManager.AddService(() => DesktopInterop.RelativePointer);
-                pluginManager.AddService(() => DesktopInterop.VirtualScreen);
-                pluginManager.AddService(() => DesktopInterop.VirtualKeyboard);
             }
             else
             {

--- a/OpenTabletDriver.Desktop/Binding/MultiKeyBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/MultiKeyBinding.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenTabletDriver.Plugin;
+using OpenTabletDriver.Plugin.Attributes;
+using OpenTabletDriver.Plugin.DependencyInjection;
+using OpenTabletDriver.Plugin.Platform.Keyboard;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Desktop.Binding
+{
+    [PluginName(PLUGIN_NAME)]
+    public class MultiKeyBinding : IBinding
+    {
+        private const string PLUGIN_NAME = "Multi-Key Binding";
+        private const char KEYS_SPLITTER = '+';
+
+        private IList<string> keys;
+        private string keysString;
+
+        [Resolved]
+        public IVirtualKeyboard Keyboard { set; get; }
+
+        [Property("Keys")]
+        public string Keys
+        {
+            set
+            {
+                this.keysString = value;
+                this.keys = ParseKeys(Keys);
+            }
+            get => this.keysString;
+        }
+
+
+        public void Press(IDeviceReport report)
+        {
+            if (keys.Count > 0)
+                Keyboard.Press(this.keys);
+        }
+
+        public void Release(IDeviceReport report)
+        {
+            if (keys.Count > 0)
+                Keyboard.Release(this.keys);
+        }
+
+        private IList<string> ParseKeys(string str)
+        {
+            var newKeys = str.Split(KEYS_SPLITTER, StringSplitOptions.TrimEntries);
+            return newKeys.All(k => Keyboard.SupportedKeys.Contains(k)) ? newKeys : Array.Empty<string>();
+        }
+
+        public override string ToString() => $"{PLUGIN_NAME}: {Keys}";
+    }
+}

--- a/OpenTabletDriver.Desktop/Binding/MultiKeyBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/MultiKeyBinding.cs
@@ -32,7 +32,6 @@ namespace OpenTabletDriver.Desktop.Binding
             get => this.keysString;
         }
 
-
         public void Press(IDeviceReport report)
         {
             if (keys.Count > 0)

--- a/OpenTabletDriver.Desktop/Interop/Input/Keyboard/EvdevVirtualKeyboard.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Keyboard/EvdevVirtualKeyboard.cs
@@ -30,7 +30,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Keyboard
 
         private EvdevDevice Device { set; get; }
 
-        private void KeyPress(string key, bool isPress)
+        private void KeyEvent(string key, bool isPress)
         {
             var keyEventCode = EtoKeysymToEventCode[key];
 
@@ -40,12 +40,24 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Keyboard
 
         public void Press(string key)
         {
-            KeyPress(key, true);
+            KeyEvent(key, true);
         }
 
         public void Release(string key)
         {
-            KeyPress(key, false);
+            KeyEvent(key, false);
+        }
+
+        public void Press(IEnumerable<string> keys)
+        {
+            foreach (var key in keys)
+                KeyEvent(key, true);
+        }
+
+        public void Release(IEnumerable<string> keys)
+        {
+            foreach (var key in keys)
+                KeyEvent(key, false);
         }
 
         public void Dispose()
@@ -53,7 +65,9 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Keyboard
             Device?.Dispose();
         }
 
-        public static readonly Dictionary<string, EventCode> EtoKeysymToEventCode = new Dictionary<string, EventCode>
+        public IEnumerable<string> SupportedKeys => EtoKeysymToEventCode.Keys;
+
+        internal static readonly Dictionary<string, EventCode> EtoKeysymToEventCode = new Dictionary<string, EventCode>
         {
             { "None", 0x0 },
             { "A", EventCode.KEY_A },

--- a/OpenTabletDriver.Desktop/Interop/Input/Keyboard/MacOSVirtualKeyboard.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Keyboard/MacOSVirtualKeyboard.cs
@@ -11,7 +11,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Keyboard
 
     public class MacOSVirtualKeyboard : IVirtualKeyboard
     {
-        private void KeyPress(string key, bool isPress)
+        private void KeyEvent(string key, bool isPress)
         {
             if (EtoKeysymToVK.TryGetValue(key, out var code))
             {
@@ -23,15 +23,29 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Keyboard
 
         public void Press(string key)
         {
-            KeyPress(key, true);
+            KeyEvent(key, true);
         }
 
         public void Release(string key)
         {
-            KeyPress(key, false);
+            KeyEvent(key, false);
         }
 
-        public static readonly Dictionary<string, CGKeyCode> EtoKeysymToVK = new Dictionary<string, CGKeyCode>
+        public void Press(IEnumerable<string> keys)
+        {
+            foreach (var key in keys)
+                KeyEvent(key, true);
+        }
+
+        public void Release(IEnumerable<string> keys)
+        {
+            foreach (var key in keys)
+                KeyEvent(key, false);
+        }
+
+        public IEnumerable<string> SupportedKeys => EtoKeysymToVK.Keys;
+
+        internal static readonly Dictionary<string, CGKeyCode> EtoKeysymToVK = new Dictionary<string, CGKeyCode>
         {
             { "None", 0x00 },
             { "A", CGKeyCode.kVK_ANSI_A },

--- a/OpenTabletDriver.Desktop/Interop/Input/Keyboard/WindowsVirtualKeyboard.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Keyboard/WindowsVirtualKeyboard.cs
@@ -10,7 +10,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Keyboard
 
     public class WindowsVirtualKeyboard : IVirtualKeyboard
     {
-        private void KeyPress(string key, bool isPress)
+        private void KeyEvent(string key, bool isPress)
         {
             var vk = EtoKeysymToVK[key];
             var input = new INPUT
@@ -35,15 +35,29 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Keyboard
 
         public void Press(string key)
         {
-            KeyPress(key, true);
+            KeyEvent(key, true);
         }
 
         public void Release(string key)
         {
-            KeyPress(key, false);
+            KeyEvent(key, false);
         }
 
-        public static readonly Dictionary<string, VirtualKey> EtoKeysymToVK = new Dictionary<string, VirtualKey>
+        public void Press(IEnumerable<string> keys)
+        {
+            foreach (var key in keys)
+                KeyEvent(key, true);
+        }
+
+        public void Release(IEnumerable<string> keys)
+        {
+            foreach (var key in keys)
+                KeyEvent(key, false);
+        }
+
+        public IEnumerable<string> SupportedKeys => EtoKeysymToVK.Keys;
+
+        internal static readonly Dictionary<string, VirtualKey> EtoKeysymToVK = new Dictionary<string, VirtualKey>
         {
             { "None", 0x00 },
             { "A", VirtualKey.VK_A },

--- a/OpenTabletDriver.Desktop/Reflection/DesktopPluginManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/DesktopPluginManager.cs
@@ -229,5 +229,18 @@ namespace OpenTabletDriver.Desktop.Reflection
                 return false;
             }
         }
+
+        public override void ResetServices()
+        {
+            base.ResetServices();
+
+            // These services will always be provided on the desktop
+            AddService<IServiceProvider>(() => this);
+            AddService(() => DesktopInterop.Timer);
+            AddService(() => DesktopInterop.AbsolutePointer);
+            AddService(() => DesktopInterop.RelativePointer);
+            AddService(() => DesktopInterop.VirtualScreen);
+            AddService(() => DesktopInterop.VirtualKeyboard);
+        }
     }
 }

--- a/OpenTabletDriver.Desktop/Reflection/DesktopPluginManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/DesktopPluginManager.cs
@@ -65,6 +65,8 @@ namespace OpenTabletDriver.Desktop.Reflection
         {
             foreach (var dir in PluginDirectory.GetDirectories())
                 LoadPlugin(dir);
+
+            AppInfo.PluginManager.ResetServices();
         }
 
         protected void LoadPlugin(DirectoryInfo directory)

--- a/OpenTabletDriver.Desktop/Reflection/PluginSettingStore.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginSettingStore.cs
@@ -115,5 +115,13 @@ namespace OpenTabletDriver.Desktop.Reflection
             set => this[property.Name] = value;
             get => this[property.Name];
         }
+
+        public string GetHumanReadableString()
+        {
+            var name = this.GetPluginReference().Name;
+            string settings = string.Join(", ", this.Settings.Select(s => $"({s.Property}: {s.Value})"));
+
+            return $"{name}: {settings}";
+        }
     }
 }

--- a/OpenTabletDriver.Desktop/Reflection/ServiceManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/ServiceManager.cs
@@ -21,7 +21,7 @@ namespace OpenTabletDriver.Desktop.Reflection
         /// <summary>
         /// Clears all of the added services.
         /// </summary>
-        public void ResetServices()
+        public virtual void ResetServices()
         {
             services.Clear();
         }

--- a/OpenTabletDriver.Plugin/Platform/Keyboard/IVirtualKeyboard.cs
+++ b/OpenTabletDriver.Plugin/Platform/Keyboard/IVirtualKeyboard.cs
@@ -1,8 +1,15 @@
-﻿namespace OpenTabletDriver.Plugin.Platform.Keyboard
+﻿using System.Collections.Generic;
+
+namespace OpenTabletDriver.Plugin.Platform.Keyboard
 {
     public interface IVirtualKeyboard
     {
         void Press(string key);
         void Release(string key);
+
+        void Press(IEnumerable<string> keys);
+        void Release(IEnumerable<string> keys);
+
+        IEnumerable<string> SupportedKeys { get; }
     }
 }

--- a/OpenTabletDriver.Tests/Interop/KeyboardTest.cs
+++ b/OpenTabletDriver.Tests/Interop/KeyboardTest.cs
@@ -1,0 +1,43 @@
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenTabletDriver.Desktop.Interop;
+using OpenTabletDriver.Plugin.Platform.Keyboard;
+
+namespace OpenTabletDriver.Tests.Interop
+{
+    [TestClass]
+    public class KeyboardTest
+    {
+        [TestInitialize]
+        public void Initialize()
+        {
+            Keyboard = DesktopInterop.VirtualKeyboard;
+        }
+
+        public IVirtualKeyboard Keyboard { set; get; }
+
+        [DataTestMethod]
+        [DataRow("Up"), DataRow("Down"), DataRow("Left"), DataRow("Right")]
+        [DataRow("Control"), DataRow("Alt"), DataRow("Application")]
+        public void TestSingleKey(string key)
+        {
+            Keyboard.Press(key);
+            Thread.Sleep(100);
+            Keyboard.Release(key);
+            Thread.Sleep(100);
+        }
+
+        [DataTestMethod]
+        [DataRow("Control+Alt+Up"), DataRow("Control+Alt+Down")]
+        [DataRow("Shift+Up"), DataRow("Shift+Down")]
+        public void TestMultiKey(string keysStr)
+        {
+            var keys = keysStr.Split('+', System.StringSplitOptions.TrimEntries);
+
+            Keyboard.Press(keys);
+            Thread.Sleep(100);
+            Keyboard.Release(keys);
+            Thread.Sleep(100);
+        }
+    }
+}

--- a/OpenTabletDriver.UX/Controls/BindingEditor.cs
+++ b/OpenTabletDriver.UX/Controls/BindingEditor.cs
@@ -151,21 +151,10 @@ namespace OpenTabletDriver.UX.Controls
                 set
                 {
                     this.binding = value;
-                    mainButton.Text = GetFriendlyDisplayString(Binding);
+                    mainButton.Text = Binding?.GetHumanReadableString();
                     BindingUpdated?.Invoke(this, Binding);
                 }
                 get => this.binding;
-            }
-
-            private string GetFriendlyDisplayString(PluginSettingStore store)
-            {
-                if (store == null)
-                    return null;
-
-                var name = store.GetPluginReference().Name;
-                string settings = string.Join(", ", store.Settings.Select(s => $"({s.Property}: {s.Value})"));
-
-                return $"{name}: {settings}";
             }
         }
 

--- a/OpenTabletDriver.UX/Windows/Bindings/BindingEditorDialog.cs
+++ b/OpenTabletDriver.UX/Windows/Bindings/BindingEditorDialog.cs
@@ -122,13 +122,13 @@ namespace OpenTabletDriver.UX.Windows.Bindings
                 if (keys == Keys.None)
                     return;
 
-                if (keys.HasFlag(Keys.Control | Keys.LeftControl) || keys.HasFlag(Keys.Control | Keys.RightControl))
-                    keys &= ~Keys.Control;
                 if (keys.HasFlag(Keys.Alt | Keys.LeftAlt) || keys.HasFlag(Keys.Alt | Keys.RightAlt))
                     keys &= ~Keys.Alt;
-                if (keys.HasFlag(Keys.Shift | Keys.LeftShift) || keys.HasFlag(Keys.Shift | Keys.RightShift))
+                else if (keys.HasFlag(Keys.Control | Keys.LeftControl) || keys.HasFlag(Keys.Control | Keys.RightControl))
+                    keys &= ~Keys.Control;
+                else if (keys.HasFlag(Keys.Shift | Keys.LeftShift) || keys.HasFlag(Keys.Shift | Keys.RightShift))
                     keys &= ~Keys.Shift;
-                if (keys.HasFlag(Keys.Application | Keys.LeftApplication) || keys.HasFlag(Keys.Application | Keys.RightApplication))
+                else if (keys.HasFlag(Keys.Application | Keys.LeftApplication) || keys.HasFlag(Keys.Application | Keys.RightApplication))
                     keys &= ~Keys.Application;
 
                 if ((keys & Keys.ModifierMask) == 0)

--- a/OpenTabletDriver.UX/Windows/Bindings/BindingEditorDialog.cs
+++ b/OpenTabletDriver.UX/Windows/Bindings/BindingEditorDialog.cs
@@ -135,7 +135,6 @@ namespace OpenTabletDriver.UX.Windows.Bindings
                 store[nameof(MouseBinding.Button)].SetValue(ParseMouseButton(e));
                 this.Store = store;
             }
-
         }
     }
 }

--- a/OpenTabletDriver.UX/Windows/Bindings/BindingEditorDialog.cs
+++ b/OpenTabletDriver.UX/Windows/Bindings/BindingEditorDialog.cs
@@ -3,7 +3,6 @@ using Eto.Drawing;
 using Eto.Forms;
 using OpenTabletDriver.Desktop.Binding;
 using OpenTabletDriver.Desktop.Reflection;
-using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Platform.Pointer;
 
 namespace OpenTabletDriver.UX.Windows.Bindings
@@ -13,57 +12,62 @@ namespace OpenTabletDriver.UX.Windows.Bindings
         public BindingEditorDialog(PluginSettingStore currentBinding = null)
         {
             Title = "Binding Editor";
-            Result = currentBinding;
 
-            var inputHandler = new TextArea
+            this.Content = new StackLayout
             {
-                Text = "Press a key or press a mouse button",
-                Width = 300,
-                Height = 150,
-                TextAlignment = TextAlignment.Center,
-                ReadOnly = true
-            };
-            inputHandler.KeyDown += CreateKeyBinding;
-            inputHandler.MouseDown += CreateMouseBinding;
-
-            var clearCommand = new Command { MenuText = "Clear" };
-            clearCommand.Executed += ClearBinding;
-            var clearButton = new Button
-            {
-                Text = "Clear",
-                Command = clearCommand,
-            };
-            clearButton.KeyDown += CreateKeyBinding;
-
-            this.Content = new TableLayout
-            {
-                Rows = 
-                {
-                    inputHandler,
-                    clearButton
-                },
+                HorizontalContentAlignment = HorizontalAlignment.Stretch,
                 Padding = new Padding(5),
-                Spacing = new Size(5, 5)
+                Spacing = 5,
+                Items =
+                {
+                    new StackLayoutItem
+                    {
+                        Expand = true,
+                        Control = bindingController = new BindingController
+                        {
+                            Store = currentBinding,
+                            Width = 300,
+                            Height = 150
+                        }
+                    },
+                    new StackLayout
+                    {
+                        Orientation = Orientation.Horizontal,
+                        Spacing = 5,
+                        Items =
+                        {
+                            new StackLayoutItem
+                            {
+                                Expand = true,
+                                Control = new Button(ClearBinding)
+                                {
+                                    Text = "Clear"
+                                }
+                            },
+                            new StackLayoutItem
+                            {
+                                Expand = true,
+                                Control = new Button(ApplyBinding)
+                                {
+                                    Text = "Apply"
+                                }
+                            }
+                        }
+                    }
+                },
             };
         }
 
-        private void CreateKeyBinding(object sender, KeyEventArgs e)
-        {
-            var store = new PluginSettingStore(typeof(KeyBinding));
-            store[nameof(KeyBinding.Key)].SetValue(e.Key.ToString());
-            Close(store);
-        }
-
-        private void CreateMouseBinding(object sender, MouseEventArgs e)
-        {
-            var store = new PluginSettingStore(typeof(MouseBinding));
-            store[nameof(MouseBinding.Button)].SetValue(ParseMouseButton(e));
-            Close(store);
-        }
+        private BindingController bindingController;
 
         private void ClearBinding(object sender, EventArgs e)
         {
             Close(null);
+        }
+
+        private void ApplyBinding(object sender, EventArgs e)
+        {
+            Close(bindingController.Store);
         }
 
         private static string ParseMouseButton(MouseEventArgs e)
@@ -79,6 +83,59 @@ namespace OpenTabletDriver.UX.Windows.Bindings
                 default:
                     return nameof(MouseButton.None);
             }
+        }
+
+        private class BindingController : TextArea
+        {
+            public BindingController()
+            {
+                TextAlignment = TextAlignment.Center;
+                ReadOnly = true;
+                ToolTip = TOOLTIP;
+                Text = TOOLTIP;
+            }
+
+            private const string TOOLTIP = "Press a key, combination of keys, or a mouse button.";
+
+            private PluginSettingStore store;
+            public PluginSettingStore Store
+            {
+                set
+                {
+                    this.store = value;
+                    Refresh();
+                }
+                get => this.store;
+            }
+
+            public void Refresh()
+            {
+                this.Text = Store?.GetHumanReadableString() ?? TOOLTIP;
+            }
+
+            protected override void OnKeyDown(KeyEventArgs e)
+            {
+                PluginSettingStore store;
+                if (e.Modifiers == 0)
+                {
+                    store = new PluginSettingStore(typeof(KeyBinding));
+                    store[nameof(KeyBinding.Key)].SetValue(e.Key.ToString());   
+                }
+                else
+                {
+                    store = new PluginSettingStore(typeof(MultiKeyBinding));
+                    store[nameof(MultiKeyBinding.Keys)].SetValue(e.KeyData.ToShortcutString());
+                }
+                this.Store = store;
+            }
+
+            protected override void OnMouseDown(MouseEventArgs e)
+            {
+                var store = new PluginSettingStore(typeof(MouseBinding));
+                store[nameof(MouseBinding.Button)].SetValue(ParseMouseButton(e));
+                this.Store = store;
+            }
+
         }
     }
 }


### PR DESCRIPTION
# Changes

- Added `MultiKeyBinding` (Friendly name `Multi-Key Binding`)
  - `Keys` property is a list of keys split by `,` which are all activated together
- `IVirtualKeyboard` changes
  - Added `Press(IEnumerable<string> keys)` and `Release(IEnumerable<string> keys)` for multi-key handling
  - Added `SupportedKeys` property to grab `IEnumerable<string>` of all keys that are supported by the current keyboard handler
- Moved `DesktopInterop` default service addition into the `DesktopPluginManager.ResetServices()` override

https://user-images.githubusercontent.com/39218853/115329842-ea9ca980-a160-11eb-8389-193326b62320.mp4

## Todo

- [x] Platform Testing
  - [x] Windows
  - [x] Linux
  - [ ] MacOS
- [x] Add easy to use UI for creating multi-key bindings

## Relevant issues

- Closes #413