### PR TITLE
Update intuos1-2 init for 200hz

### DIFF
--- a/OpenTabletDriver/Configurations/Wacom/GD-0405-U.json
+++ b/OpenTabletDriver/Configurations/Wacom/GD-0405-U.json
@@ -32,7 +32,7 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
@@ -45,7 +45,7 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},

--- a/OpenTabletDriver/Configurations/Wacom/GD-0608-U.json
+++ b/OpenTabletDriver/Configurations/Wacom/GD-0608-U.json
@@ -32,7 +32,7 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
@@ -45,7 +45,7 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},

--- a/OpenTabletDriver/Configurations/Wacom/GD-0912-U.json
+++ b/OpenTabletDriver/Configurations/Wacom/GD-0912-U.json
@@ -32,7 +32,7 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
@@ -45,7 +45,7 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},

--- a/OpenTabletDriver/Configurations/Wacom/GD-1212-U.json
+++ b/OpenTabletDriver/Configurations/Wacom/GD-1212-U.json
@@ -32,7 +32,7 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
@@ -45,7 +45,7 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},

--- a/OpenTabletDriver/Configurations/Wacom/GD-1218-U.json
+++ b/OpenTabletDriver/Configurations/Wacom/GD-1218-U.json
@@ -32,7 +32,7 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
@@ -45,7 +45,7 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},

--- a/OpenTabletDriver/Configurations/Wacom/XD-0405-U.json
+++ b/OpenTabletDriver/Configurations/Wacom/XD-0405-U.json
@@ -32,7 +32,7 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
@@ -45,7 +45,7 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},

--- a/OpenTabletDriver/Configurations/Wacom/XD-0608-U.json
+++ b/OpenTabletDriver/Configurations/Wacom/XD-0608-U.json
@@ -32,7 +32,7 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
@@ -45,7 +45,7 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},

--- a/OpenTabletDriver/Configurations/Wacom/XD-0912-U.json
+++ b/OpenTabletDriver/Configurations/Wacom/XD-0912-U.json
@@ -32,7 +32,7 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
@@ -45,7 +45,7 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},

--- a/OpenTabletDriver/Configurations/Wacom/XD-1212-U.json
+++ b/OpenTabletDriver/Configurations/Wacom/XD-1212-U.json
@@ -32,7 +32,7 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
@@ -45,7 +45,7 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},

--- a/OpenTabletDriver/Configurations/Wacom/XD-1218-U.json
+++ b/OpenTabletDriver/Configurations/Wacom/XD-1218-U.json
@@ -32,7 +32,7 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.IntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
@@ -45,7 +45,7 @@
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Vendors.Wacom.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": [
-        "AgI="
+        "BAA="
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},


### PR DESCRIPTION
GD and XD series have been confirmed to work with only `BAA=` and send at 200hz when using it. Instead of the 100hz using `AgI=`.