### PR TITLE
Revert Veikk configs to SkipByteTabletReportParser

### DIFF
--- a/OpenTabletDriver/Configurations/VEIKK/A15 Pro.json
+++ b/OpenTabletDriver/Configurations/VEIKK/A15 Pro.json
@@ -25,7 +25,7 @@
       "ProductID": 6,
       "InputReportLength": 9,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Vendors.Veikk.VeikkReportParser",
+      "ReportParser": "OpenTabletDriver.Vendors.SkipByteTabletReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE"

--- a/OpenTabletDriver/Configurations/VEIKK/A15.json
+++ b/OpenTabletDriver/Configurations/VEIKK/A15.json
@@ -25,7 +25,7 @@
       "ProductID": 4,
       "InputReportLength": 9,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Vendors.Veikk.VeikkReportParser",
+      "ReportParser": "OpenTabletDriver.Vendors.SkipByteTabletReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE"

--- a/OpenTabletDriver/Configurations/VEIKK/A30.json
+++ b/OpenTabletDriver/Configurations/VEIKK/A30.json
@@ -25,7 +25,7 @@
       "ProductID": 2,
       "InputReportLength": 9,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Vendors.Veikk.VeikkReportParser",
+      "ReportParser": "OpenTabletDriver.Vendors.SkipByteTabletReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE"

--- a/OpenTabletDriver/Configurations/VEIKK/A50.json
+++ b/OpenTabletDriver/Configurations/VEIKK/A50.json
@@ -25,7 +25,7 @@
       "ProductID": 3,
       "InputReportLength": 9,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Vendors.Veikk.VeikkReportParser",
+      "ReportParser": "OpenTabletDriver.Vendors.SkipByteTabletReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE"

--- a/OpenTabletDriver/Configurations/VEIKK/S640.json
+++ b/OpenTabletDriver/Configurations/VEIKK/S640.json
@@ -23,7 +23,7 @@
       "ProductID": 1,
       "InputReportLength": 9,
       "OutputReportLength": 9,
-      "ReportParser": "OpenTabletDriver.Vendors.Veikk.VeikkReportParser",
+      "ReportParser": "OpenTabletDriver.Vendors.SkipByteTabletReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE"


### PR DESCRIPTION
The Veikk S640 has been confirmed to not work with `OpenTabletDriver.Vendors.Veikk.VeikkReportParser` and there is no verification that the remaining Veikk tablets (except the Veikk S640 V2 which remains unchanged in this PR) will work with `OpenTabletDriver.Vendors.Veikk.VeikkReportParser`.

The Veikk S640 must be reverted to `OpenTabletDriver.Vendors.SkipByteTabletReportParser` and I believe the others should as well due to lack of verification (as far as I am aware of) on the original change to `OpenTabletDriver.Vendors.Veikk.VeikkReportParser`.