### PR TITLE
Rework AppInfo to XDG Base Directory specification

### DIFF
--- a/OpenTabletDriver.Daemon/Program.cs
+++ b/OpenTabletDriver.Daemon/Program.cs
@@ -52,8 +52,10 @@ namespace OpenTabletDriver.Daemon
                 };
                 rootCommand.Handler = CommandHandler.Create<DirectoryInfo, DirectoryInfo>((appdata, config) => 
                 {
-                    AppInfo.Current.AppDataDirectory = appdata?.FullName;
-                    AppInfo.Current.ConfigurationDirectory = config?.FullName;
+                    if (!string.IsNullOrWhiteSpace(appdata?.FullName))
+                        AppInfo.Current.AppDataDirectory = appdata.FullName;
+                    if (!string.IsNullOrWhiteSpace(config?.FullName))
+                        AppInfo.Current.ConfigurationDirectory = config.FullName;
                 });
                 rootCommand.Invoke(args);
 

--- a/OpenTabletDriver.Desktop/AppInfo.cs
+++ b/OpenTabletDriver.Desktop/AppInfo.cs
@@ -93,7 +93,7 @@ namespace OpenTabletDriver.Desktop
         private class LinuxAppInfo : AppInfo
         {
             protected override string GetDefaultAppDataDirectory() => GetDirectory("$XDG_CONFIG_HOME/OpenTabletDriver", "$HOME/.config/OpenTabletDriver");
-            public override string TemporaryDirectory => GetDirectory("$TEMP/OpenTabletDriver", base.TemporaryDirectory);
+            public override string TemporaryDirectory => GetDirectory("$XDG_RUNTIME_DIR/OpenTabletDriver", "$TEMP/OpenTabletDriver", base.TemporaryDirectory);
             public override string CacheDirectory => GetDirectory("$XDG_CACHE_HOME/OpenTabletDriver", "$HOME/.cache/OpenTabletDriver", base.CacheDirectory);
         }
 

--- a/OpenTabletDriver.Desktop/AppInfo.cs
+++ b/OpenTabletDriver.Desktop/AppInfo.cs
@@ -1,63 +1,107 @@
 using System;
+using System.Collections;
 using System.IO;
+using System.Linq;
+using System.Text;
 using OpenTabletDriver.Desktop.Interop;
 using OpenTabletDriver.Desktop.Reflection;
 using OpenTabletDriver.Plugin;
 
 namespace OpenTabletDriver.Desktop
 {
-    public class AppInfo
+    public abstract class AppInfo
     {
-        public static AppInfo Current { set; get; } = new AppInfo();
+        public static AppInfo Current { set; get; } = DesktopInterop.CurrentPlatform switch
+        {
+            PluginPlatform.Windows => new WindowsAppInfo(),
+            PluginPlatform.Linux => new LinuxAppInfo(),
+            PluginPlatform.MacOS => new MacOSAppInfo(),
+            _ => null
+        };
 
         public static DesktopPluginManager PluginManager { get; } = new DesktopPluginManager();
 
-        private string configDirectory, appDataDirectory;
+        private string appDataDir, configDir;
 
-        public string ConfigurationDirectory
+        public virtual string AppDataDirectory
         {
-            set => this.configDirectory = value;
-            get => this.configDirectory ??= DefaultConfigurationDirectory;
-        }
-
-        public string AppDataDirectory
-        {
-            set => this.appDataDirectory = value;
-            get => this.appDataDirectory ??= DefaultAppDataDirectory;
-        }
-
-        public string SettingsFile => Path.Join(AppDataDirectory, "settings.json");
-        public string PluginDirectory => Path.Join(AppDataDirectory, "Plugins");
-        public string TemporaryDirectory => Path.Join(AppDataDirectory, "Temp");
-        public string CacheDirectory => Path.Join(AppDataDirectory, "Cache");
-        public string TrashDirectory => Path.Join(AppDataDirectory, "Trash");
-
-        private static string ProgramDirectory => AppContext.BaseDirectory;
-
-        private static string DefaultConfigurationDirectory
-        {
+            set => this.appDataDir = value;
             get
             {
-                var path = Path.Join(ProgramDirectory, "Configurations");
-                var fallbackPath = Path.Join(Environment.CurrentDirectory, "Configurations");
-                return Directory.Exists(path) ? path : fallbackPath;
+                if (!string.IsNullOrWhiteSpace(this.appDataDir))
+                    return this.appDataDir;
+
+                // Allows for userdata folder to be created
+                var userData = Path.Join(ProgramDirectory, "userdata");
+                return this.appDataDir = Directory.Exists(userData) ? userData : GetDefaultAppDataDirectory();
             }
         }
 
-        private static string DefaultAppDataDirectory
+        public virtual string ConfigurationDirectory
         {
-            get
+            set => this.configDir = value;
+            get => this.configDir ??= GetDefaultConfigurationDirectory();
+        }
+
+        public virtual string SettingsFile => Path.Join(AppDataDirectory, "settings.json");
+        public virtual string PluginDirectory => Path.Join(AppDataDirectory, "Plugins");
+        public virtual string TemporaryDirectory => Path.Join(AppDataDirectory, "Temp");
+        public virtual string CacheDirectory => Path.Join(AppDataDirectory, "Cache");
+        public virtual string TrashDirectory => Path.Join(AppDataDirectory, "Trash");
+
+        protected static string ProgramDirectory => AppContext.BaseDirectory;
+
+        protected abstract string GetDefaultAppDataDirectory();
+
+        protected virtual string GetDefaultConfigurationDirectory()
+        {
+            var path = Path.Join(ProgramDirectory, "Configurations");
+            var fallbackPath = Path.Join(Environment.CurrentDirectory, "Configurations");
+            return Directory.Exists(path) ? path : fallbackPath;
+        }
+
+        private static string GetDirectory(params string[] directories)
+        {
+            foreach (var dir in directories.Select(d => InjectVariables(d)))
+                if (Path.IsPathRooted(dir))
+                    return dir;
+
+            return null;
+        }
+
+        private static string InjectVariables(string str)
+        {
+            StringBuilder sb = new StringBuilder(str);
+            sb.Replace("~", Environment.GetEnvironmentVariable("HOME"));
+
+            foreach (DictionaryEntry envVar in Environment.GetEnvironmentVariables())
             {
-                var path = Path.Join(ProgramDirectory, "userdata");
-                var fallbackPath = DesktopInterop.CurrentPlatform switch
-                {
-                    PluginPlatform.Windows => Path.Join(Environment.GetEnvironmentVariable("LOCALAPPDATA"), "OpenTabletDriver"),
-                    PluginPlatform.Linux   => Path.Join(Environment.GetEnvironmentVariable("HOME"), ".config", "OpenTabletDriver"),
-                    PluginPlatform.MacOS   => Path.Join(Environment.GetEnvironmentVariable("HOME"), "Library", "Application Support", "OpenTabletDriver"),
-                    _                      => null
-                };
-                return Directory.Exists(path) ? path : fallbackPath;
+                string key = envVar.Key as string;
+                string value = envVar.Value as string;
+                sb.Replace($"${key}", value); // $KEY
+                sb.Replace($"${{{key}}}", value); // ${KEY}
             }
+
+            return sb.ToString();
+        }
+
+        private class WindowsAppInfo : AppInfo
+        {
+            protected override string GetDefaultAppDataDirectory() => GetDirectory("$LOCALAPPDATA\\OpenTabletDriver");
+        }
+
+        private class LinuxAppInfo : AppInfo
+        {
+            protected override string GetDefaultAppDataDirectory() => GetDirectory("$XDG_CONFIG_HOME/OpenTabletDriver", "$HOME/.config/OpenTabletDriver");
+            public override string TemporaryDirectory => GetDirectory("$TEMP/OpenTabletDriver", base.TemporaryDirectory);
+            public override string CacheDirectory => GetDirectory("$XDG_CACHE_HOME/OpenTabletDriver", "$HOME/.cache/OpenTabletDriver", base.CacheDirectory);
+        }
+
+        private class MacOSAppInfo : AppInfo
+        {
+            protected override string GetDefaultAppDataDirectory() => GetDirectory("$HOME/Library/Application Support/OpenTabletDriver");
+            public override string TemporaryDirectory => GetDirectory("$TMPDIR/OpenTabletDriver", base.TemporaryDirectory);
+            public override string CacheDirectory => GetDirectory("$HOME/Library/Caches/OpenTabletDriver", base.CacheDirectory);
         }
     }
 }

--- a/OpenTabletDriver.Tests/ConsoleExtensions.cs
+++ b/OpenTabletDriver.Tests/ConsoleExtensions.cs
@@ -8,16 +8,15 @@ namespace OpenTabletDriver.Tests
 {
     public static class ConsoleExtensions
     {
-        public static void WriteLines(this TextWriter tw, IList<string> strings) => tw.WriteLine(string.Concat(strings));
+        public static void WriteLines(this TextWriter tw, IEnumerable<string> strings) => tw.WriteLine(string.Concat(strings));
         public static void WriteLines(this TextWriter tw, params string[] strings) => WriteLines(tw, (IList<string>)strings);
 
         public static void WriteProperties<T>(this TextWriter tw, T source)
         {
             var properties = from property in typeof(T).GetProperties()
-                select (Name: property.Name, Value: property.GetValue(source) ?? "{null}");
+                select $"{property.Name}: {property.GetValue(source) ?? "{null}"}";
 
-            foreach (var propertyPair in properties)
-                tw.WriteLine($"{propertyPair.Name}: {propertyPair.Value}");
+            tw.WriteLines(properties);
         }
     }
 }

--- a/OpenTabletDriver.Tests/PluginRepositoryTest.cs
+++ b/OpenTabletDriver.Tests/PluginRepositoryTest.cs
@@ -10,17 +10,13 @@ namespace OpenTabletDriver.Tests
     [TestClass]
     public class PluginRepositoryTest : TestBase
     {
-        private static string TestAppDataDirectory => Path.Join(TestDirectory, nameof(PluginRepositoryTest));
         private static string CollectionTarball => Path.Join(AppInfo.Current.AppDataDirectory, TarballName);
         private const string TarballName = "repository.tar.gz";
 
         [TestInitialize]
         public void Initialize()
         {
-            AppInfo.Current = new AppInfo
-            {
-                AppDataDirectory = TestAppDataDirectory
-            };
+            AppInfo.Current = new TestAppInfo();
         }
 
         [TestCleanup]

--- a/OpenTabletDriver.Tests/TestBase.cs
+++ b/OpenTabletDriver.Tests/TestBase.cs
@@ -1,5 +1,7 @@
 using System;
+using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenTabletDriver.Desktop;
 
 namespace OpenTabletDriver.Tests
 {
@@ -7,5 +9,10 @@ namespace OpenTabletDriver.Tests
     public class TestBase
     {
         protected static string TestDirectory = Environment.GetEnvironmentVariable("OPENTABLETDRIVER_TEST") ?? Environment.CurrentDirectory;
+
+        protected class TestAppInfo : AppInfo
+        {
+            protected override string GetDefaultAppDataDirectory() => Path.Join(TestDirectory, nameof(PluginRepositoryTest));
+        }
     }
 }

--- a/OpenTabletDriver.Tests/TestBase.cs
+++ b/OpenTabletDriver.Tests/TestBase.cs
@@ -12,7 +12,7 @@ namespace OpenTabletDriver.Tests
 
         protected class TestAppInfo : AppInfo
         {
-            protected override string GetDefaultAppDataDirectory() => Path.Join(TestDirectory, nameof(PluginRepositoryTest));
+            public override string AppDataDirectory => Path.Join(TestDirectory, nameof(PluginRepositoryTest));
         }
     }
 }


### PR DESCRIPTION
`AppInfo` has been reworked to support the [FreeDesktop XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html). Each platform has its own implementation of `AppInfo`.

Other minor improvements have been made, such as metadata caches being stored.