### PR TITLE
Add tablet configuration database

### DIFF
--- a/TABLETS.md
+++ b/TABLETS.md
@@ -1,0 +1,110 @@
+| Tablet                 |      Status      | Notes |
+| ---------------------- | :--------------: | ----- |
+| Gaomon M106K Pro       |    Supported     |
+| Gaomon M10K            |    Supported     |
+| Gaomon M10K Pro        |    Supported     |
+| Gaomon M1120           |    Supported     |
+| Gaomon PD1161          |    Supported     |
+| Gaomon S56K            |    Supported     |
+| Gaomon S620            |    Supported     |
+| Huion GT-133           |    Supported     |
+| Huion H1060P           |    Supported     |
+| Huion H420X            |    Supported     |
+| Huion H430P            |    Supported     |
+| Huion H610 Pro         |    Supported     |
+| Huion H610 Pro V2      |    Supported     |
+| Huion HS64             |    Supported     |
+| Huion Inspiroy Q11K V2 |    Supported     |
+| Huion New 1060 Plus    |    Supported     |
+| Huion WH1409 V2        |    Supported     |
+| UC-Logic 1060N         |    Supported     |
+| VEIKK A15              |    Supported     |
+| VEIKK A15 Pro          |    Supported     |
+| VEIKK A30              |    Supported     |
+| VEIKK A50              |    Supported     |
+| VEIKK S640             |    Supported     |
+| Wacom CTE-430          |    Supported     |
+| Wacom CTH-470          |    Supported     |
+| Wacom CTH-480          |    Supported     |
+| Wacom CTH-490          |    Supported     |
+| Wacom CTH-680          |    Supported     |
+| Wacom CTL-4100         |    Supported     |
+| Wacom CTL-460          |    Supported     |
+| Wacom CTL-470          |    Supported     |
+| Wacom CTL-471          |    Supported     |
+| Wacom CTL-472          |    Supported     |
+| Wacom CTL-480          |    Supported     |
+| Wacom CTL-490          |    Supported     |
+| Wacom CTL-6100         |    Supported     |
+| Wacom CTL-671          |    Supported     |
+| Wacom CTL-672          |    Supported     |
+| Wacom CTL-680          |    Supported     |
+| Wacom CTL-690          |    Supported     |
+| Wacom FT-0405-U        |    Supported     |
+| Wacom GD-0405-U        |    Supported     |
+| XP-Pen Deco 01         |    Supported     |
+| XP-Pen Deco 01 V2      |    Supported     |
+| XP-Pen Deco 02         |    Supported     |
+| XP-Pen Deco 03         |    Supported     |
+| XP-Pen Star 03v2       |    Supported     |
+| XP-Pen Star G430       |    Supported     |
+| XP-Pen Star G430S      |    Supported     |
+| XP-Pen Star G540 Pro   |    Supported     |
+| XP-Pen Star G5640      |    Supported     |
+| XP-Pen Star G640 V2    |    Supported     |
+| XP-Pen Star G640s      |    Supported     |
+| XP-Pen Star G960S      |    Supported     |
+| XP-Pen Star G960S Plus |    Supported     |
+| XP-Pen Star G960v2     |    Supported     |
+| Huion H1161            | Missing Features |
+| Huion HC16             | Missing Features |
+| Huion HS610            | Missing Features |
+| Huion HS611            | Missing Features |
+| Huion Kamvas 16        | Missing Features |
+| Huion Q620M            | Missing Features |
+| Wacom CTE-450          | Missing Features |
+| Wacom MTE-450          | Missing Features |
+| Wacom PTH-460          | Missing Features |
+| Wacom PTH-651          | Missing Features |
+| Wacom PTH-660          | Missing Features |
+| Wacom PTH-850          | Missing Features |
+| Wacom PTH-860          | Missing Features |
+| Wacom PTK-440          | Missing Features |
+| Wacom PTK-540WL        | Missing Features |
+| Wacom PTZ-630          | Missing Features |
+| Wacom PTZ-930          | Missing Features |
+| Wacom XD-0608-U        | Missing Features |
+| XP-Pen Artist Pro 12   | Missing Features |
+| XP-Pen Deco mini7      | Missing Features |
+| XP-Pen Deco Pro Medium | Missing Features |
+| XP-Pen Deco Pro Small  | Missing Features |
+| XP-Pen Star 06C        | Missing Features |
+| Huion 420              |      Broken      |
+| Huion H420             |      Broken      |
+| Wacom ISD-V4           |      Broken      | #394  |
+| XP-Pen G540            |      Broken      | #698  |
+| Huion G10T             |     Untested     |
+| Huion H950 P           |     Untested     |
+| Huion Inspiroy Q11K    |     Untested     |
+| Huion osu! Tablet      |     Untested     |
+| Wacom CTE-440          |     Untested     |
+| Wacom CTE-460          |     Untested     |
+| Wacom CTH-670          |     Untested     |
+| Wacom GD-0608-U        |     Untested     |
+| Wacom GD-0912-U        |     Untested     |
+| Wacom GD-1218-U        |     Untested     |
+| Wacom PTH-450          |     Untested     |
+| Wacom PTH-451          |     Untested     |
+| Wacom PTH-660          |     Untested     |
+| Wacom PTH-851          |     Untested     |
+| Wacom PTK-430          |     Untested     |
+| Wacom PTK-650          |     Untested     |
+| Wacom PTZ-1230         |     Untested     |
+| Wacom PTZ-1231W        |     Untested     |
+| Wacom PTZ-430          |     Untested     |
+| Wacom PTZ-431W         |     Untested     |
+| Wacom PTZ-631W         |     Untested     |
+| Wacom XD-0405-U        |     Untested     |
+| Wacom XD-0912-U        |     Untested     |
+| Wacom XD-1212-U        |     Untested     |
+| Wacom XD-1218-U        |     Untested     |

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -63,7 +63,7 @@
 | Huion Kamvas 16        | Missing Features |
 | Huion Q620M            | Missing Features |
 | Wacom CTE-450          | Missing Features |
-| Wacom MTE-450          | Missing Features |
+| Wacom MTE-450          | Missing Features | Touch wheel is unsupported.
 | Wacom PTH-460          | Missing Features |
 | Wacom PTH-651          | Missing Features |
 | Wacom PTH-660          | Missing Features |
@@ -79,10 +79,10 @@
 | XP-Pen Deco Pro Medium | Missing Features |
 | XP-Pen Deco Pro Small  | Missing Features |
 | XP-Pen Star 06C        | Missing Features |
-| Huion 420              |      Broken      |
-| Huion H420             |      Broken      |
-| Wacom ISD-V4           |      Broken      | #394  |
-| XP-Pen G540            |      Broken      | #698  |
+| Huion 420              |      Broken      | WinUSB implementation required.
+| Huion H420             |      Broken      | WinUSB implementation required.
+| Wacom ISD-V4           |      Broken      | [#394](https://github.com/OpenTabletDriver/OpenTabletDriver/issues/394)
+| XP-Pen G540            |      Broken      | [#698](https://github.com/OpenTabletDriver/OpenTabletDriver/issues/698)
 | Huion G10T             |     Untested     |
 | Huion H950 P           |     Untested     |
 | Huion Inspiroy Q11K    |     Untested     |


### PR DESCRIPTION
Moving from projects to a file directly in the repository. Allows contributors to note information about the tablet(s) within their commits.