### PR TITLE
Fix PTH-451 Config's Parser

### DIFF
--- a/OpenTabletDriver/Configurations/Wacom/PTH-451.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTH-451.json
@@ -43,7 +43,7 @@
       "ProductID": 788,
       "InputReportLength": 11,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Vendors.Wacom.Wacom64bAuxReportParser",
+      "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": [
         "AgI="
       ],


### PR DESCRIPTION
Shouldn't have an aux parser on an endpoint that isn't aux.