### PR TITLE
Binding editor controls cleanup

### DIFF
--- a/OpenTabletDriver.UX/Controls/BindingDisplay.cs
+++ b/OpenTabletDriver.UX/Controls/BindingDisplay.cs
@@ -1,0 +1,78 @@
+using System;
+using Eto.Forms;
+using OpenTabletDriver.Desktop.Reflection;
+using OpenTabletDriver.UX.Windows.Bindings;
+
+namespace OpenTabletDriver.UX.Controls
+{
+    public class BindingDisplay : Panel
+    {
+        public BindingDisplay()
+        {
+            this.Content = new StackLayout
+            {
+                Spacing = 5,
+                Orientation = Orientation.Horizontal,
+                Items =
+                {
+                    new StackLayoutItem
+                    {
+                        Expand = true,
+                        Control = mainButton = new Button()
+                    },
+                    new StackLayoutItem
+                    {
+                        Control = advancedButton = new Button
+                        {
+                            Text = "...",
+                            Width = 25
+                        }
+                    }
+                }
+            };
+
+            mainButton.TextBinding.Bind(this.StoreBinding.Convert<string>(s => s?.GetHumanReadableString()));
+
+            mainButton.Click += async (sender, e) =>
+            {
+                var dialog = new BindingEditorDialog(Store);
+                this.Store = await dialog.ShowModalAsync(this);
+            };
+
+            advancedButton.Click += async (sender, e) =>
+            {
+                var dialog = new AdvancedBindingEditorDialog(Store);
+                this.Store = await dialog.ShowModalAsync(this);
+            };
+        }
+
+        private Button mainButton, advancedButton;
+
+        public event EventHandler<EventArgs> StoreChanged;
+
+        private PluginSettingStore store;
+        public PluginSettingStore Store
+        {
+            set
+            {
+                this.store = value;
+                StoreChanged?.Invoke(this, new EventArgs());
+            }
+            get => this.store;
+        }
+
+        public BindableBinding<BindingDisplay, PluginSettingStore> StoreBinding
+        {
+            get
+            {
+                return new BindableBinding<BindingDisplay, PluginSettingStore>(
+                    this,
+                    c => c.Store,
+                    (c, v) => c.Store = v,
+                    (c, h) => c.StoreChanged += h,
+                    (c, h) => c.StoreChanged -= h
+                );
+            }
+        }
+    }
+}

--- a/OpenTabletDriver.UX/Controls/Generic/FloatSlider.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/FloatSlider.cs
@@ -1,0 +1,76 @@
+using System;
+using System.ComponentModel;
+using Eto.Forms;
+using OpenTabletDriver.UX.Controls.Generic;
+using OpenTabletDriver.UX.Controls.Generic.Text;
+
+namespace OpenTabletDriver.UX.Controls
+{
+    /// <summary>
+    /// A slider with a textbox for fine tuning a floating point value.
+    /// </summary>
+    public class FloatSlider : Panel
+    {
+        public FloatSlider()
+        {
+            var slider = new Slider
+            {
+                MinValue = Minimum,
+                MaxValue = Maximum
+            };
+
+            var nb = new FloatNumberBox();
+
+            slider.Bind(
+                s => s.Value,
+                nb.ValueBinding
+            );
+
+            nb.ValueBinding.Bind(this.ValueBinding);
+
+            this.Content = new StackView
+            {
+                Orientation = Orientation.Horizontal,
+                VerticalContentAlignment = VerticalAlignment.Center,
+                Items =
+                {
+                    new StackLayoutItem(slider, true),
+                    new StackLayoutItem(nb, false)
+                }
+            };
+        }
+
+        public event EventHandler<EventArgs> ValueChanged;
+
+        private float value;
+        public float Value
+        {
+            set
+            {
+                this.value = value;
+                ValueChanged?.Invoke(this, new EventArgs());
+            }
+            get => this.value;
+        }
+
+        [DefaultValue(0)]
+        public int Minimum { set; get; } = 0;
+
+        [DefaultValue(100)]
+        public int Maximum { set; get; } = 100;
+
+        public BindableBinding<FloatSlider, float> ValueBinding
+        {
+            get
+            {
+                return new BindableBinding<FloatSlider, float>(
+                    this,
+                    c => c.Value,
+                    (c, v) => c.Value = v,
+                    (c, h) => c.ValueChanged += h,
+                    (c, h) => c.ValueChanged -= h
+                );
+            }
+        }
+    }
+}

--- a/OpenTabletDriver.UX/Windows/Bindings/BindingEditorDialog.cs
+++ b/OpenTabletDriver.UX/Windows/Bindings/BindingEditorDialog.cs
@@ -13,6 +13,7 @@ namespace OpenTabletDriver.UX.Windows.Bindings
         public BindingEditorDialog(PluginSettingStore currentBinding = null)
         {
             Title = "Binding Editor";
+            Result = currentBinding;
 
             this.Content = new StackLayout
             {

--- a/OpenTabletDriver.UX/Windows/Greeter/Pages/BindingPage.cs
+++ b/OpenTabletDriver.UX/Windows/Greeter/Pages/BindingPage.cs
@@ -1,6 +1,5 @@
 using Eto.Drawing;
 using Eto.Forms;
-using OpenTabletDriver.Desktop.Reflection;
 using OpenTabletDriver.UX.Attributes;
 using OpenTabletDriver.UX.Controls;
 using OpenTabletDriver.UX.Controls.Generic;
@@ -60,12 +59,11 @@ namespace OpenTabletDriver.UX.Windows.Greeter.Pages
             };
         }
 
-        private class DemoBindingDisplay : BindingEditor.BindingDisplay
+        private class DemoBindingDisplay : BindingDisplay
         {
             public DemoBindingDisplay()
-                : base(PluginSettingStore.FromPath(typeof(OpenTabletDriver.Plugin.IBinding).FullName))
             {
-                Width = 256;
+                Width = 512;
             }
         }
     }


### PR DESCRIPTION
# Changes
- Reworked `PressureSlider` -> `FloatSlider` universal control
  - This can now be used outside of the binding editor
- Reworked `BindingDisplay`
  - Accessible outside of the binding editor as well, used in the guide `BindingPage`