### PR TITLE
Add Artisul M0610 Pro Config

### DIFF
--- a/OpenTabletDriver/Configurations/Artisul/M0610 Pro.json
+++ b/OpenTabletDriver/Configurations/Artisul/M0610 Pro.json
@@ -1,0 +1,48 @@
+{
+  "Name": "Artisul M0610 Pro",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 257.375,
+      "Height": 161.49,
+      "MaxX": 51475.0,
+      "MaxY": 32298.0
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ActiveReportID": {
+        "Start": 64,
+        "StartInclusive": true,
+        "End": null,
+        "EndInclusive": false
+      },
+      "Buttons": {
+        "ButtonCount": 0
+      }
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 0
+    },
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 21827,
+      "ProductID": 129,
+      "InputReportLength": 10,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Tablet.TabletReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "201": "F610_M61P-T\\d{4}$"
+      },
+      "InitializationStrings": [
+        "100"
+      ]
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/OpenTabletDriver/Configurations/UC-Logic/1060N.json
+++ b/OpenTabletDriver/Configurations/UC-Logic/1060N.json
@@ -35,7 +35,9 @@
       "OutputInitReport": [
         "ArAC"
       ],
-      "DeviceStrings": {},
+      "DeviceStrings": {
+        "201": "F600_A60n_E\\d{4}$"
+      },
       "InitializationStrings": [
         100
       ]

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -56,6 +56,7 @@
 | XP-Pen Star G960S      |    Supported     |
 | XP-Pen Star G960S Plus |    Supported     |
 | XP-Pen Star G960v2     |    Supported     |
+| Artisul M0610 Pro      | Missing Features | Buttons, tilt, and touch wheel are unsupported.
 | Huion H1161            | Missing Features |
 | Huion HC16             | Missing Features |
 | Huion HS610            | Missing Features |


### PR DESCRIPTION
Verification for Artisul M0610 Pro Config:
[discord](https://discord.com/channels/615607687467761684/615611007951306863/851127217258102785)
[discord](https://discord.com/channels/615607687467761684/615611007951306863/851124595942883388)
[discord](https://discord.com/channels/615607687467761684/615611007951306863/851115933904273453)

Verification for UC-Logic 1060N String (needed to avoid conflict with Artisul and any other future UC-Logic tablets):
[discord](https://discord.com/channels/615607687467761684/615611007951306863/828744043248091146)

Artisul M0610 Pro is missing tablet button support and tilt support. Current parsers and possibly current init methods don't work for its aux endpoint.