### PR TITLE
Fix #1330

### DIFF
--- a/OpenTabletDriver/Vendors/Wacom/Bamboo/BambooReportParser.cs
+++ b/OpenTabletDriver/Vendors/Wacom/Bamboo/BambooReportParser.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using OpenTabletDriver.Plugin.Tablet;
 using OpenTabletDriver.Tablet;
 
@@ -16,7 +17,7 @@ namespace OpenTabletDriver.Vendors.Wacom.Bamboo
 
         private IDeviceReport GetToolReport(byte[] report)
         {
-            if (report[1].IsBitSet(4))
+            if (Unsafe.ReadUnaligned<ulong>(ref report[1])>0)
                 return new BambooTabletReport(report);
 
             return new BambooAuxReport(report);

--- a/OpenTabletDriver/Vendors/Wacom/Bamboo/BambooReportParser.cs
+++ b/OpenTabletDriver/Vendors/Wacom/Bamboo/BambooReportParser.cs
@@ -17,7 +17,7 @@ namespace OpenTabletDriver.Vendors.Wacom.Bamboo
 
         private IDeviceReport GetToolReport(byte[] report)
         {
-            if (Unsafe.ReadUnaligned<ulong>(ref report[1])<<16>0)
+            if ( (Unsafe.ReadUnaligned<ulong>(ref report[1]) << 16) > 0 )
                 return new BambooTabletReport(report);
 
             return new BambooAuxReport(report);

--- a/OpenTabletDriver/Vendors/Wacom/Bamboo/BambooReportParser.cs
+++ b/OpenTabletDriver/Vendors/Wacom/Bamboo/BambooReportParser.cs
@@ -17,7 +17,7 @@ namespace OpenTabletDriver.Vendors.Wacom.Bamboo
 
         private IDeviceReport GetToolReport(byte[] report)
         {
-            if (Unsafe.ReadUnaligned<ulong>(ref report[1])>0)
+            if (Unsafe.ReadUnaligned<ulong>(ref report[1])<<16>0)
                 return new BambooTabletReport(report);
 
             return new BambooAuxReport(report);

--- a/OpenTabletDriver/Vendors/Wacom/Bamboo/BambooTabletReport.cs
+++ b/OpenTabletDriver/Vendors/Wacom/Bamboo/BambooTabletReport.cs
@@ -17,7 +17,7 @@ namespace OpenTabletDriver.Vendors.Wacom.Bamboo
                 Y = Unsafe.ReadUnaligned<ushort>(ref report[4])
             };
 
-            Pressure = (uint)(report[6] | ((report[7] & 0x01) << 8));
+            Pressure = report[1].IsBitSet(6) ? 0 : (uint)(report[6] | ((report[7] & 0x01) << 8));
             Eraser = report[1].IsBitSet(5);
 
             PenButtons = new bool[]

--- a/OpenTabletDriver/Vendors/Wacom/Bamboo/BambooTabletReport.cs
+++ b/OpenTabletDriver/Vendors/Wacom/Bamboo/BambooTabletReport.cs
@@ -17,7 +17,7 @@ namespace OpenTabletDriver.Vendors.Wacom.Bamboo
                 Y = Unsafe.ReadUnaligned<ushort>(ref report[4])
             };
 
-            Pressure = report[1].IsBitSet(6) ? 0 : (uint)(report[6] | ((report[7] & 0x01) << 8));
+            Pressure = !report[1].IsBitSet(0) ? 0 : (uint)(report[6] | ((report[7] & 0x01) << 8));
             Eraser = report[1].IsBitSet(5);
 
             PenButtons = new bool[]


### PR DESCRIPTION
I am not completely sure, which bit this is. I this should be the 'detected pen tip' bit.

Also tested changes locally with the tablet debugger. Can confirm, that eraser and pen tip still work.

Fixes #1330