### PR TITLE
Fix area lock when a display is on a negative coordinate

### DIFF
--- a/OpenTabletDriver.UX/Controls/Area/AreaDisplay.cs
+++ b/OpenTabletDriver.UX/Controls/Area/AreaDisplay.cs
@@ -117,6 +117,9 @@ namespace OpenTabletDriver.UX.Controls.Area
                     if (ViewModel.LockToUsableArea)
                     {
                         var bounds = ViewModel.FullBackground;
+                        bounds.X = 0;
+                        bounds.Y = 0;
+
                         var rect = RectangleF.FromCenter(PointF.Empty, new SizeF(ViewModel.Width, ViewModel.Height));
 
                         var corners = new PointF[]


### PR DESCRIPTION
## Changes

- Push bounds rectangle to (0, 0).

Fixes #945