### PR TITLE
Linux Artist Mode: Refactor Eraser detection logic and expose Proximity to libinput

### DIFF
--- a/OpenTabletDriver.Desktop/Binding/PenPassthroughBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/PenPassthroughBinding.cs
@@ -19,8 +19,7 @@ namespace OpenTabletDriver.Desktop.Binding
             if (report is ITabletReport tabletReport)
             {
                 float pressure = (float)tabletReport.Pressure / (float)tablet.Properties.Specifications.Pen.MaxPressure;
-                bool isEraser = report is IEraserReport eraserReport ? eraserReport.Eraser : false;
-                Tablet.SetPressure(pressure, isEraser);
+                Tablet.SetPressure(pressure);
                 Tablet.SetButtonState(0, tabletReport.PenButtons[0]);
                 Tablet.SetButtonState(1, tabletReport.PenButtons[1]);
             }

--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -19,6 +19,8 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
         };
 
         private Vector2 ScreenScale = new Vector2(DesktopInterop.VirtualScreen.Width, DesktopInterop.VirtualScreen.Height);
+        private bool IsEraser = false;
+        private bool Proximity = true;
 
         public unsafe EvdevVirtualTablet()
         {
@@ -76,14 +78,14 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
         public void SetPosition(Vector2 pos)
         {
             var newPos = pos / ScreenScale * Max;
+            Device.Write(EventType.EV_KEY, IsEraser ? EventCode.BTN_TOOL_RUBBER : EventCode.BTN_TOOL_PEN, Proximity ? 1 : 0);
             Device.Write(EventType.EV_ABS, EventCode.ABS_X, (int)newPos.X);
             Device.Write(EventType.EV_ABS, EventCode.ABS_Y, (int)newPos.Y);
             Device.Sync();
         }
 
-        public void SetPressure(float percentage, bool isEraser)
+        public void SetPressure(float percentage)
         {
-            Device.Write(EventType.EV_KEY, isEraser ? EventCode.BTN_TOOL_RUBBER : EventCode.BTN_TOOL_PEN, 1);
             Device.Write(EventType.EV_KEY, EventCode.BTN_TOUCH, percentage > 0 ? 1 : 0);
             Device.Write(EventType.EV_ABS, EventCode.ABS_PRESSURE, (int)(MaxPressure * percentage));
             Device.Sync();
@@ -99,6 +101,18 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
         public void SetButtonState(uint button, bool active)
         {
             Device.Write(EventType.EV_KEY, BUTTONS[button], active ? 1 : 0);
+            Device.Sync();
+        }
+
+        public void SetEraser(bool isEraser)
+        {
+            IsEraser = isEraser;
+        }
+
+        public void SetProximity(bool proximity, uint distance)
+        {
+            Proximity = proximity;
+            Device.Write(EventType.EV_ABS, EventCode.ABS_DISTANCE, (int)distance);
             Device.Sync();
         }
 

--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -57,6 +57,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
                 EventCode.BTN_TOUCH,
                 EventCode.BTN_STYLUS,
                 EventCode.BTN_TOOL_PEN,
+                EventCode.BTN_TOOL_RUBBER,
                 EventCode.BTN_STYLUS2,
                 EventCode.BTN_STYLUS3
             );

--- a/OpenTabletDriver.Desktop/Output/LinuxArtistMode.cs
+++ b/OpenTabletDriver.Desktop/Output/LinuxArtistMode.cs
@@ -27,7 +27,8 @@ namespace OpenTabletDriver.Desktop.Output
             if (report is ITiltReport tiltReport)
                 VirtualTablet.SetTilt(tiltReport.Tilt);
 
-            VirtualTablet.SetEraser(report is IEraserReport); // FIXME: this is probably inefficient
+            if (report is IEraserReport eraserReport)
+                VirtualTablet.SetEraser(eraserReport.Eraser);
 
             if (report is IProximityReport proximityReport)
                 VirtualTablet.SetProximity(proximityReport.NearProximity, proximityReport.HoverDistance);

--- a/OpenTabletDriver.Desktop/Output/LinuxArtistMode.cs
+++ b/OpenTabletDriver.Desktop/Output/LinuxArtistMode.cs
@@ -26,6 +26,11 @@ namespace OpenTabletDriver.Desktop.Output
 
             if (report is ITiltReport tiltReport)
                 VirtualTablet.SetTilt(tiltReport.Tilt);
+
+            VirtualTablet.SetEraser(report is IEraserReport); // FIXME: this is probably inefficient
+
+            if (report is IProximityReport proximityReport)
+                VirtualTablet.SetProximity(proximityReport.NearProximity, proximityReport.HoverDistance);
         }
     }
 }

--- a/OpenTabletDriver.Plugin/Platform/Pointer/IVirtualTablet.cs
+++ b/OpenTabletDriver.Plugin/Platform/Pointer/IVirtualTablet.cs
@@ -4,8 +4,10 @@ namespace OpenTabletDriver.Plugin.Platform.Pointer
 {
     public interface IVirtualTablet : IAbsolutePointer
     {
-        void SetPressure(float percentage, bool isEraser);
+        void SetPressure(float percentage);
         void SetTilt(Vector2 tilt);
         void SetButtonState(uint button, bool active);
+        void SetEraser(bool isEraser);
+        void SetProximity(bool proximity, uint distance);
     }
 }


### PR DESCRIPTION
This PR adjusts some code quirks to bring it in line with what programs (particularly Linux' libinput) expects from a tablet driver, most notably changing when we emit the `BTN_TOOL_<name>` event (currently only pen and eraser).

Kernel documentation states:
> `BTN_TOOL_<name>` events must be reported when a stylus or other tool is active on the tablet

Pre-PR: This would only be set when pressure is applied, which deviates from this specification

Post-PR: This is instead set in `SetPosition()`, allowing for programs to detect the different tools before being put to use.

The Eraser variable is currently updated on every report, which can most likely be optimized.

As a part of the PR, proximity and hover distance is added and exposed to libinput as I don't know of another way to correctly report negative `BTN_TOOL_<name>` reports.

This has the side effect of effectively lowering hover distance on some tablets (at least on my GD-0608) as libinput will drop inputs when the device reports out of range.

This feature is from my current tablets perspective advantageous as it provides invalid tilt reports ("stuck" at last value) at extreme hover distances.

If the proximity feature is not desired I can remove it (or split it into its own PR for further analysis), and we'll most likely have to live with negative `BTN_TOOL_<name>` events never being reported to libinput, which I'd argue breaks spec.

Therefore, non-proximity based tablet owners that use Linux Artist Mode are encouraged to test out this PR.