### PR TITLE
Add Huion 680S Configuration

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/680S.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/680S.json
@@ -1,0 +1,41 @@
+{
+  "Name": "Huion 680S",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 203.2,
+      "Height": 152.4,
+      "MaxX": 32000,
+      "MaxY": 24000
+    },
+    "Pen": {
+      "MaxPressure": 2047,
+      "Buttons": {
+        "ButtonCount": 2
+      }
+    },
+    "AuxiliaryButtons": null,
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 9580,
+      "ProductID": 110,
+      "InputReportLength": 64,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "6": "PenTablet"
+      },
+      "InitializationStrings": [
+        "100"
+      ]
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -11,6 +11,7 @@
 | Genius i608x                  |     Supported     | Require Zadig's WinUSB
 | Huion 1060 Plus               |     Supported     |
 | Huion 420                     |     Supported     | Windows: Requires Zadig's WinUSB to be installed on interface 0
+| Huion 680S                    |     Supported     | Windows: Requires Zadig's WinUSB to be installed on interface 0
 | Huion H420                    |     Supported     | Windows: Requires Zadig's WinUSB to be installed on interface 0
 | Huion H420X                   |     Supported     |
 | Huion H430P                   |     Supported     |


### PR DESCRIPTION
# Verification:

https://discord.com/channels/615607687467761684/885625611681419275/885653844057550928

# Note:

- Use WinUSB
- The device string was suggested by void but the Gaomon S56K has the same string at that index.
A proper device string need to be defined.

string dump: https://discord.com/channels/615607687467761684/885625611681419275/885647919494070322

# Tablet Owner / Contributor:

- matteshoe#4459