### PR TITLE
Improve object construction log

### DIFF
--- a/OpenTabletDriver.Desktop/Reflection/PluginManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginManager.cs
@@ -85,10 +85,18 @@ namespace OpenTabletDriver.Desktop.Reflection
                         }
                     }
                 }
-                catch
+                catch (TargetInvocationException e) when (e.Message == "Exception has been thrown by the target of an invocation.")
+                {
+                    Log.Write("Plugin", "Object construction has thrown an error", LogLevel.Error);
+                    Log.Exception(e.InnerException);
+                }
+                catch (Exception e)
                 {
                     Log.Write("Plugin", $"Unable to construct object '{name}'", LogLevel.Error);
+                    Log.Exception(e);
                 }
+
+                return null;
             }
             Log.Write("Plugin", $"No constructor found for '{name}'", LogLevel.Debug);
             return null;

--- a/OpenTabletDriver.Desktop/Reflection/PluginManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginManager.cs
@@ -80,8 +80,11 @@ namespace OpenTabletDriver.Desktop.Reflection
                                         field.SetValue(obj, service);
                                 }
                             }
-
                             return obj;
+                        }
+                        else
+                        {
+                            Log.Write("Plugin", $"No constructor found for '{name}'", LogLevel.Error);
                         }
                     }
                 }
@@ -95,10 +98,7 @@ namespace OpenTabletDriver.Desktop.Reflection
                     Log.Write("Plugin", $"Unable to construct object '{name}'", LogLevel.Error);
                     Log.Exception(e);
                 }
-
-                return null;
             }
-            Log.Write("Plugin", $"No constructor found for '{name}'", LogLevel.Debug);
             return null;
         }
 


### PR DESCRIPTION
## Changes

- Log the cause of construction failure when available, else log the whole exception.
- Fix "No constructor found" log. (is previously called even if a constructor is found)