### PR TITLE
Expose tilt to libinput (Linux evdev)

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -45,18 +45,18 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
 
             var xTilt = new input_absinfo
             {
-                minimum = -127,
-                maximum = 128,
-                resolution = 100
+                minimum = -64,
+                maximum = 63,
+                resolution = 57
             };
             input_absinfo* xTiltPtr = &xTilt;
             Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_TILT_X, (IntPtr)xTiltPtr);
 
             var yTilt = new input_absinfo
             {
-                minimum = -127,
-                maximum = 128,
-                resolution = 100
+                minimum = -64,
+                maximum = 63,
+                resolution = 57
             };
             input_absinfo* yTiltPtr = &yTilt;
             Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_TILT_Y, (IntPtr)yTiltPtr);

--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -43,6 +43,24 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
             input_absinfo* pressurePtr = &pressure;
             Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_PRESSURE, (IntPtr)pressurePtr);
 
+            var xTilt = new input_absinfo
+            {
+                minimum = -127,
+                maximum = 128,
+                resolution = 1 // units per radian
+            };
+            input_absinfo* xTiltPtr = &xTilt;
+            Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_TILT_X, (IntPtr)xTiltPtr);
+
+            var yTilt = new input_absinfo
+            {
+                minimum = -127,
+                maximum = 128,
+                resolution = 1 // units per radian
+            };
+            input_absinfo* yTiltPtr = &yTilt;
+            Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_TILT_Y, (IntPtr)yTiltPtr);
+
             Device.EnableTypeCodes(
                 EventType.EV_KEY,
                 EventCode.BTN_TOUCH,

--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -47,7 +47,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
             {
                 minimum = -127,
                 maximum = 128,
-                resolution = 1 // units per radian
+                resolution = 100
             };
             input_absinfo* xTiltPtr = &xTilt;
             Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_TILT_X, (IntPtr)xTiltPtr);
@@ -56,7 +56,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
             {
                 minimum = -127,
                 maximum = 128,
-                resolution = 1 // units per radian
+                resolution = 100
             };
             input_absinfo* yTiltPtr = &yTilt;
             Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_TILT_Y, (IntPtr)yTiltPtr);


### PR DESCRIPTION
Tilt doesn't work on Linux in Artist mode - this PR fixes that.

# How to verify/check for tilt compatibility:

1. Launch `libinput debug-gui`
2. Observe cursor dot stretching (or lack thereof) according to tilt

# Things to consider before merging

- Minimums and maximus are currently considered to be between -127 to 128 at 1 unit per degree, totaling 255 degrees, which probably doesn't make sense as I don't know of any tablets with more than 60 degrees of tilt per direction (totaling ~120 degrees). However, I doubt this causes any degree inaccuracy, given the `resolution` parameter exists.
    - It'd probably be worth adding `TiltResolution` (or similar naming) to tablet configuration files if any tablets have more than 1 unit per degree resolution. Support for this isn't included in the PR.
- ~~Krita does not seem to work with tilt done this way yet, investigating.~~ Fixed by increasing resolution from 1 to ~~100~~ 57