### PR TITLE
Add UGTABLET M708 configuration file

### DIFF
--- a/OpenTabletDriver/Configurations/UGTABLET/M708.json
+++ b/OpenTabletDriver/Configurations/UGTABLET/M708.json
@@ -1,0 +1,77 @@
+{
+  "Name": "UGTABLET M708",
+  "DigitizerIdentifiers": [
+    {
+      "Width": 254.0,
+      "Height": 152.4,
+      "MaxX": 50800.0,
+      "MaxY": 30480.0,
+      "MaxPressure": 8191,
+      "ActiveReportID": {
+        "Start": 80,
+        "StartInclusive": true,
+        "End": 96,
+        "EndInclusive": false
+      },
+      "VendorID": 10429,
+      "ProductID": 2311,
+      "InputReportLength": 12,
+      "OutputReportLength": 10,
+      "ReportParser": "OpenTabletDriver.Tablet.TabletReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": "ArAE",
+      "DeviceStrings": {
+        "4": "UG902_BPG1006"
+      },
+      "InitializationStrings": []
+    },
+    {
+      "Width": 254.0,
+      "Height": 152.4,
+      "MaxX": 50800.0,
+      "MaxY": 30480.0,
+      "MaxPressure": 8191,
+      "ActiveReportID": {
+        "Start": 64,
+        "StartInclusive": false,
+        "End": null,
+        "EndInclusive": false
+      },
+      "VendorID": 10429,
+      "ProductID": 2311,
+      "InputReportLength": 10,
+      "OutputReportLength": 8,
+      "ReportParser": "OpenTabletDriver.Tablet.TabletReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": "ArAE",
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    },
+    {
+      "Width": 254.0,
+      "Height": 152.4,
+      "MaxX": 50800.0,
+      "MaxY": 30480.0,
+      "MaxPressure": 8191,
+      "ActiveReportID": {
+        "Start": 80,
+        "StartInclusive": true,
+        "End": 96,
+        "EndInclusive": false
+      },
+      "VendorID": 10429,
+      "ProductID": 2311,
+      "InputReportLength": 12,
+      "OutputReportLength": 10,
+      "ReportParser": "OpenTabletDriver.Tablet.TabletReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": "ArAE",
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/OpenTabletDriver/Configurations/UGTABLET/M708.json
+++ b/OpenTabletDriver/Configurations/UGTABLET/M708.json
@@ -3,7 +3,7 @@
   "Specifications": {
     "Digitizer": {
       "Width": 254.0,
-      "Height": 154.5,
+      "Height": 152.4,
       "MaxX": 50800.0,
       "MaxY": 30480.0
     },

--- a/OpenTabletDriver/Configurations/UGTABLET/M708.json
+++ b/OpenTabletDriver/Configurations/UGTABLET/M708.json
@@ -1,11 +1,13 @@
 {
   "Name": "UGTABLET M708",
-  "DigitizerIdentifiers": [
-    {
+  "Specifications": {
+    "Digitizer": {
       "Width": 254.0,
-      "Height": 152.4,
+      "Height": 154.5,
       "MaxX": 50800.0,
-      "MaxY": 30480.0,
+      "MaxY": 30480.0
+    },
+    "Pen": {
       "MaxPressure": 8191,
       "ActiveReportID": {
         "Start": 80,
@@ -13,60 +15,29 @@
         "End": 96,
         "EndInclusive": false
       },
+      "Buttons": {
+        "ButtonCount": 2
+      }
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 8
+    },
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
       "VendorID": 10429,
       "ProductID": 2311,
       "InputReportLength": 12,
       "OutputReportLength": 10,
-      "ReportParser": "OpenTabletDriver.Tablet.TabletReportParser",
+      "ReportParser": "OpenTabletDriver.Vendors.XP_Pen.XP_PenTiltReportParser",
       "FeatureInitReport": null,
-      "OutputInitReport": "ArAE",
+      "OutputInitReport": [
+        "ArAE"
+      ],
       "DeviceStrings": {
         "4": "UG902_BPG1006"
       },
-      "InitializationStrings": []
-    },
-    {
-      "Width": 254.0,
-      "Height": 152.4,
-      "MaxX": 50800.0,
-      "MaxY": 30480.0,
-      "MaxPressure": 8191,
-      "ActiveReportID": {
-        "Start": 64,
-        "StartInclusive": false,
-        "End": null,
-        "EndInclusive": false
-      },
-      "VendorID": 10429,
-      "ProductID": 2311,
-      "InputReportLength": 10,
-      "OutputReportLength": 8,
-      "ReportParser": "OpenTabletDriver.Tablet.TabletReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": "ArAE",
-      "DeviceStrings": {},
-      "InitializationStrings": []
-    },
-    {
-      "Width": 254.0,
-      "Height": 152.4,
-      "MaxX": 50800.0,
-      "MaxY": 30480.0,
-      "MaxPressure": 8191,
-      "ActiveReportID": {
-        "Start": 80,
-        "StartInclusive": true,
-        "End": 96,
-        "EndInclusive": false
-      },
-      "VendorID": 10429,
-      "ProductID": 2311,
-      "InputReportLength": 12,
-      "OutputReportLength": 10,
-      "ReportParser": "OpenTabletDriver.Tablet.TabletReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": "ArAE",
-      "DeviceStrings": {},
       "InitializationStrings": []
     }
   ],

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -14,7 +14,7 @@
 | Huion Q11K             |    Supported     |
 | Huion WH1409 V2        |    Supported     |
 | UC-Logic 1060N         |    Supported     |
-| UGTABLET M&)*          |    Supported     |
+| UGTABLET M708          |    Supported     |
 | VEIKK A15              |    Supported     |
 | VEIKK S640             |    Supported     |
 | Wacom CTE-430          |    Supported     |

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -14,6 +14,7 @@
 | Huion Q11K             |    Supported     |
 | Huion WH1409 V2        |    Supported     |
 | UC-Logic 1060N         |    Supported     |
+| UGTABLET M&)*          |    Supported     |
 | VEIKK A15              |    Supported     |
 | VEIKK S640             |    Supported     |
 | Wacom CTE-430          |    Supported     |


### PR DESCRIPTION
An Edited configuration file from XP-PEN Deco 01 v2 to support UGTABLET M708
Notice: there are two variant M708 with different Vendor ID Product ID
Tilt, Tablet button not work.
pen button, Tip, pressure work.