### PR TITLE
Add full init sequence to intuos3 tablets

### DIFF
--- a/OpenTabletDriver/Configurations/Wacom/PTZ-1230.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTZ-1230.json
@@ -32,7 +32,9 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "AgI=",
+        "CAIDAAA=",
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
@@ -45,7 +47,9 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "AgI=",
+        "CAIDAAA=",
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},

--- a/OpenTabletDriver/Configurations/Wacom/PTZ-1231W.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTZ-1231W.json
@@ -32,7 +32,9 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "AgI=",
+        "CAIDAAA=",
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
@@ -45,7 +47,9 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "AgI=",
+        "CAIDAAA=",
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},

--- a/OpenTabletDriver/Configurations/Wacom/PTZ-430.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTZ-430.json
@@ -32,7 +32,9 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "AgI=",
+        "CAIDAAA=",
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
@@ -45,7 +47,9 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "AgI=",
+        "CAIDAAA=",
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},

--- a/OpenTabletDriver/Configurations/Wacom/PTZ-431W.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTZ-431W.json
@@ -32,7 +32,9 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "AgI=",
+        "CAIDAAA=",
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
@@ -45,7 +47,9 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "AgI=",
+        "CAIDAAA=",
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},

--- a/OpenTabletDriver/Configurations/Wacom/PTZ-630.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTZ-630.json
@@ -32,7 +32,9 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "AgI=",
+        "CAIDAAA=",
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
@@ -45,7 +47,9 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "AgI=",
+        "CAIDAAA=",
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},

--- a/OpenTabletDriver/Configurations/Wacom/PTZ-631W.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTZ-631W.json
@@ -32,7 +32,9 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "AgI=",
+        "CAIDAAA=",
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
@@ -45,7 +47,9 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "AgI=",
+        "CAIDAAA=",
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},

--- a/OpenTabletDriver/Configurations/Wacom/PTZ-930.json
+++ b/OpenTabletDriver/Configurations/Wacom/PTZ-930.json
@@ -32,7 +32,9 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "AgI=",
+        "CAIDAAA=",
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
@@ -45,7 +47,9 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "AgI=",
+        "CAIDAAA=",
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},


### PR DESCRIPTION
Seems like this was meant to be added when multi init was implemented, but everyone forgot about it, lol.

Works on ptz-630: https://discord.com/channels/615607687467761684/628651971267788800/836495244484149269
and ptz-930 (source: myself), probably safe to assume all intuos3 tablets share this init.