### PR TITLE
Add Huion HS64 V2 configuration

### DIFF
--- a/OpenTabletDriver/Configurations/Huion/HS64 V2.json
+++ b/OpenTabletDriver/Configurations/Huion/HS64 V2.json
@@ -1,0 +1,43 @@
+{
+  "Name": "Huion HS64 V2",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 160.0,
+      "Height": 102.0,
+      "MaxX": 32000.0,
+      "MaxY": 20400.0
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "Buttons": {
+        "ButtonCount": 2
+      }
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 4
+    },
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 9580,
+      "ProductID": 109,
+      "InputReportLength": 12,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Vendors.UCLogic.UCLogicReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "201": "HUION_T181_\\d{6}$"
+      },
+      "InitializationStrings": [
+        200
+      ]
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/OpenTabletDriver/Configurations/XP-Pen/Star 03.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/Star 03.json
@@ -45,7 +45,7 @@
       ],
       "DeviceStrings": {},
       "InitializationStrings": []
-    },
+    }
   ],
   "AuxilaryDeviceIdentifiers": [],
   "Attributes": {

--- a/OpenTabletDriver/Configurations/XP-Pen/Star 03.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/Star 03.json
@@ -45,6 +45,19 @@
       ],
       "DeviceStrings": {},
       "InitializationStrings": []
+    },
+    {
+      "VendorID": 10429,
+      "ProductID": 2311,
+      "InputReportLength": 12,
+      "OutputReportLength": 10,
+      "ReportParser": "OpenTabletDriver.Vendors.XP_Pen.XP_PenReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": [
+        "ArAE"
+      ],
+      "DeviceStrings": {},
+      "InitializationStrings": []
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver/Configurations/XP-Pen/Star 03.json
+++ b/OpenTabletDriver/Configurations/XP-Pen/Star 03.json
@@ -46,19 +46,6 @@
       "DeviceStrings": {},
       "InitializationStrings": []
     },
-    {
-      "VendorID": 10429,
-      "ProductID": 2311,
-      "InputReportLength": 12,
-      "OutputReportLength": 10,
-      "ReportParser": "OpenTabletDriver.Vendors.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": [
-        "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": []
-    }
   ],
   "AuxilaryDeviceIdentifiers": [],
   "Attributes": {


### PR DESCRIPTION
Seems to be the same as the normal HS64 but with a new device string.