### PR TITLE
Add Parblo Ninos S support

### DIFF
--- a/OpenTabletDriver/Configurations/Parblo/Parblo Ninos S.json
+++ b/OpenTabletDriver/Configurations/Parblo/Parblo Ninos S.json
@@ -1,0 +1,41 @@
+{
+  "Name": "Parblo Ninos S",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 152.4,
+      "Height": 101.6,
+      "MaxX": 24742.0,
+      "MaxY": 16379.0
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "Buttons": {
+        "ButtonCount": 2
+      }
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 5
+    },
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 1155,
+      "ProductID": 40966,
+      "InputReportLength": 10,
+      "OutputReportLength": 8,
+      "ReportParser": "OpenTabletDriver.Vendors.XP_Pen.XP_PenReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": [
+        "ArAE"
+      ],
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/OpenTabletDriver/Configurations/Parblo/Parblo Ninos S.json
+++ b/OpenTabletDriver/Configurations/Parblo/Parblo Ninos S.json
@@ -2,10 +2,10 @@
   "Name": "Parblo Ninos S",
   "Specifications": {
     "Digitizer": {
-      "Width": 152.4,
-      "Height": 101.6,
-      "MaxX": 24742.0,
-      "MaxY": 16379.0
+      "Width": 152.0,
+      "Height": 95.0,
+      "MaxX": 24743.0,
+      "MaxY": 16380.0
     },
     "Pen": {
       "MaxPressure": 8191,

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -60,6 +60,7 @@
 | XP-Pen Star G640S      |    Supported     |
 | XP-Pen Star G960S      |    Supported     |
 | XP-Pen Star G960S Plus |    Supported     |
+| Parblo Ninos S         |   Has Quirks     | Aux buttons are not in order
 | Artisul M0610 Pro      | Missing Features | Tablet buttons, tilt, and wheel are unsupported.
 | Gaomon M106K Pro       | Missing Features | Tilt is unsupported.
 | Gaomon M10K            | Missing Features | Wheel is unsupported.


### PR DESCRIPTION
## Verification

Personally tested.

## Quirks

Aux buttons are mapped out-of-order. Heavy smoothing.