### PR TITLE
Convert SendInput primitives to blittable types

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/WindowsAbsolutePointer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/WindowsAbsolutePointer.cs
@@ -23,17 +23,17 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
             );
         }
 
-        private static System.Threading.Timer timer;
+        private readonly static System.Threading.Timer timer;
         private static Vector2 ScreenToVirtualDesktop = new Vector2(DesktopInterop.VirtualScreen.Width, DesktopInterop.VirtualScreen.Height) / 65535;
 
-        public void SetPosition(Vector2 pos)
+        public unsafe void SetPosition(Vector2 pos)
         {
             var virtualDesktopCoords = pos / ScreenToVirtualDesktop;
 
-            inputs[0].U.mi.dwFlags = MOUSEEVENTF.ABSOLUTE | MOUSEEVENTF.MOVE | MOUSEEVENTF.VIRTUALDESK;
-            inputs[0].U.mi.dx = (int)virtualDesktopCoords.X;
-            inputs[0].U.mi.dy = (int)virtualDesktopCoords.Y;
-            SendInput(1, inputs, INPUT.Size);
+            mouseInput->dwFlags = MOUSEEVENTF.ABSOLUTE | MOUSEEVENTF.MOVE | MOUSEEVENTF.VIRTUALDESK;
+            mouseInput->dx = (int)virtualDesktopCoords.X;
+            mouseInput->dy = (int)virtualDesktopCoords.Y;
+            SendInput(1, input, INPUT.Size);
         }
     }
 }

--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/WindowsAbsolutePointer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/WindowsAbsolutePointer.cs
@@ -33,7 +33,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
             mouseInput->dwFlags = MOUSEEVENTF.ABSOLUTE | MOUSEEVENTF.MOVE | MOUSEEVENTF.VIRTUALDESK;
             mouseInput->dx = (int)virtualDesktopCoords.X;
             mouseInput->dy = (int)virtualDesktopCoords.Y;
-            SendInput(1, input, INPUT.Size);
+            SendInput(1, input, sizeof(INPUT));
         }
     }
 }

--- a/OpenTabletDriver.Desktop/Interop/Input/Keyboard/WindowsVirtualKeyboard.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Keyboard/WindowsVirtualKeyboard.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using OpenTabletDriver.Native.Windows;
 using OpenTabletDriver.Native.Windows.Input;
 using OpenTabletDriver.Plugin.Platform.Keyboard;
@@ -15,8 +16,10 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Keyboard
 
         public unsafe WindowsVirtualKeyboard()
         {
-            *input = new INPUT() { type = INPUT_TYPE.KEYBD_INPUT };
-            keyboardInput = INPUT.GetKeyboardInputPtr(input);
+            var pinnedBuffer = GC.AllocateArray<INPUT>(1, true);
+            input = (INPUT*)Unsafe.AsPointer(ref pinnedBuffer[0]);
+            input->type = INPUT_TYPE.KEYBD_INPUT;
+            keyboardInput = input->KeyboardInputPtr;
         }
 
         private unsafe void KeyEvent(string key, bool isPress)
@@ -31,7 +34,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Keyboard
                 time = 0
             };
 
-            SendInput(1, input, INPUT.Size);
+            SendInput(1, input, sizeof(INPUT));
         }
 
         public void Press(string key)

--- a/OpenTabletDriver.Desktop/Interop/Input/Keyboard/WindowsVirtualKeyboard.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Keyboard/WindowsVirtualKeyboard.cs
@@ -10,27 +10,28 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Keyboard
 
     public class WindowsVirtualKeyboard : IVirtualKeyboard
     {
-        private void KeyEvent(string key, bool isPress)
+        private readonly unsafe INPUT* input;
+        private readonly unsafe KEYBDINPUT* keyboardInput;
+
+        public unsafe WindowsVirtualKeyboard()
+        {
+            *input = new INPUT() { type = INPUT_TYPE.KEYBD_INPUT };
+            keyboardInput = INPUT.GetKeyboardInputPtr(input);
+        }
+
+        private unsafe void KeyEvent(string key, bool isPress)
         {
             var vk = EtoKeysymToVK[key];
-            var input = new INPUT
+
+            *keyboardInput = new KEYBDINPUT
             {
-                type = INPUT_TYPE.KEYBD_INPUT,
-                U = new InputUnion
-                {
-                    ki = new KEYBDINPUT
-                    {
-                        wVk = (short)vk,
-                        wScan = 0,
-                        dwFlags = isPress ? KEYEVENTF.KEYDOWN : KEYEVENTF.KEYUP,
-                        time = 0,
-                        dwExtraInfo = UIntPtr.Zero
-                    }
-                }
+                wVk = (short)vk,
+                wScan = 0,
+                dwFlags = isPress ? KEYEVENTF.KEYDOWN : KEYEVENTF.KEYUP,
+                time = 0
             };
 
-            var inputs = new INPUT[] { input };
-            SendInput((uint)inputs.Length, inputs, INPUT.Size);
+            SendInput(1, input, INPUT.Size);
         }
 
         public void Press(string key)

--- a/OpenTabletDriver.Desktop/Interop/Input/Relative/WindowsRelativePointer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Relative/WindowsRelativePointer.cs
@@ -11,15 +11,15 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Relative
     {
         private Vector2 error;
 
-        public void Translate(Vector2 delta)
+        public unsafe void Translate(Vector2 delta)
         {
             delta += error;
             error = new Vector2(delta.X % 1, delta.Y % 1);
 
-            inputs[0].U.mi.dwFlags = MOUSEEVENTF.MOVE;
-            inputs[0].U.mi.dx = (int)delta.X;
-            inputs[0].U.mi.dy = (int)delta.Y;
-            SendInput(1, inputs, INPUT.Size);
+            mouseInput->dwFlags = MOUSEEVENTF.MOVE;
+            mouseInput->dx = (int)delta.X;
+            mouseInput->dy = (int)delta.Y;
+            SendInput(1, input, INPUT.Size);
         }
     }
 }

--- a/OpenTabletDriver.Desktop/Interop/Input/Relative/WindowsRelativePointer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Relative/WindowsRelativePointer.cs
@@ -7,7 +7,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Relative
 {
     using static Windows;
 
-    public class WindowsRelativePointer : Input.WindowsVirtualMouse, IRelativePointer
+    public class WindowsRelativePointer : WindowsVirtualMouse, IRelativePointer
     {
         private Vector2 error;
 
@@ -19,7 +19,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Relative
             mouseInput->dwFlags = MOUSEEVENTF.MOVE;
             mouseInput->dx = (int)delta.X;
             mouseInput->dy = (int)delta.Y;
-            SendInput(1, input, INPUT.Size);
+            SendInput(1, input, sizeof(INPUT));
         }
     }
 }

--- a/OpenTabletDriver.Desktop/Interop/Input/WindowsVirtualMouse.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/WindowsVirtualMouse.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Runtime.CompilerServices;
 using OpenTabletDriver.Native.Windows;
 using OpenTabletDriver.Native.Windows.Input;
 using OpenTabletDriver.Plugin.Attributes;
@@ -15,15 +17,17 @@ namespace OpenTabletDriver.Desktop.Interop.Input
 
         public unsafe WindowsVirtualMouse()
         {
-            *input = new INPUT() { type = INPUT_TYPE.MOUSE_INPUT };
-            mouseInput = INPUT.GetMouseInputPtr(input);
+            var pinnedBuffer = GC.AllocateArray<INPUT>(1, true);
+            input = (INPUT*)Unsafe.AsPointer(ref pinnedBuffer[0]);
+            input->type = INPUT_TYPE.MOUSE_INPUT;
+            mouseInput = input->MouseInputPtr;
         }
 
         protected unsafe void MouseEvent(MOUSEEVENTF arg, uint dwData = 0)
         {
             mouseInput->dwFlags = arg;
             mouseInput->mouseData = dwData;
-            SendInput(1, input, INPUT.Size);
+            SendInput(1, input, sizeof(INPUT));
         }
 
         public void MouseDown(MouseButton button)

--- a/OpenTabletDriver.Desktop/Interop/Input/WindowsVirtualMouse.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/WindowsVirtualMouse.cs
@@ -1,4 +1,3 @@
-using System;
 using OpenTabletDriver.Native.Windows;
 using OpenTabletDriver.Native.Windows.Input;
 using OpenTabletDriver.Plugin.Attributes;
@@ -11,27 +10,20 @@ namespace OpenTabletDriver.Desktop.Interop.Input
     [PluginIgnore]
     public abstract class WindowsVirtualMouse : IVirtualMouse
     {
-        protected INPUT[] inputs = new INPUT[]
-        {
-            new INPUT
-            {
-                type = INPUT_TYPE.MOUSE_INPUT,
-                U = new InputUnion
-                {
-                    mi = new MOUSEINPUT
-                    {
-                        time = 0,
-                        dwExtraInfo = UIntPtr.Zero
-                    }
-                }
-            }
-        };
+        protected readonly unsafe INPUT* input;
+        protected readonly unsafe MOUSEINPUT* mouseInput;
 
-        protected void MouseEvent(MOUSEEVENTF arg, uint dwData = 0)
+        public unsafe WindowsVirtualMouse()
         {
-            inputs[0].U.mi.dwFlags = arg;
-            inputs[0].U.mi.mouseData = dwData;
-            SendInput(1, inputs, INPUT.Size);
+            *input = new INPUT() { type = INPUT_TYPE.MOUSE_INPUT };
+            mouseInput = INPUT.GetMouseInputPtr(input);
+        }
+
+        protected unsafe void MouseEvent(MOUSEEVENTF arg, uint dwData = 0)
+        {
+            mouseInput->dwFlags = arg;
+            mouseInput->mouseData = dwData;
+            SendInput(1, input, INPUT.Size);
         }
 
         public void MouseDown(MouseButton button)

--- a/OpenTabletDriver.Native/OpenTabletDriver.Native.csproj
+++ b/OpenTabletDriver.Native/OpenTabletDriver.Native.csproj
@@ -6,4 +6,8 @@
     <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup Label="32 bit compatibility">
+    <DefineConstants Condition="$(RuntimeIdentifier.Contains(x86)) Or $(Platform) == 'x86'">OTDPLATFORM32;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+
 </Project>

--- a/OpenTabletDriver.Native/Windows/Input/INPUT.cs
+++ b/OpenTabletDriver.Native/Windows/Input/INPUT.cs
@@ -1,13 +1,30 @@
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace OpenTabletDriver.Native.Windows.Input
 {
     [StructLayout(LayoutKind.Sequential)]
-    public struct INPUT
+    public unsafe struct INPUT
     {
         public INPUT_TYPE type;
-        public InputUnion U;
-        public static int Size => Marshal.SizeOf(typeof(INPUT));
+        public fixed byte data[28];
+
+        public static MOUSEINPUT* GetMouseInputPtr(INPUT* input)
+        {
+            return (MOUSEINPUT*)input->data;
+        }
+
+        public static KEYBDINPUT* GetKeyboardInputPtr(INPUT* input)
+        {
+            return (KEYBDINPUT*)input->data;
+        }
+
+        public static HARDWAREINPUT* GetHardwareInputPtr(INPUT* input)
+        {
+            return (HARDWAREINPUT*)input->data;
+        }
+
+        public static int Size => Unsafe.SizeOf<INPUT>();
     }
 
     public enum INPUT_TYPE

--- a/OpenTabletDriver.Native/Windows/Input/INPUT.cs
+++ b/OpenTabletDriver.Native/Windows/Input/INPUT.cs
@@ -7,27 +7,18 @@ namespace OpenTabletDriver.Native.Windows.Input
     public unsafe struct INPUT
     {
         public INPUT_TYPE type;
-        public fixed byte data[28];
-
-        public static MOUSEINPUT* GetMouseInputPtr(INPUT* input)
-        {
-            return (MOUSEINPUT*)input->data;
-        }
-
-        public static KEYBDINPUT* GetKeyboardInputPtr(INPUT* input)
-        {
-            return (KEYBDINPUT*)input->data;
-        }
-
-        public static HARDWAREINPUT* GetHardwareInputPtr(INPUT* input)
-        {
-            return (HARDWAREINPUT*)input->data;
-        }
-
-        public static int Size => Unsafe.SizeOf<INPUT>();
+#if OTDPLATFORM32
+        public fixed byte data[24];
+#else
+        private fixed byte padding[4];
+        public fixed byte data[32];
+#endif
+        public MOUSEINPUT* MouseInputPtr => (MOUSEINPUT*)Unsafe.AsPointer(ref data[0]);
+        public KEYBDINPUT* KeyboardInputPtr => (KEYBDINPUT*)Unsafe.AsPointer(ref data[0]);
+        public HARDWAREINPUT* HardwareInputPtr => (HARDWAREINPUT*)Unsafe.AsPointer(ref data[0]);
     }
 
-    public enum INPUT_TYPE
+    public enum INPUT_TYPE : uint
     {
         MOUSE_INPUT,
         KEYBD_INPUT,

--- a/OpenTabletDriver.Native/Windows/Input/KEYBDINPUT.cs
+++ b/OpenTabletDriver.Native/Windows/Input/KEYBDINPUT.cs
@@ -3,8 +3,6 @@ using System.Runtime.InteropServices;
 
 namespace OpenTabletDriver.Native.Windows.Input
 {
-    using Int16 = Int16;
-    using UInt32 = UInt32;
     using VirtualKeyShort = Int16;
     using ScanCodeShort = Int16;
 
@@ -15,6 +13,6 @@ namespace OpenTabletDriver.Native.Windows.Input
         public ScanCodeShort wScan;
         public KEYEVENTF dwFlags;
         public int time;
-        public UIntPtr dwExtraInfo;
+        public unsafe void* dwExtraInfo;
     }
 }

--- a/OpenTabletDriver.Native/Windows/Input/MOUSEINPUT.cs
+++ b/OpenTabletDriver.Native/Windows/Input/MOUSEINPUT.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Runtime.InteropServices;
 
 namespace OpenTabletDriver.Native.Windows.Input
@@ -11,6 +10,6 @@ namespace OpenTabletDriver.Native.Windows.Input
         public uint mouseData;
         public MOUSEEVENTF dwFlags;
         public uint time;
-        public UIntPtr dwExtraInfo;
+        public unsafe void* dwExtraInfo;
     }
 }

--- a/OpenTabletDriver.Native/Windows/Windows.cs
+++ b/OpenTabletDriver.Native/Windows/Windows.cs
@@ -30,7 +30,7 @@ namespace OpenTabletDriver.Native.Windows
 
         #region Input
 
-        [DllImport("user32.dll")]
+        [DllImport("user32.dll", ExactSpelling = true)]
         public static extern unsafe uint SendInput(uint nInputs, INPUT* pInputs, int cbSize);
 
         #endregion

--- a/OpenTabletDriver.Native/Windows/Windows.cs
+++ b/OpenTabletDriver.Native/Windows/Windows.cs
@@ -31,7 +31,7 @@ namespace OpenTabletDriver.Native.Windows
         #region Input
 
         [DllImport("user32.dll")]
-        public static extern uint SendInput(uint nInputs, [MarshalAs(UnmanagedType.LPArray), In] INPUT[] pInputs, int cbSize);
+        public static extern unsafe uint SendInput(uint nInputs, INPUT* pInputs, int cbSize);
 
         #endregion
 

--- a/OpenTabletDriver/SystemDrivers/DriverInfo.cs
+++ b/OpenTabletDriver/SystemDrivers/DriverInfo.cs
@@ -50,10 +50,17 @@ namespace OpenTabletDriver.SystemDrivers
                 new VeikkDriverInfoDriver(),
                 new OpenTabletDriverInfoProvider(),
                 new TabletDriverInfoProvider()
-            };
+            }.AsEnumerable();
 
             SystemProcesses = Process.GetProcesses();
-            ProcessModuleQueryableDriverInfoProvider.Refresh();
+            try
+            {
+                ProcessModuleQueryableDriverInfoProvider.Refresh();
+            }
+            catch
+            {
+                providers = providers.Where(p => p is not ProcessModuleQueryableDriverInfoProvider);
+            }
 
             // Remove "UC Logic" duplicates
             return providers.Select(provider => provider.GetDriverInfo())


### PR DESCRIPTION
## Changes

- Use fixed byte array for manual blitting of union structures.
- Remove unneeded keyboard SendInput allocation.
- Perform zero-copy SendInput by allowing the primitives to be blittable and not require further marshalling by CLR.

## Other changes

- Fix driver detection crash when running on 32-on-64 bit situations.
- Allow for 32 bit compatibility when `OTDPLATFORM32` constant is defined.