### PR TITLE
Fix area resize

### DIFF
--- a/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Eto.Forms;
 using OpenTabletDriver.Desktop.Interop;
@@ -64,6 +63,7 @@ namespace OpenTabletDriver.UX.Controls.Output
             tabletWidth = SettingsBinding.Child(c => c.Tablet.Width);
             tabletHeight = SettingsBinding.Child(c => c.Tablet.Height);
 
+            tabletAreaEditor.LockAspectRatioChanged += HandleAspectRatioLock;
             displayWidth.DataValueChanged += HandleAspectRatioLock;
             displayHeight.DataValueChanged += HandleAspectRatioLock;
             tabletWidth.DataValueChanged += HandleAspectRatioLock;
@@ -117,10 +117,14 @@ namespace OpenTabletDriver.UX.Controls.Output
                 // Avoids looping
                 handlingArLock = true;
 
-                if ((sender == displayWidth || sender == tabletWidth) && prevDisplayWidth is float prevWidth)
+                if ((sender == displayWidth) && prevDisplayWidth is float prevWidth)
                     tabletWidth.DataValue *= displayWidth.DataValue / prevWidth;
-                else if ((sender == displayHeight || sender == tabletHeight) && prevDisplayHeight is float prevHeight)
+                else if ((sender == displayHeight) && prevDisplayHeight is float prevHeight)
                     tabletHeight.DataValue *= displayHeight.DataValue / prevHeight;
+                else if (sender == tabletAreaEditor || sender == tabletWidth)
+                    tabletHeight.DataValue = displayHeight.DataValue / displayWidth.DataValue * tabletWidth.DataValue;
+                else if (sender == tabletHeight)
+                    tabletWidth.DataValue = displayWidth.DataValue / displayHeight.DataValue * tabletHeight.DataValue;
 
                 prevDisplayWidth = displayWidth.DataValue;
                 prevDisplayHeight = displayHeight.DataValue;

--- a/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
@@ -117,14 +117,14 @@ namespace OpenTabletDriver.UX.Controls.Output
                 // Avoids looping
                 handlingArLock = true;
 
-                if ((sender == displayWidth) && prevDisplayWidth is float prevWidth)
-                    tabletWidth.DataValue *= displayWidth.DataValue / prevWidth;
-                else if ((sender == displayHeight) && prevDisplayHeight is float prevHeight)
-                    tabletHeight.DataValue *= displayHeight.DataValue / prevHeight;
-                else if (sender == tabletAreaEditor || sender == tabletWidth)
+                if (sender == tabletWidth || sender == tabletAreaEditor)
                     tabletHeight.DataValue = displayHeight.DataValue / displayWidth.DataValue * tabletWidth.DataValue;
                 else if (sender == tabletHeight)
                     tabletWidth.DataValue = displayWidth.DataValue / displayHeight.DataValue * tabletHeight.DataValue;
+                else if ((sender == displayWidth) && prevDisplayWidth is float prevWidth)
+                    tabletWidth.DataValue *= displayWidth.DataValue / prevWidth;
+                else if ((sender == displayHeight) && prevDisplayHeight is float prevHeight)
+                    tabletHeight.DataValue *= displayHeight.DataValue / prevHeight;
 
                 prevDisplayWidth = displayWidth.DataValue;
                 prevDisplayHeight = displayHeight.DataValue;


### PR DESCRIPTION
## Reproduction

1. Set area to something not equal to display aspect ratio.
2. Enable aspect ratio lock.

## Results

Pre-PR: Aspect ratio lock only applies when tablet width/height actually changes.

Post-PR: Aspect ratio lock immediately applies after pressing enabling aspect ratio lock.