### PR TITLE
Fix empty/null string check in KeyBinding

### DIFF
--- a/OpenTabletDriver.Desktop/Binding/KeyBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/KeyBinding.cs
@@ -23,13 +23,13 @@ namespace OpenTabletDriver.Desktop.Binding
 
         public void Press(IDeviceReport report)
         {
-            if (string.IsNullOrWhiteSpace(Key))
+            if (!string.IsNullOrWhiteSpace(Key))
                 Keyboard.Press(Key);
         }
 
         public void Release(IDeviceReport report)
         {
-            if (string.IsNullOrWhiteSpace(Key))
+            if (!string.IsNullOrWhiteSpace(Key))
                 Keyboard.Release(Key);
         }
 


### PR DESCRIPTION
This check wasn't negated and worked in the opposite way to that intended - virtual keys would get pressed only if the key string was null or empty.
