### PR TITLE
Load MenuBar on daemon connection

### DIFF
--- a/OpenTabletDriver.Desktop/RPC/RpcClient.cs
+++ b/OpenTabletDriver.Desktop/RPC/RpcClient.cs
@@ -12,6 +12,7 @@ namespace OpenTabletDriver.Desktop.RPC
         private JsonRpc rpc;
 
         public T Instance { private set; get; }
+        public event EventHandler Connected;
         public event EventHandler Disconnected;
 
         public RpcClient(string pipeName)
@@ -34,6 +35,7 @@ namespace OpenTabletDriver.Desktop.RPC
                 Disconnected?.Invoke(this, null);
                 rpc.Dispose();
             };
+            Connected?.Invoke(this, null);
         }
 
         private NamedPipeClientStream GetStream()

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -30,7 +30,7 @@ namespace OpenTabletDriver.UX
 
             Driver.Connected += (_, _) =>
             {
-                Menu = ConstructMenu();
+                Application.Instance.AsyncInvoke(() => Menu = ConstructMenu());
             };
 
             Driver.Disconnected += (_, _) =>

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -29,6 +29,11 @@ namespace OpenTabletDriver.UX
             Content = ConstructPlaceholderControl();
             Menu = ConstructMenu();
 
+            Driver.Connected += (_, _) =>
+            {
+                Menu = ConstructMenu();
+            };
+
             Driver.Disconnected += (_, _) =>
             {
                 Application.Instance.AsyncInvoke(async () =>

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -27,7 +27,6 @@ namespace OpenTabletDriver.UX
             UpdateTitle(null);
             ClientSize = new Size(DEFAULT_CLIENT_WIDTH, DEFAULT_CLIENT_HEIGHT);
             Content = ConstructPlaceholderControl();
-            Menu = ConstructMenu();
 
             Driver.Connected += (_, _) =>
             {


### PR DESCRIPTION
# Changes
The menu bar now only loads when the daemon has connected, preventing the user from performing actions that require the daemon connected