### PR TITLE
Ignore OpenTabletDriver.Plugin.dll when loading plugins

### DIFF
--- a/OpenTabletDriver.Desktop/Reflection/DesktopPluginContext.cs
+++ b/OpenTabletDriver.Desktop/Reflection/DesktopPluginContext.cs
@@ -16,7 +16,14 @@ namespace OpenTabletDriver.Desktop.Reflection
             FriendlyName = Directory.Name;
 
             foreach (var plugin in Directory.EnumerateFiles("*.dll"))
+            {
+                // Ignore a plugin library build artifact
+                // Loading it seems to stop loading any further DLLs from the directory
+                if (string.Equals(plugin.Name, "OpenTabletDriver.Plugin.dll", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
                 LoadAssemblyFromFile(plugin);
+            }
         }
 
         public DirectoryInfo Directory { get; }


### PR DESCRIPTION
Loading `OpenTabletDriver.Plugin.dll` inexplicably breaks further plugin loading (at least for the current folder), so by ignoring that we (hopefully) solve the issue where plugins state they've been loaded while they actually don't work (e.g. missing from Filter list).
