### PR TITLE
Do not setup device notification hooks on Windows 7 and below

### DIFF
--- a/OpenTabletDriver/Devices/WinUSB/WinUSBRootHub.cs
+++ b/OpenTabletDriver/Devices/WinUSB/WinUSBRootHub.cs
@@ -35,7 +35,16 @@ namespace OpenTabletDriver.Devices.WinUSB
         {
             _callback = NotificationCallback;
             _callbackPin = GCHandle.Alloc(_callback);
-            HookDeviceNotification();
+
+            if (OperatingSystem.IsWindowsVersionAtLeast(6, 2))
+            {
+                HookDeviceNotification();
+            }
+            else
+            {
+                Log.Write(nameof(WinUSBRootHub), $"Windows 7 does not support {nameof(WinUSBRootHub)} hotplug functionality.", LogLevel.Warning);
+                Log.Write(nameof(WinUSBRootHub), $"WinUSB device connections or disconnections won't be detected automatically and requires Daemon restart.", LogLevel.Warning);
+            }
 
             _currentDevices = new List<WinUSBInterface>();
 

--- a/OpenTabletDriver/Devices/WinUSB/WinUSBRootHub.cs
+++ b/OpenTabletDriver/Devices/WinUSB/WinUSBRootHub.cs
@@ -42,8 +42,8 @@ namespace OpenTabletDriver.Devices.WinUSB
             }
             else
             {
-                Log.Write(nameof(WinUSBRootHub), $"Windows 7 does not support {nameof(WinUSBRootHub)} hotplug functionality.", LogLevel.Warning);
-                Log.Write(nameof(WinUSBRootHub), $"WinUSB device connections or disconnections won't be detected automatically and require Daemon restart.", LogLevel.Warning);
+                Log.Write(nameof(WinUSBRootHub), $"{nameof(WinUSBRootHub)} does not support hotplug functionality for Windows 7 and below.", LogLevel.Warning);
+                Log.Write(nameof(WinUSBRootHub), $"WinUSB device connections or disconnections won't be detected automatically.", LogLevel.Warning);
             }
 
             _currentDevices = new List<WinUSBInterface>();

--- a/OpenTabletDriver/Devices/WinUSB/WinUSBRootHub.cs
+++ b/OpenTabletDriver/Devices/WinUSB/WinUSBRootHub.cs
@@ -43,7 +43,7 @@ namespace OpenTabletDriver.Devices.WinUSB
             else
             {
                 Log.Write(nameof(WinUSBRootHub), $"Windows 7 does not support {nameof(WinUSBRootHub)} hotplug functionality.", LogLevel.Warning);
-                Log.Write(nameof(WinUSBRootHub), $"WinUSB device connections or disconnections won't be detected automatically and requires Daemon restart.", LogLevel.Warning);
+                Log.Write(nameof(WinUSBRootHub), $"WinUSB device connections or disconnections won't be detected automatically and require Daemon restart.", LogLevel.Warning);
             }
 
             _currentDevices = new List<WinUSBInterface>();


### PR DESCRIPTION
## Changes

- Fixes daemon crash on Windows 7 and below.
- Log WinUSB warning when running on Windows 7 and below.