### PR TITLE
Remove curly braces from RelativeOutputMode

### DIFF
--- a/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
@@ -139,9 +139,7 @@ namespace OpenTabletDriver.Plugin.Output
         protected override void OnOutput(IDeviceReport report)
         {
             if (report is IAbsolutePositionReport absReport)
-            {
                 Pointer.SetPosition(absReport.Position);
-            }
         }
     }
 }

--- a/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
@@ -139,7 +139,9 @@ namespace OpenTabletDriver.Plugin.Output
         protected override void OnOutput(IDeviceReport report)
         {
             if (report is IAbsolutePositionReport absReport)
+            {
                 Pointer.SetPosition(absReport.Position);
+            }
         }
     }
 }

--- a/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
@@ -95,9 +95,7 @@ namespace OpenTabletDriver.Plugin.Output
         protected override void OnOutput(IDeviceReport report)
         {
             if (report is IAbsolutePositionReport absReport)
-            {
                 Pointer.Translate(absReport.Position);
-            }
         }
     }
 }


### PR DESCRIPTION
To match the RelativeOutputMode.