### PR TITLE
Fix lock aspect ratio behaviour when display area changes size

### DIFF
--- a/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
@@ -74,6 +74,8 @@ namespace OpenTabletDriver.UX.Controls.Output
         internal TabletAreaEditor tabletAreaEditor;
 
         private bool handlingArLock;
+        private float? prevDisplayWidth;
+        private float? prevDisplayHeight;
         private DirectBinding<float> displayWidth;
         private DirectBinding<float> displayHeight;
         private DirectBinding<float> tabletWidth;
@@ -115,10 +117,13 @@ namespace OpenTabletDriver.UX.Controls.Output
                 // Avoids looping
                 handlingArLock = true;
 
-                if (sender == displayWidth || sender == tabletWidth)
-                    tabletHeight.DataValue = displayHeight.DataValue / displayWidth.DataValue * tabletWidth.DataValue;
-                if (sender == displayHeight || sender == tabletHeight)
-                    tabletWidth.DataValue = displayWidth.DataValue / displayHeight.DataValue * tabletHeight.DataValue;
+                if ((sender == displayWidth || sender == tabletWidth) && prevDisplayWidth is float prevWidth)
+                    tabletWidth.DataValue *= displayWidth.DataValue / prevWidth;
+                else if ((sender == displayHeight || sender == tabletHeight) && prevDisplayHeight is float prevHeight)
+                    tabletHeight.DataValue *= displayHeight.DataValue / prevHeight;
+
+                prevDisplayWidth = displayWidth.DataValue;
+                prevDisplayHeight = displayHeight.DataValue;
 
                 handlingArLock = false;
             }


### PR DESCRIPTION
## Test

1. Enable Lock Aspect Ratio (required for Pre-PR to trigger the bug)
2. Change display area to quarter area (manual editing or changing mapped monitor of different resolution also triggers the bug)

### Pre-PR

The tablet area becomes twice bigger.

### Post-PR

Tablet area resizes to a quarter of its original size, correctly reflecting the changes that happened on display area.

> Salvaged from #779