### PR TITLE
Fix IntuosV3 reportID for PTH-x60

### DIFF
--- a/OpenTabletDriver/Vendors/Wacom/IntuosV3Report.cs
+++ b/OpenTabletDriver/Vendors/Wacom/IntuosV3Report.cs
@@ -23,8 +23,14 @@ namespace OpenTabletDriver.Vendors.Wacom
                 HoverDistance = 0;
                 return;
             }
-
-            ReportID = report[0];
+            if (report[1] == 0)
+            {
+                ReportID = 0;
+            }
+            else
+            {
+                ReportID = report[0];
+            }
             Position = new Vector2
             {
                 X = (report[2] | (report[3] << 8) | (report[4] << 16)),

--- a/OpenTabletDriver/Vendors/Wacom/IntuosV3Report.cs
+++ b/OpenTabletDriver/Vendors/Wacom/IntuosV3Report.cs
@@ -23,7 +23,7 @@ namespace OpenTabletDriver.Vendors.Wacom
                 HoverDistance = 0;
                 return;
             }
-            ReportID = report[1] != 0 ? report[0] : 0;
+            ReportID = report[1] != 0 ? report[0] : 0u;
             Position = new Vector2
             {
                 X = (report[2] | (report[3] << 8) | (report[4] << 16)),

--- a/OpenTabletDriver/Vendors/Wacom/IntuosV3Report.cs
+++ b/OpenTabletDriver/Vendors/Wacom/IntuosV3Report.cs
@@ -23,14 +23,7 @@ namespace OpenTabletDriver.Vendors.Wacom
                 HoverDistance = 0;
                 return;
             }
-            if (report[1] == 0)
-            {
-                ReportID = 0;
-            }
-            else
-            {
-                ReportID = report[0];
-            }
+            ReportID = report[1] != 0 ? report[0] : 0;
             Position = new Vector2
             {
                 X = (report[2] | (report[3] << 8) | (report[4] << 16)),


### PR DESCRIPTION
PTH-x60 sends `00` on byte 2 when going far to the side of the tablet where it also sends a bogus position report. I've set the reportID to 0 when byte 2 is `00`. Otherwise reportID will use byte 1 as usual.

Tested on PTH-460 and CTL-4100. Causes no conflict with CTL-4100.