### PR TITLE
Apply optimization to core report parsers

### DIFF
--- a/OpenTabletDriver/Tablet/AuxReport.cs
+++ b/OpenTabletDriver/Tablet/AuxReport.cs
@@ -7,12 +7,14 @@ namespace OpenTabletDriver.Tablet
         public AuxReport(byte[] report)
         {
             Raw = report;
+
+            var auxByte = report[3];
             AuxButtons = new bool[]
             {
-                (report[3] & (1 << 0)) != 0,
-                (report[3] & (1 << 1)) != 0,
-                (report[3] & (1 << 2)) != 0,
-                (report[3] & (1 << 3)) != 0
+                auxByte.IsBitSet(0),
+                auxByte.IsBitSet(1),
+                auxByte.IsBitSet(2),
+                auxByte.IsBitSet(3)
             };
         }
 

--- a/OpenTabletDriver/Tablet/ByteExtensions.cs
+++ b/OpenTabletDriver/Tablet/ByteExtensions.cs
@@ -1,0 +1,10 @@
+namespace OpenTabletDriver.Tablet
+{
+    public static class ByteExtensions
+    {
+        public static bool IsBitSet(this byte a, int bit)
+        {
+            return (a & (1 << bit)) != 0;
+        }
+    }
+}

--- a/OpenTabletDriver/Tablet/TabletReport.cs
+++ b/OpenTabletDriver/Tablet/TabletReport.cs
@@ -1,5 +1,5 @@
-using System;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Tablet
@@ -13,14 +13,16 @@ namespace OpenTabletDriver.Tablet
             ReportID = (uint)report[1] >> 1;
             Position = new Vector2
             {
-                X = BitConverter.ToUInt16(report, 2),
-                Y = BitConverter.ToUInt16(report, 4)
+                X = Unsafe.ReadUnaligned<ushort>(ref report[2]),
+                Y = Unsafe.ReadUnaligned<ushort>(ref report[4])
             };
-            Pressure = BitConverter.ToUInt16(report, 6);
+            Pressure = Unsafe.ReadUnaligned<ushort>(ref report[6]);
+
+            var penByte = report[1];
             PenButtons = new bool[]
             {
-                (report[1] & (1 << 1)) != 0,
-                (report[1] & (1 << 2)) != 0
+                penByte.IsBitSet(1),
+                penByte.IsBitSet(2)
             };
         }
 

--- a/OpenTabletDriver/Tablet/TiltTabletReport.cs
+++ b/OpenTabletDriver/Tablet/TiltTabletReport.cs
@@ -1,5 +1,5 @@
-using System;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Tablet
@@ -13,19 +13,21 @@ namespace OpenTabletDriver.Tablet
             ReportID = (uint)report[1] >> 1;
             Position = new Vector2
             {
-                X = BitConverter.ToUInt16(report, 2),
-                Y = BitConverter.ToUInt16(report, 4)
+                X = Unsafe.ReadUnaligned<ushort>(ref report[2]),
+                Y = Unsafe.ReadUnaligned<ushort>(ref report[4])
             };
             Tilt = new Vector2
             {
                 X = (sbyte)report[10],
                 Y = (sbyte)report[11]
             };
-            Pressure = BitConverter.ToUInt16(report, 6);
+            Pressure = Unsafe.ReadUnaligned<ushort>(ref report[6]);
+
+            var penByte = report[1];
             PenButtons = new bool[]
             {
-                (report[1] & (1 << 1)) != 0,
-                (report[1] & (1 << 2)) != 0
+                penByte.IsBitSet(1),
+                penByte.IsBitSet(2)
             };
         }
 


### PR DESCRIPTION
## Changes

- Use Unsafe.ReadUnaligned instead of BitConverter
- Add ByteExtensions.IsBitSet (generates the same asm code as `BitVector32`, as long as we cache the byte first)