### PR TITLE
Fix IntuosV1 parser not ignoring Intuos 1 tool reports

### DIFF
--- a/OpenTabletDriver/Vendors/Wacom/IntuosV1/IntuosV1ReportParser.cs
+++ b/OpenTabletDriver/Vendors/Wacom/IntuosV1/IntuosV1ReportParser.cs
@@ -20,7 +20,7 @@ namespace OpenTabletDriver.Vendors.Wacom.IntuosV1
 
         private IDeviceReport GetToolReport(byte[] report)
         {
-            if (report[1].IsBitSet(6))
+            if (report[1].IsBitSet(5))
                 return new IntuosV1TabletReport(report);
             
             return new DeviceReport(report);

--- a/OpenTabletDriver/Vendors/Wacom/IntuosV1/IntuosV1ReportParser.cs
+++ b/OpenTabletDriver/Vendors/Wacom/IntuosV1/IntuosV1ReportParser.cs
@@ -20,9 +20,11 @@ namespace OpenTabletDriver.Vendors.Wacom.IntuosV1
 
         private IDeviceReport GetToolReport(byte[] report)
         {
+            if (report[0] == 0x10 && report[1] == 0x20)
+                return new DeviceReport(report);
             if (report[1].IsBitSet(5))
                 return new IntuosV1TabletReport(report);
-            
+
             return new DeviceReport(report);
         }
     }


### PR DESCRIPTION
Pre-PR: Bringing any Intuos 1 tool (pen/eraser/airbrush) into proximity glitches the cursor, as the tablet report is handled as if it was a position report.

Post-PR: Tool reports instead fall through as a `DeviceReport` and do not trigger position events.

Fixes #1251 

Tablets that are affected with this change:

- Wacom/CTH-490
- Wacom/CTH-690
- Wacom/CTL-490
- Wacom/CTL-690
- Wacom/GD-0405-U
- Wacom/GD-0608-U
- Wacom/GD-0912-U
- Wacom/GD-1212-U
- Wacom/GD-1218-U
- Wacom/PTH-450
- Wacom/PTH-451
- Wacom/PTH-650
- Wacom/PTH-651
- Wacom/PTH-850
- Wacom/PTH-851
- Wacom/PTK-1240
- Wacom/PTK-440
- Wacom/PTK-450
- Wacom/PTK-540WL
- Wacom/PTK-640
- Wacom/PTK-650
- Wacom/PTK-840
- Wacom/XD-0405-U
- Wacom/XD-0608-U
- Wacom/XD-0912-U
- Wacom/XD-1212-U
- Wacom/XD-1218-U