### PR TITLE
Fix Wacom CTL-671 size in config

### DIFF
--- a/OpenTabletDriver/Configurations/Wacom/CTL-671.json
+++ b/OpenTabletDriver/Configurations/Wacom/CTL-671.json
@@ -2,10 +2,10 @@
   "Name": "Wacom CTL-671",
   "Specifications": {
     "Digitizer": {
-      "Width": 216.48,
-      "Height": 153.3,
-      "MaxX": 21648.0,
-      "MaxY": 15330.0
+      "Width": 216.0,
+      "Height": 135.0,
+      "MaxX": 21600.0,
+      "MaxY": 13500.0
     },
     "Pen": {
       "MaxPressure": 1023,


### PR DESCRIPTION
Verification:
[discord](https://discord.com/channels/615607687467761684/787072060563128321/839213121146716180)
[also supported by input-wacom](https://github.com/linuxwacom/input-wacom/blob/74f6fd70f2584f0548303583ef8713e53d3314a5/4.5/wacom_wac.c#L4723)