### PR TITLE
BindingHandler: Mangle pressure reports to account for thresholds

### DIFF
--- a/OpenTabletDriver.Desktop/Binding/ThresholdBindingState.cs
+++ b/OpenTabletDriver.Desktop/Binding/ThresholdBindingState.cs
@@ -1,4 +1,3 @@
-using OpenTabletDriver.Desktop.Reflection;
 using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Desktop.Binding
@@ -20,9 +19,8 @@ namespace OpenTabletDriver.Desktop.Binding
                 else // remap pressure when beyond threshold
                 {
                     var maxPressure = tablet.Properties.Specifications.Pen.MaxPressure;
-                    tabletReport.Pressure = (uint)(maxPressure *
-                                        ((value - ActivationThreshold) /
-                                         ( 100f - ActivationThreshold)));
+                    var remappedPressure = (value - ActivationThreshold) / (100f - ActivationThreshold);
+                    tabletReport.Pressure = (uint)(maxPressure * remappedPressure);
                 }
             }
 

--- a/OpenTabletDriver.Desktop/Binding/ThresholdBindingState.cs
+++ b/OpenTabletDriver.Desktop/Binding/ThresholdBindingState.cs
@@ -10,6 +10,22 @@ namespace OpenTabletDriver.Desktop.Binding
         public void Invoke(TabletReference tablet, IDeviceReport report, float value)
         {
             bool newState = value > ActivationThreshold;
+
+            if (report is ITabletReport tabletReport)
+            {
+                if (!newState)
+                {
+                    tabletReport.Pressure = 0;
+                }
+                else // remap pressure when beyond threshold
+                {
+                    var maxPressure = tablet.Properties.Specifications.Pen.MaxPressure;
+                    tabletReport.Pressure = (uint)(maxPressure *
+                                        ((value - ActivationThreshold) /
+                                         ( 100f - ActivationThreshold)));
+                }
+            }
+
             base.Invoke(tablet, report, newState);
         }
     }


### PR DESCRIPTION
`IInterruptBinding`s are currently invoked regardless of state, and has no way of knowing the pressure threshold, resulting in pressure threshold being useless for some bindings, such as `PenPassthroughBinding`.

By rewriting the pressure in the report we achieve correct behavior in `EvdevVirtualTablet`'s `SetPressure()` and allows tip and eraser thresholds to be effective even when using `IInterruptBinding`s.

This also has the additional side effect of only triggering `BTN_TOUCH` events in `EvdevVirtualTablet` when the pressure exceeds the users specified threshold, which would previously incorrectly trigger on tablets with noisy pressure reports.

# Pre-PR:
- `PenPassthroughBinding` ignores tip/eraser pressure threshold setting, confusing the user.
- `EvdevVirtualTablet` cannot see the tip/eraser pressure threshold setting, theoretically resulting in occasional incorrect clicks by triggering `BTN_TOUCH` whenever pressure isn't 0. While this technically didn't cause any misclicks (probably because of internal libinput thresholds), it can be interpreted as breaking spec by submitting `BTN_TOUCH` when the tool isn't actually in contact with the tablet:
> `BTN_TOUCH` should be used to report when the tool is in contact with the tablet.

[source](https://www.kernel.org/doc/Documentation/input/event-codes.txt)

# Post-PR:
- PenPassthroughBinding now only sees the adjusted tip pressure (ie. 51% input pressure at 50% threshold results in 2% output pressure)
- `BTN_TOUCH` is only actuated when the pressure threshold is exceeded.

# Other thoughts:

Rewriting tablet reports seems wrong, but it seems to be the only way to make pressure threshold behave as intended.

libinput's writeup on tablet support is a good read: https://wayland.freedesktop.org/libinput/doc/latest/tablet-support.html - it also explains that pressure is "zeroed" when the tool comes into proximity, which explains why the superfluous `BTN_TOUCH` events did not actually cause any harm.