### PR TITLE
detect tablets after wake

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -55,6 +55,14 @@ namespace OpenTabletDriver.Daemon
                     await DetectTablets();
             };
 
+            DesktopInterop.PowerManager.PowerEvent += async (object sender, PowerEventArgs e) =>
+            {
+                if (e.EventType == PowerEventType.Resume)
+                {
+                    await DetectTablets();
+                }
+            };
+
             LoadUserSettings();
         }
 

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -19,6 +19,7 @@ using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Logging;
 using OpenTabletDriver.Plugin.Output;
 using OpenTabletDriver.Plugin.Tablet;
+using OpenTabletDriver.Desktop.Interop.Power;
 
 namespace OpenTabletDriver.Daemon
 {
@@ -53,6 +54,14 @@ namespace OpenTabletDriver.Daemon
             {
                 if (await GetTablet() == null && args.Additions.Count() > 0)
                     await DetectTablets();
+            };
+
+            DesktopInterop.PowerManager.PowerEvent += async (sender, args) =>
+            {
+                if (args.EventType == PowerEventType.Resume) 
+                {
+                    await DetectTablets();
+                }
             };
 
             LoadUserSettings();

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -55,14 +55,6 @@ namespace OpenTabletDriver.Daemon
                     await DetectTablets();
             };
 
-            DesktopInterop.PowerManager.PowerEvent += async (object sender, PowerEventArgs e) =>
-            {
-                if (e.EventType == PowerEventType.Resume)
-                {
-                    await DetectTablets();
-                }
-            };
-
             LoadUserSettings();
         }
 

--- a/OpenTabletDriver.Desktop/Interop/DesktopInterop.cs
+++ b/OpenTabletDriver.Desktop/Interop/DesktopInterop.cs
@@ -5,6 +5,7 @@ using OpenTabletDriver.Desktop.Interop.Input.Absolute;
 using OpenTabletDriver.Desktop.Interop.Input.Keyboard;
 using OpenTabletDriver.Desktop.Interop.Input.Relative;
 using OpenTabletDriver.Desktop.Interop.Timer;
+using OpenTabletDriver.Desktop.Interop.Power;
 using OpenTabletDriver.Interop;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Platform.Display;

--- a/OpenTabletDriver.Desktop/Interop/DesktopInterop.cs
+++ b/OpenTabletDriver.Desktop/Interop/DesktopInterop.cs
@@ -108,5 +108,11 @@ namespace OpenTabletDriver.Desktop.Interop
             Log.Write("Display", "Neither Wayland nor X11 were detected, defaulting to X11.", LogLevel.Warning);
             return new XScreen();
         }
+
+        public static IPowerManager PowerManager => CurrentPlatform switch 
+        {
+            PluginPlatform.Windows => new WindowsPowerManager(),
+            _ => null
+        };
     }
 }

--- a/OpenTabletDriver.Desktop/Interop/Power/IPowerManager.cs
+++ b/OpenTabletDriver.Desktop/Interop/Power/IPowerManager.cs
@@ -1,0 +1,6 @@
+using System;
+
+public interface IPowerManager : IDisposable
+{
+    event EventHandler<PowerEventArgs> PowerEvent;
+}

--- a/OpenTabletDriver.Desktop/Interop/Power/IPowerManager.cs
+++ b/OpenTabletDriver.Desktop/Interop/Power/IPowerManager.cs
@@ -1,6 +1,9 @@
 using System;
 
-public interface IPowerManager : IDisposable
+namespace OpenTabletDriver.Desktop.Interop.Power 
 {
+    public interface IPowerManager : IDisposable
+    {
     event EventHandler<PowerEventArgs> PowerEvent;
+    }
 }

--- a/OpenTabletDriver.Desktop/Interop/Power/IPowerManager.cs
+++ b/OpenTabletDriver.Desktop/Interop/Power/IPowerManager.cs
@@ -4,6 +4,6 @@ namespace OpenTabletDriver.Desktop.Interop.Power
 {
     public interface IPowerManager : IDisposable
     {
-    event EventHandler<PowerEventArgs> PowerEvent;
+        event EventHandler<PowerEventArgs> PowerEvent;
     }
 }

--- a/OpenTabletDriver.Desktop/Interop/Power/PowerEvent.cs
+++ b/OpenTabletDriver.Desktop/Interop/Power/PowerEvent.cs
@@ -1,0 +1,14 @@
+using System;
+public enum PowerEventType
+{
+    Unknown,
+    Suspend,
+    Resume
+}
+
+public class PowerEventArgs : EventArgs 
+{
+    public PowerEventType EventType;
+
+    public PowerEventArgs(PowerEventType type) => EventType = type;
+}

--- a/OpenTabletDriver.Desktop/Interop/Power/PowerEvent.cs
+++ b/OpenTabletDriver.Desktop/Interop/Power/PowerEvent.cs
@@ -1,14 +1,18 @@
 using System;
-public enum PowerEventType
-{
-    Unknown,
-    Suspend,
-    Resume
-}
 
-public class PowerEventArgs : EventArgs 
+namespace OpenTabletDriver.Desktop.Interop.Power 
 {
-    public PowerEventType EventType;
+    public enum PowerEventType
+    {
+        Unknown,
+        Suspend,
+        Resume
+    }
 
-    public PowerEventArgs(PowerEventType type) => EventType = type;
+    public class PowerEventArgs : EventArgs 
+    {
+        public PowerEventType EventType;
+
+        public PowerEventArgs(PowerEventType type) => EventType = type;
+    }
 }

--- a/OpenTabletDriver.Desktop/Interop/Power/PowerEventArgs.cs
+++ b/OpenTabletDriver.Desktop/Interop/Power/PowerEventArgs.cs
@@ -1,14 +1,7 @@
-using System;
+    using System;
 
 namespace OpenTabletDriver.Desktop.Interop.Power 
 {
-    public enum PowerEventType
-    {
-        Unknown,
-        Suspend,
-        Resume
-    }
-
     public class PowerEventArgs : EventArgs 
     {
         public PowerEventType EventType;

--- a/OpenTabletDriver.Desktop/Interop/Power/PowerEventType.cs
+++ b/OpenTabletDriver.Desktop/Interop/Power/PowerEventType.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace OpenTabletDriver.Desktop.Interop.Power 
+{
+    public enum PowerEventType
+    {
+        Unknown,
+        Suspend,
+        Resume
+    }
+}

--- a/OpenTabletDriver.Desktop/Interop/Power/WindowsPowerManager.cs
+++ b/OpenTabletDriver.Desktop/Interop/Power/WindowsPowerManager.cs
@@ -1,0 +1,39 @@
+using System;
+using Microsoft.Win32;
+
+public class WindowsPowerManager : IPowerManager
+{
+    public event EventHandler<PowerEventArgs> PowerEvent;
+
+    public WindowsPowerManager() 
+    {
+        SystemEvents.PowerModeChanged += OnPowerEvent;
+    }
+
+    void OnPowerEvent(object sender, PowerModeChangedEventArgs e)
+    {
+        PowerEvent?.Invoke(this, ConvertArgs(e));
+    }
+
+    private PowerEventArgs ConvertArgs(PowerModeChangedEventArgs e)
+    {
+        switch (e.Mode)
+        {
+            case PowerModes.Suspend:
+                return new PowerEventArgs(PowerEventType.Suspend);
+
+            case PowerModes.Resume:
+                return new PowerEventArgs(PowerEventType.Resume);
+        }
+
+        return new PowerEventArgs(PowerEventType.Unknown);
+    }
+
+    public void Dispose()
+    {
+        // detach static event handler to prevent memory leaks
+        // https://docs.microsoft.com/en-us/dotnet/api/microsoft.win32.systemevents.powermodechanged?view=net-5.0#remarks
+        
+        SystemEvents.PowerModeChanged -= OnPowerEvent;
+    }
+}

--- a/OpenTabletDriver.Desktop/Interop/Power/WindowsPowerManager.cs
+++ b/OpenTabletDriver.Desktop/Interop/Power/WindowsPowerManager.cs
@@ -6,12 +6,14 @@ namespace OpenTabletDriver.Desktop.Interop.Power
     {
         public event EventHandler<PowerEventArgs> PowerEvent;
 
+        #pragma warning disable CA1416
+
         public WindowsPowerManager() 
         {
-            SystemEvents.PowerModeChanged += OnPowerEvent;
+            SystemEvents.PowerModeChanged += HandlePowerEvent;
         }
 
-        void OnPowerEvent(object sender, PowerModeChangedEventArgs e)
+        private void HandlePowerEvent(object sender, PowerModeChangedEventArgs e)
         {
             PowerEvent?.Invoke(this, ConvertArgs(e));
         }
@@ -35,7 +37,11 @@ namespace OpenTabletDriver.Desktop.Interop.Power
             // detach static event handler to prevent memory leaks
             // https://docs.microsoft.com/en-us/dotnet/api/microsoft.win32.systemevents.powermodechanged?view=net-5.0#remarks
         
-            SystemEvents.PowerModeChanged -= OnPowerEvent;
+            SystemEvents.PowerModeChanged -= HandlePowerEvent;
         }
+
+        ~WindowsPowerManager() => Dispose();
+
+        #pragma warning restore CA1416
     }
 }

--- a/OpenTabletDriver.Desktop/Interop/Power/WindowsPowerManager.cs
+++ b/OpenTabletDriver.Desktop/Interop/Power/WindowsPowerManager.cs
@@ -1,39 +1,41 @@
 using System;
 using Microsoft.Win32;
-
-public class WindowsPowerManager : IPowerManager
+namespace OpenTabletDriver.Desktop.Interop.Power 
 {
-    public event EventHandler<PowerEventArgs> PowerEvent;
-
-    public WindowsPowerManager() 
+    public class WindowsPowerManager : IPowerManager
     {
-        SystemEvents.PowerModeChanged += OnPowerEvent;
-    }
+        public event EventHandler<PowerEventArgs> PowerEvent;
 
-    void OnPowerEvent(object sender, PowerModeChangedEventArgs e)
-    {
-        PowerEvent?.Invoke(this, ConvertArgs(e));
-    }
-
-    private PowerEventArgs ConvertArgs(PowerModeChangedEventArgs e)
-    {
-        switch (e.Mode)
+        public WindowsPowerManager() 
         {
-            case PowerModes.Suspend:
-                return new PowerEventArgs(PowerEventType.Suspend);
-
-            case PowerModes.Resume:
-                return new PowerEventArgs(PowerEventType.Resume);
+            SystemEvents.PowerModeChanged += OnPowerEvent;
         }
 
-        return new PowerEventArgs(PowerEventType.Unknown);
-    }
+        void OnPowerEvent(object sender, PowerModeChangedEventArgs e)
+        {
+            PowerEvent?.Invoke(this, ConvertArgs(e));
+        }
 
-    public void Dispose()
-    {
-        // detach static event handler to prevent memory leaks
-        // https://docs.microsoft.com/en-us/dotnet/api/microsoft.win32.systemevents.powermodechanged?view=net-5.0#remarks
+        private PowerEventArgs ConvertArgs(PowerModeChangedEventArgs e)
+        {
+            switch (e.Mode)
+            {
+                case PowerModes.Suspend:
+                    return new PowerEventArgs(PowerEventType.Suspend);
+
+                case PowerModes.Resume:
+                    return new PowerEventArgs(PowerEventType.Resume);
+            }
+
+            return new PowerEventArgs(PowerEventType.Unknown);
+        }
+
+        public void Dispose()
+        {
+            // detach static event handler to prevent memory leaks
+            // https://docs.microsoft.com/en-us/dotnet/api/microsoft.win32.systemevents.powermodechanged?view=net-5.0#remarks
         
-        SystemEvents.PowerModeChanged -= OnPowerEvent;
+            SystemEvents.PowerModeChanged -= OnPowerEvent;
+        }
     }
 }

--- a/OpenTabletDriver.Desktop/OpenTabletDriver.Desktop.csproj
+++ b/OpenTabletDriver.Desktop/OpenTabletDriver.Desktop.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="NuGet Packages">
+    <PackageReference Include="Microsoft.Win32.SystemEvents" Version="5.0.0" />
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="SharpZipLib" Version="1.3.1" />
     <PackageReference Include="StreamJsonRpc" Version="2.6.121" />


### PR DESCRIPTION
Since #1093 didn't receive any updates in 2 weeks, i decided to do it myself
- [X] Power management abstraction (`OpenTabletDriver.Desktop.Interop.Power`)
- [X] Detect tablets on resume power event
- [X] Dispose `PowerManager` on daemon exit (Done in the deconstructor)

> This is needed on Windows to prevent memory leaks (see [here](https://docs.microsoft.com/en-us/dotnet/api/microsoft.win32.systemevents.powermodechanged?view=net-5.0#remarks)) and likely on Linux and MacOS as well depending on their implementation

- [X] Implement Windows power event
- Will implement Linux and MacOS power events in a separate PR