### PR TITLE
Migrate built in binding properties to new properties

### DIFF
--- a/OpenTabletDriver.Desktop/Reflection/PluginSetting.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginSetting.cs
@@ -30,7 +30,7 @@ namespace OpenTabletDriver.Desktop.Reflection
         }
 
         [JsonProperty]
-        public string Property { protected set; get; }
+        public string Property { set; get; }
 
         [JsonProperty]
         public JToken Value { set; get; }


### PR DESCRIPTION
## Changes

- Add support for migrating certain property values to a new property.
- Migrate `KeyBinding` and `MouseBinding` from `Property` to the new equivalent property.