### PR TITLE
PenPassthroughBinding: Enable pen barrel button functionality

### DIFF
--- a/OpenTabletDriver.Desktop/Binding/PenPassthroughBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/PenPassthroughBinding.cs
@@ -21,6 +21,8 @@ namespace OpenTabletDriver.Desktop.Binding
                 float pressure = (float)tabletReport.Pressure / (float)tablet.Properties.Specifications.Pen.MaxPressure;
                 bool isEraser = report is IEraserReport eraserReport ? eraserReport.Eraser : false;
                 Tablet.SetPressure(pressure, isEraser);
+                Tablet.SetButtonState(0, tabletReport.PenButtons[0]);
+                Tablet.SetButtonState(1, tabletReport.PenButtons[1]);
             }
         }
     }

--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -11,6 +11,11 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
     public class EvdevVirtualTablet : EvdevVirtualMouse, IAbsolutePointer, IVirtualTablet
     {
         private const int Max = 1 << 28;
+        private static readonly EventCode[] BUTTONS = { EventCode.BTN_STYLUS,
+                                              EventCode.BTN_STYLUS2,
+                                              EventCode.BTN_STYLUS3
+                                            };
+
         private Vector2 ScreenScale = new Vector2(DesktopInterop.VirtualScreen.Width, DesktopInterop.VirtualScreen.Height);
 
         public unsafe EvdevVirtualTablet()
@@ -86,6 +91,12 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
         {
             Device.Write(EventType.EV_ABS, EventCode.ABS_TILT_X, (int)tilt.X);
             Device.Write(EventType.EV_ABS, EventCode.ABS_TILT_Y, (int)tilt.Y);
+            Device.Sync();
+        }
+
+        public void SetButtonState(uint button, bool active)
+        {
+            Device.Write(EventType.EV_KEY, BUTTONS[button], active ? 1 : 0);
             Device.Sync();
         }
 

--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -11,10 +11,12 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
     public class EvdevVirtualTablet : EvdevVirtualMouse, IAbsolutePointer, IVirtualTablet
     {
         private const int Max = 1 << 28;
-        private static readonly EventCode[] BUTTONS = { EventCode.BTN_STYLUS,
-                                              EventCode.BTN_STYLUS2,
-                                              EventCode.BTN_STYLUS3
-                                            };
+        private static readonly EventCode[] BUTTONS =
+        {
+            EventCode.BTN_STYLUS,
+            EventCode.BTN_STYLUS2,
+            EventCode.BTN_STYLUS3
+        };
 
         private Vector2 ScreenScale = new Vector2(DesktopInterop.VirtualScreen.Width, DesktopInterop.VirtualScreen.Height);
 

--- a/OpenTabletDriver.Plugin/Platform/Pointer/IVirtualTablet.cs
+++ b/OpenTabletDriver.Plugin/Platform/Pointer/IVirtualTablet.cs
@@ -6,5 +6,6 @@ namespace OpenTabletDriver.Plugin.Platform.Pointer
     {
         void SetPressure(float percentage, bool isEraser);
         void SetTilt(Vector2 tilt);
+        void SetButtonState(uint button, bool active);
     }
 }


### PR DESCRIPTION
Pre-PR: When `Invoke()`'d, `PenPassthroughBinding` sets tip pressure and eraser state

Post-PR: We also set pen button states for `EvdevVirtualTablet`, enabling applications like Krita to use the barrel buttons via their native libinput button names (`BTN_STYLUS{,2,3}`).

It's tested working with Krita, and exposes the buttons as `BTN_STYLUS`, `BTN_STYLUS2` and `BTN_STYLUS3` as expected.

I have a feeling that setting every button state on a binding invocation is the incorrect way to go about it, so comments are appreciated.