### PR TITLE
Changed Q620M parser in the config

### DIFF
--- a/OpenTabletDriver/Configurations/Huion/Q620M.json
+++ b/OpenTabletDriver/Configurations/Huion/Q620M.json
@@ -30,7 +30,7 @@
       "ProductID": 109,
       "InputReportLength": 12,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Tablet.TabletReportParser",
+      "ReportParser": "OpenTabletDriver.Vendors.Huion.GianoReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19785860/119256108-470b4280-bbbf-11eb-9371-a7c81cbffaab.png)

Noticed Tilt wasn't working on my tablet, took a quick look at the config and compared with another Huion tablet, compared `GianoReport.cs` and `TabletReport.cs` and didn't see anything fundamentally different except ofc tilt support, maybe except this part? lmk if I need to test something else: https://github.com/OpenTabletDriver/OpenTabletDriver/blob/8c5e48008881e9c99da35d722ad7ac64210255e9/OpenTabletDriver/Vendors/Huion/GianoReport.cs#L16 

lmk if anything needs to get changed, love u guys work ❤