### PR TITLE
Fix linking issues

### DIFF
--- a/OpenTabletDriver.Plugin/Output/OutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/OutputMode.cs
@@ -74,7 +74,7 @@ namespace OpenTabletDriver.Plugin.Output
                         entryElement = this;
 
                         // Link TransformElement to PostTransformElements
-                        this.Emit += PostTransformElements.Last().Consume;
+                        LinkElement(this, PostTransformElements.Last());
 
                         // Hook PostTransformElements to output
                         PostTransformElements.Last().Emit += this.OnOutput;
@@ -84,10 +84,10 @@ namespace OpenTabletDriver.Plugin.Output
                         entryElement = PreTransformElements.First();
 
                         // Link PreTransformElements to TransformElement
-                        PreTransformElements.Last().Emit += this.Consume;
+                        LinkElement(PreTransformElements.Last(), this);
 
                         // Link TransformElement to PostTransformElements
-                        this.Emit += PostTransformElements.First().Consume;
+                        LinkElement(this, PostTransformElements.First());
 
                         // Link PostTransformElements to output
                         PostTransformElements.Last().Emit += this.OnOutput;

--- a/OpenTabletDriver.Plugin/Output/OutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/OutputMode.cs
@@ -24,24 +24,25 @@ namespace OpenTabletDriver.Plugin.Output
         {
             private set
             {
+                Action<IDeviceReport> output = this.OnOutput;
                 if (value && !passthrough)
                 {
                     this.entryElement = this;
-                    this.Emit += this.OnOutput;
+                    Link(this, output);
                     this.passthrough = true;
                 }
                 else if (!value && passthrough)
                 {
                     this.entryElement = null;
-                    this.Emit -= this.OnOutput;
+                    Unlink(this, output);
                     this.passthrough = false;
                 }
             }
             get => this.passthrough;
         }
 
-        protected IList<IPositionedPipelineElement<IDeviceReport>> PreTransformElements { private set; get; }
-        protected IList<IPositionedPipelineElement<IDeviceReport>> PostTransformElements { private set; get; }
+        protected IList<IPositionedPipelineElement<IDeviceReport>> PreTransformElements { private set; get; } = Array.Empty<IPositionedPipelineElement<IDeviceReport>>();
+        protected IList<IPositionedPipelineElement<IDeviceReport>> PostTransformElements { private set; get; } = Array.Empty<IPositionedPipelineElement<IDeviceReport>>();
 
         public Matrix3x2 TransformationMatrix { protected set; get; }
 
@@ -51,51 +52,43 @@ namespace OpenTabletDriver.Plugin.Output
             {
                 this.elements = value;
 
+                Passthrough = false;
+                DestroyInternalLinks();
+
                 if (Elements != null && Elements.Count > 0)
                 {
-                    Passthrough = false;
                     PreTransformElements = GroupElements(Elements, PipelinePosition.PreTransform);
                     PostTransformElements = GroupElements(Elements, PipelinePosition.PostTransform);
-                    LinkElements(PreTransformElements);
-                    LinkElements(PostTransformElements);
+
+                    Action<IDeviceReport> output = this.OnOutput;
 
                     if (PreTransformElements.Any() && !PostTransformElements.Any())
                     {
                         entryElement = PreTransformElements.First();
 
-                        // Link PreTransformElements to TransformElement
-                        LinkElement(PreTransformElements.Last(), this);
-
-                        // Link TransformElement to output
-                        this.Emit += this.OnOutput;
+                        // PreTransform --> Transform --> Output
+                        LinkAll(PreTransformElements, this, output);
                     }
                     else if (PostTransformElements.Any() && !PreTransformElements.Any())
                     {
                         entryElement = this;
 
-                        // Link TransformElement to PostTransformElements
-                        LinkElement(this, PostTransformElements.Last());
-
-                        // Hook PostTransformElements to output
-                        PostTransformElements.Last().Emit += this.OnOutput;
+                        // Transform --> PostTransform --> Output
+                        LinkAll(this, PostTransformElements, output);
                     }
                     else if (PreTransformElements.Any() && PostTransformElements.Any())
                     {
                         entryElement = PreTransformElements.First();
 
-                        // Link PreTransformElements to TransformElement
-                        LinkElement(PreTransformElements.Last(), this);
-
-                        // Link TransformElement to PostTransformElements
-                        LinkElement(this, PostTransformElements.First());
-
-                        // Link PostTransformElements to output
-                        PostTransformElements.Last().Emit += this.OnOutput;
+                        // PreTransform --> Transform --> PostTransform --> Output
+                        LinkAll(PreTransformElements, this, PostTransformElements, output);
                     }
                 }
                 else
                 {
                     Passthrough = true;
+                    PreTransformElements = Array.Empty<IPositionedPipelineElement<IDeviceReport>>();
+                    PostTransformElements = Array.Empty<IPositionedPipelineElement<IDeviceReport>>();
                 }
             }
             get => this.elements;
@@ -127,5 +120,23 @@ namespace OpenTabletDriver.Plugin.Output
         protected abstract Matrix3x2 CreateTransformationMatrix();
         protected abstract ITabletReport Transform(ITabletReport tabletReport);
         protected abstract void OnOutput(IDeviceReport report);
+
+        private void DestroyInternalLinks()
+        {
+            Action<IDeviceReport> output = this.OnOutput;
+
+            if (PreTransformElements.Any() && !PostTransformElements.Any())
+            {
+                UnlinkAll(PreTransformElements, this, output);
+            }
+            else if (PostTransformElements.Any() && !PreTransformElements.Any())
+            {
+                UnlinkAll(this, PostTransformElements, output);
+            }
+            else if (PreTransformElements.Any() && PostTransformElements.Any())
+            {
+                UnlinkAll(PreTransformElements, this, PostTransformElements, output);
+            }
+        }
     }
 }

--- a/OpenTabletDriver.Plugin/Output/PipelineManager.cs
+++ b/OpenTabletDriver.Plugin/Output/PipelineManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -5,16 +6,42 @@ namespace OpenTabletDriver.Plugin.Output
 {
     public class PipelineManager<T>
     {
-        protected void LinkElement(IPipelineElement<T> source, IPipelineElement<T> destination)
+        protected void Link<T2>(IPipelineElement<T> source, T2 destination)
         {
             if (source != null && destination != null)
-                source.Emit += destination.Consume;
+            {
+                switch (destination)
+                {
+                    case IPipelineElement<T> nextElement:
+                        source.Emit += nextElement.Consume;
+                        break;
+                    case IEnumerable<IPipelineElement<T>> nextGroup:
+                        source.Emit += nextGroup.First().Consume;
+                        break;
+                    case Action<T> nextAction:
+                        source.Emit += nextAction;
+                        break;
+                }
+            }
         }
 
-        protected void UnlinkElement(IPipelineElement<T> source, IPipelineElement<T> destination)
+        protected void Unlink<T2>(IPipelineElement<T> source, T2 destination)
         {
             if (source != null && destination != null)
-                source.Emit -= destination.Consume;
+            {
+                switch (destination)
+                {
+                    case IPipelineElement<T> nextElement:
+                        source.Emit -= nextElement.Consume;
+                        break;
+                    case IEnumerable<IPipelineElement<T>> nextGroup:
+                        source.Emit -= nextGroup.First().Consume;
+                        break;
+                    case Action<T> nextAction:
+                        source.Emit -= nextAction;
+                        break;
+                }
+            }
         }
 
         protected void LinkElements(IEnumerable<IPipelineElement<T>> elements)
@@ -24,7 +51,7 @@ namespace OpenTabletDriver.Plugin.Output
                 IPipelineElement<T> prevElement = null;
                 foreach (var element in elements)
                 {
-                    LinkElement(prevElement, element);
+                    Link(prevElement, element);
                     prevElement = element;
                 }
             }
@@ -37,15 +64,47 @@ namespace OpenTabletDriver.Plugin.Output
                 IPipelineElement<T> prevElement = null;
                 foreach (var element in elements)
                 {
-                    UnlinkElement(prevElement, element);
+                    Unlink(prevElement, element);
                     prevElement = element;
+                }
+            }
+        }
+
+        protected void LinkAll(params object[] elements)
+        {
+            foreach ((var prev, var next) in elements.Zip(elements.Skip(1)))
+            {
+                if (prev is IPipelineElement<T> prevElement)
+                {
+                    Link(prevElement, next);
+                }
+                else if (prev is IEnumerable<IPipelineElement<T>> prevGroup)
+                {
+                    LinkElements(prevGroup);
+                    Link(prevGroup.Last(), next);
+                }
+            }
+        }
+
+        protected void UnlinkAll(params object[] elements)
+        {
+            foreach ((var prev, var next) in elements.Zip(elements.Skip(1)))
+            {
+                if (prev is IPipelineElement<T> prevElement)
+                {
+                    Unlink(prevElement, next);
+                }
+                else if (prev is IEnumerable<IPipelineElement<T>> prevGroup)
+                {
+                    UnlinkElements(prevGroup);
+                    Unlink(prevGroup.Last(), next);
                 }
             }
         }
 
         protected IList<IPositionedPipelineElement<T>> GroupElements(IList<IPositionedPipelineElement<T>> elements, PipelinePosition position)
         {
-            return elements.Where(e => e.Position == position)?.ToArray();
+            return elements.Where(e => e.Position == position)?.ToArray() ?? Array.Empty<IPositionedPipelineElement<T>>();
         }
     }
 }


### PR DESCRIPTION
## Changes

- Fix `PostTransform` only using the last element of its group.
- Provide `LinkAll` function to link all parameters and the reverse in `UnlinkAll`.
- Unlink existing elements. Fixes event handler leaks on `this`.
- Fix possible null reference on `PreTransformElements` and `PostTransformElements`.

### Tested by

- [Kuuube](https://discord.com/channels/615607687467761684/628651971267788800/838096546964570142)