### PR TITLE
Bump Eto.Platform.Gtk to 2.5.11

### DIFF
--- a/OpenTabletDriver.UX.Gtk/OpenTabletDriver.UX.Gtk.csproj
+++ b/OpenTabletDriver.UX.Gtk/OpenTabletDriver.UX.Gtk.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="NuGet Packages">
-    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.10" />
+    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.11" />
   </ItemGroup>
 
   <ItemGroup Label="Project References">


### PR DESCRIPTION
This fixes GUI not working with glib >= 2.68

Fixes #896 

This may break packaging for maintainers that have already implemented workarounds (AUR maintainer: @LavaDesu, others?)