### PR TITLE
Update TABLETS.md to support Wacom GD-0608-U

### DIFF
--- a/OpenTabletDriver/Configurations/Wacom/GD-0608-U.json
+++ b/OpenTabletDriver/Configurations/Wacom/GD-0608-U.json
@@ -16,7 +16,7 @@
         "EndInclusive": false
       },
       "Buttons": {
-        "ButtonCount": 0
+        "ButtonCount": 2
       }
     },
     "AuxiliaryButtons": {

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -45,6 +45,7 @@
 | Wacom CTL-690          |    Supported     |
 | Wacom FT-0405-U        |    Supported     |
 | Wacom GD-0405-U        |    Supported     |
+| Wacom GD-0608-U        |    Supported     |
 | Wacom XD-0608-U        |    Supported     |
 | XP-Pen CT430           |    Supported     |
 | XP-Pen Deco 01         |    Supported     |
@@ -115,7 +116,6 @@
 | Huion G10T             |     Untested     |
 | Huion osu! Tablet      |     Untested     |
 | Wacom CTE-440          |     Untested     |
-| Wacom GD-0608-U        |     Untested     |
 | Wacom GD-0912-U        |     Untested     |
 | Wacom GD-1218-U        |     Untested     |
 | Wacom PTH-851          |     Untested     |


### PR DESCRIPTION
Tested working:
- [x] Position
- [x] Pressure
- [x] Tilt
- [x] Hover Distance
- [x] Proximity
- [x] Pen Barrel Buttons

The hardware does not seem to indicate when the Eraser end is used (or is not live-indicated in reports), so it has no eraser support per se.