### PR TITLE
Reduce verbosity of dual loads in DesktopPluginManager.cs

### DIFF
--- a/OpenTabletDriver.Desktop/Reflection/DesktopPluginManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/DesktopPluginManager.cs
@@ -98,7 +98,7 @@ namespace OpenTabletDriver.Desktop.Reflection
             }
             else
             {
-                Log.Write("Plugin", $"Attempted to load the plugin {directory.Name} when it is already loaded.", LogLevel.Warning);
+                Log.Write("Plugin", $"Attempted to load the plugin {directory.Name} when it is already loaded.", LogLevel.Debug);
             }
         }
 


### PR DESCRIPTION
This info message seems to confuse normal users, and is likely only relevant for developers