### PR TITLE
Fix Huion Q11K config

### DIFF
--- a/OpenTabletDriver/Configurations/Huion/Q11K.json
+++ b/OpenTabletDriver/Configurations/Huion/Q11K.json
@@ -34,7 +34,22 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {
-        "201": "HUION_TI64_\\d{6}$"
+        "201": "HUION_T164_\\d{6}$"
+      },
+      "InitializationStrings": [
+        200
+      ]
+    },
+    {
+      "VendorID": 9580,
+      "ProductID": 110,
+      "InputReportLength": 12,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Tablet.TabletReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "201": "HUION_T164_\\d{6}$"
       },
       "InitializationStrings": [
         200


### PR DESCRIPTION
Verification:
[discord](https://discord.com/channels/615607687467761684/615611007951306863/852586534594281553)
string changes are also supported by #864 

Somehow the string became `HUION_TI64_\\d{6}$` instead of `HUION_T164_\\d{6}$` (first one has an `I` instead of a `1`)

It appears that from the beginning (ce57b15745bce8500a0917d8069868b1b0c6c19d) the Q11K config has used `TI64` and I cannot find any verification anywhere that points to `HUION_TI64_\\d{6}$` being an actual string used on this tablet. It seems like the `I` was a typo when converting configs from hawku fork to OTD since even there it is listed as `T164`:
 (https://github.com/InfinityGhost/TabletDriver/blob/23a8aa0ff3f65dbc617c47ecd1285c26925e257b/TabletDriverService/config/huion.cfg#L145)