### PR TITLE
Fix eraser status report for wacom bamboo

### DIFF
--- a/OpenTabletDriver/Configurations/Wacom/CTH-470.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTH-470.json
@@ -17,7 +17,7 @@
       "ProductID": 222,
       "InputReportLength": 10,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Tablet.TabletReportParser",
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.BambooCaptureReportParser",
       "FeatureInitReport": "AgI=",
       "OutputInitReport": null,
       "DeviceStrings": {},

--- a/OpenTabletDriver/Vendors/Wacom/BambooCaptureReport.cs
+++ b/OpenTabletDriver/Vendors/Wacom/BambooCaptureReport.cs
@@ -4,9 +4,9 @@ using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Vendors.Wacom
 {
-    public struct BambooReport : ITabletReport, IAuxReport, IEraserReport
+    public struct BambooCaptureReport : ITabletReport, IAuxReport, IEraserReport
     {
-        public BambooReport(byte[] report)
+        public BambooCaptureReport(byte[] report)
         {
             Raw = report;
 

--- a/OpenTabletDriver/Vendors/Wacom/BambooCaptureReport.cs
+++ b/OpenTabletDriver/Vendors/Wacom/BambooCaptureReport.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Numerics;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Vendors.Wacom
+{
+    public struct BambooReport : ITabletReport, IAuxReport, IEraserReport
+    {
+        public BambooReport(byte[] report)
+        {
+            Raw = report;
+
+            ReportID = (uint)report[1] >> 1;
+            Position = new Vector2
+            {
+                X = BitConverter.ToUInt16(report, 2),
+                Y = BitConverter.ToUInt16(report, 4)
+            };
+            Pressure = (uint)(report[6] | ((report[7] & 0x01) << 8));
+            Eraser = (report[1] & (1 << 3)) != 0;
+
+            PenButtons = new bool[]
+            {
+                (report[1] & (1 << 1)) != 0,
+                (report[1] & (1 << 2)) != 0
+            };
+            AuxButtons = new bool[]
+            {
+                (report[7] & (1 << 3)) != 0,
+                (report[7] & (1 << 4)) != 0,
+                (report[7] & (1 << 5)) != 0,
+                (report[7] & (1 << 6)) != 0
+            };
+        }
+
+        public byte[] Raw { set; get; }
+        public uint ReportID { set; get; }
+        public Vector2 Position { set; get; }
+        public uint Pressure { set; get; }
+        public bool[] PenButtons { set; get; }
+        public bool[] AuxButtons { set; get; }
+        public bool Eraser { set; get; }
+    }
+}

--- a/OpenTabletDriver/Vendors/Wacom/BambooCaptureReportParser.cs
+++ b/OpenTabletDriver/Vendors/Wacom/BambooCaptureReportParser.cs
@@ -1,0 +1,12 @@
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Vendors.Wacom
+{
+    public class BambooCaptureReportParser : IReportParser<IDeviceReport>
+    {
+        public IDeviceReport Parse(byte[] report)
+        {
+            return new BambooCaptureReport(report);
+        }
+    }
+}

--- a/OpenTabletDriver/Vendors/Wacom/BambooReport.cs
+++ b/OpenTabletDriver/Vendors/Wacom/BambooReport.cs
@@ -17,7 +17,7 @@ namespace OpenTabletDriver.Vendors.Wacom
                 Y = BitConverter.ToUInt16(report, 4)
             };
             Pressure = (uint)(report[6] | ((report[7] & 0x01) << 8));
-            Eraser = (report[1] & (1 << 3)) != 0;
+            Eraser = (report[1] & (1 << 5)) != 0;
 
             PenButtons = new bool[]
             {

--- a/OpenTabletDriver/Vendors/Wacom/BambooReport.cs
+++ b/OpenTabletDriver/Vendors/Wacom/BambooReport.cs
@@ -17,7 +17,7 @@ namespace OpenTabletDriver.Vendors.Wacom
                 Y = BitConverter.ToUInt16(report, 4)
             };
             Pressure = (uint)(report[6] | ((report[7] & 0x01) << 8));
-            Eraser = (report[1] & (1 << 5)) != 0;
+            Eraser = (report[1] & (1 << 3)) != 0;
 
             PenButtons = new bool[]
             {


### PR DESCRIPTION
On the wacoom CTH-470 the eraser status was always true even when using the tip.
Credits to @X9VoiD for the solution.