### PR TITLE
Catch binding validation exceptions

### DIFF
--- a/OpenTabletDriver.Plugin/Attributes/PropertyValidatedAttribute.cs
+++ b/OpenTabletDriver.Plugin/Attributes/PropertyValidatedAttribute.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace OpenTabletDriver.Plugin.Attributes
 {
@@ -24,13 +25,33 @@ namespace OpenTabletDriver.Plugin.Attributes
         {
             var sourceType = property.ReflectedType;
             var member = sourceType.GetMember(MemberName).First();
-            return member.MemberType switch
+            try
             {
-                MemberTypes.Property => (T)sourceType.GetProperty(MemberName).GetValue(null),
-                MemberTypes.Field => (T)sourceType.GetField(MemberName).GetValue(null),
-                MemberTypes.Method => (T)sourceType.GetMethod(MemberName).Invoke(null, null),
-                _ => default(T)
-            };
+                return member.MemberType switch
+                {
+                    MemberTypes.Property => (T)sourceType.GetProperty(MemberName).GetValue(null),
+                    MemberTypes.Field => (T)sourceType.GetField(MemberName).GetValue(null),
+                    MemberTypes.Method => (T)sourceType.GetMethod(MemberName).Invoke(null, null),
+                    _ => default
+                };
+            }
+            catch (Exception e)
+            {
+                Log.Write("Plugin", $"Failed to get valid binding values for '{MemberName}'", LogLevel.Error);
+
+                var match = Regex.Match(e.Message, "Non-static (.*) requires a target\\.");
+
+                if (e is TargetException && match.Success)
+                {
+                    Log.Debug("Plugin", $"Validation {match.Groups[1].Value} must be static");
+                }
+                else
+                {
+                    Log.Exception(e);
+                }
+            }
+
+            return default;
         }
     }
 }


### PR DESCRIPTION
## Changes

- Fixes crashes encountered during retrieval of binding validation.
- Adds a log entry specific to plugin developers forgetting to use static validator.