### PR TITLE
Linux build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,6 @@ Required packages (some packages may be pre-installed for your distribution)
 - libx11
 - libxrandr
 - libevdev2
-
-On Fedora or some other distributions, libevdev2 may be present but may
-require a symlink as the name of the binary is different from what
-.NET expects.
-
-Symlink command used on Fedora 34:
-
-```
-sudo ln -s /lib64/libevdev.so.2 /lib64/libevdev.so
-```
-
 - GTK+3
 
 To build on Linux, run the provided 'build.sh' file. This will run the

--- a/README.md
+++ b/README.md
@@ -46,10 +46,23 @@ Required packages (some packages may be pre-installed for your distribution)
 
 - libx11
 - libxrandr
-- libevdev2 (on Fedora or some other systems, this library is present but may require a symlink as the name of the binary is different)
+- libevdev2
+
+On Fedora or some other distributions, libevdev2 may be present but may
+require a symlink as the name of the binary is different from what
+.NET expects.
+
+Symlink command used on Fedora 34:
+
+```
+sudo ln -s /lib64/libevdev.so.2 /lib64/libevdev.so
+```
+
 - GTK+3
 
-To build on Linux, run the provided 'build.sh' file. This will run the same 'dotnet publish' commands used for building the AUR package.
+To build on Linux, run the provided 'build.sh' file. This will run the
+same 'dotnet publish' commands used for building the AUR package, and
+will produce usable binaries in 'OpenTabletDriver/bin'.
 
 #### MacOS [Experimental]
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ To build on Linux, run the provided 'build.sh' file. This will run the
 same 'dotnet publish' commands used for building the AUR package, and
 will produce usable binaries in 'OpenTabletDriver/bin'.
 
+To build on ARM linux, run the provided 'build.sh' file with the
+appropriate runtime provided as an argument. For arm64, this is
+'linux-arm64'.
+
 #### MacOS [Experimental]
 
 No other dependencies.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The requirements to build OpenTabletDriver are consistent across all platforms. 
 
 ### All platforms
 
-- .NET 5 SDK
+- .NET 5 SDK (can be obtained from [here](https://dotnet.microsoft.com/download/dotnet/5.0) - You want the SDK for your platform, Linux users should install via package manager where possible, ensure package provides .NET 5)
 
 #### Windows
 
@@ -42,10 +42,14 @@ No other dependencies.
 
 #### Linux
 
+Required packages (some packages may be pre-installed for your distribution)
+
 - libx11
 - libxrandr
-- libevdev2
+- libevdev2 (on Fedora or some other systems, this library is present but may require a symlink as the name of the binary is different)
 - GTK+3
+
+To build on Linux, run the provided 'build.sh' file. This will run the same 'dotnet publish' commands used for building the AUR package.
 
 #### MacOS [Experimental]
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ To build on ARM linux, run the provided 'build.sh' file with the
 appropriate runtime provided as an argument. For arm64, this is
 'linux-arm64'.
 
+Note: If building for the first time, run the included
+generate-rules.sh script. This will generate a set of udev rules in
+OpenTabletDriver/bin, called '99-opentabletdriver.rules'. This file
+should then be moved to `/etc/udev/rules.d/`:
+
+```
+sudo mv ./bin/99-opentabletdriver.rules /etc/udev/rules.d/
+```
+
 #### MacOS [Experimental]
 
 No other dependencies.

--- a/build.sh
+++ b/build.sh
@@ -4,10 +4,10 @@
 # Uses the same commands as those found in the PKGBUILD for the AUR
 # package.
 
-echo "Building OpenTabletDriver. Projects may need restoration..."
+echo "Building OpenTabletDriver."
 mkdir ./bin
 
-echo "\nBuilding Daemon...\n"
+echo -e "\nBuilding Daemon...\n"
 dotnet publish OpenTabletDriver.Daemon     \
   --configuration   Release                \
   --framework       net5                   \
@@ -17,7 +17,7 @@ dotnet publish OpenTabletDriver.Daemon     \
   /p:SuppressNETCoreSdkPreviewMessage=true \
   /p:PublishTrimmed=false
 
-echo "\nBuilding Console...\n"
+echo -e "\nBuilding Console...\n"
 dotnet publish OpenTabletDriver.Console    \
   --configuration   Release                \
   --framework       net5                   \
@@ -27,7 +27,7 @@ dotnet publish OpenTabletDriver.Console    \
   /p:SuppressNETCoreSdkPreviewMessage=true \
   /p:PublishTrimmed=false
 
-echo "\nBuilding GTK UX...\n"
+echo -e "\nBuilding GTK UX...\n"
 dotnet publish OpenTabletDriver.UX.Gtk     \
   --configuration   Release                \
   --framework       net5                   \
@@ -38,3 +38,9 @@ dotnet publish OpenTabletDriver.UX.Gtk     \
   /p:PublishTrimmed=false
 
 echo "Build finished. Binaries created in './bin'"
+
+chmod +x ./bin/OpenTabletDriver.Daemon
+chmod +x ./bin/OpenTabletDriver.Console
+chmod +x ./bin/OpenTabletDriver.UX.Gtk
+
+echo "Binaries made executable. [DONE]"

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,7 @@
 # package.
 
 runtime=${1:-linux-x64}
+shift
 
 options=(--configuration='Release' --framework='net5' --self-contained='false' --output='./bin' /p:SuppressNETCoreSdkPreviewMessage=true /p:PublishTrimmed=false --runtime=$runtime)
 
@@ -12,12 +13,12 @@ echo "Building OpenTabletDriver with runtime $runtime."
 mkdir -p ./bin
 
 echo -e "\nBuilding Daemon...\n"
-dotnet publish OpenTabletDriver.Daemon ${options[@]}
+dotnet publish OpenTabletDriver.Daemon ${options[@]} $@
 
 echo -e "\nBuilding Console...\n"
-dotnet publish OpenTabletDriver.Console ${options[@]}
+dotnet publish OpenTabletDriver.Console ${options[@]} $@
 
 echo -e "\nBuilding GTK UX...\n"
-dotnet publish OpenTabletDriver.UX.Gtk ${options[@]}
+dotnet publish OpenTabletDriver.UX.Gtk ${options[@]} $@
 
 echo "Build finished. Binaries created in ./bin"

--- a/build.sh
+++ b/build.sh
@@ -5,30 +5,33 @@
 # package.
 
 echo "Building OpenTabletDriver..."
+mkdir ./out
 
-dotnet publish OpenTabletDriver.Daemon        \
-  --configuration   Release                   \
-  --framework       net5                      \
-  --runtime         linux-x64                 \
-  --self-contained  false                     \
-  --output          "./$_pkgname/out"         \
-  /p:SuppressNETCoreSdkPreviewMessage=true    \
+dotnet publish OpenTabletDriver.Daemon     \
+  --configuration   Release                \
+  --framework       net5                   \
+  --runtime         linux-x64              \
+  --self-contained  false                  \
+  --output          "./out"                \
+  /p:SuppressNETCoreSdkPreviewMessage=true \
   /p:PublishTrimmed=false
 
-dotnet publish OpenTabletDriver.Console       \
-  --configuration   Release                   \
-  --framework       net5                      \
-  --runtime         linux-x64                 \
-  --self-contained  false                     \
-  --output          "./$_pkgname/out"         \
-  /p:SuppressNETCoreSdkPreviewMessage=true    \
+dotnet publish OpenTabletDriver.Console    \
+  --configuration   Release                \
+  --framework       net5                   \
+  --runtime         linux-x64              \
+  --self-contained  false                  \
+  --output          "./out"                \
+  /p:SuppressNETCoreSdkPreviewMessage=true \
   /p:PublishTrimmed=false
 
-dotnet publish OpenTabletDriver.UX.Gtk        \
-  --configuration   Release                   \
-  --framework       net5                      \
-  --runtime         linux-x64                 \
-  --self-contained  false                     \
-  --output          "./$_pkgname/out"         \
-  /p:SuppressNETCoreSdkPreviewMessage=true    \
+dotnet publish OpenTabletDriver.UX.Gtk     \
+  --configuration   Release                \
+  --framework       net5                   \
+  --runtime         linux-x64              \
+  --self-contained  false                  \
+  --output          "./out"                \
+  /p:SuppressNETCoreSdkPreviewMessage=true \
   /p:PublishTrimmed=false
+
+echo "Build finished. Binaries created in ./out"

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Simple bash script to easily build on linux to verify functionality.
 # Uses the same commands as those found in the PKGBUILD for the AUR
@@ -6,24 +6,18 @@
 
 runtime=${1:-linux-x64}
 
-options=(--configuration='Release' --framework='net5' --self-contained='false' --output='./bin' /p:SuppressNETCoreSdkPreviewMessage=true /p:PublishTrimmed=false)
+options=(--configuration='Release' --framework='net5' --self-contained='false' --output='./bin' /p:SuppressNETCoreSdkPreviewMessage=true /p:PublishTrimmed=false --runtime=$runtime)
 
 echo "Building OpenTabletDriver with runtime $runtime."
 mkdir ./bin
 
 echo -e "\nBuilding Daemon...\n"
-dotnet publish OpenTabletDriver.Daemon ${options[@]} --runtime $runtime
+dotnet publish OpenTabletDriver.Daemon ${options[@]}
 
 echo -e "\nBuilding Console...\n"
-dotnet publish OpenTabletDriver.Console ${options[@]} --runtime $runtime
+dotnet publish OpenTabletDriver.Console ${options[@]}
 
 echo -e "\nBuilding GTK UX...\n"
-dotnet publish OpenTabletDriver.UX.Gtk ${options[@]} --runtime $runtime
+dotnet publish OpenTabletDriver.UX.Gtk ${options[@]}
 
 echo "Build finished. Binaries created in ./bin"
-
-chmod +x ./bin/OpenTabletDriver.Daemon
-chmod +x ./bin/OpenTabletDriver.Console
-chmod +x ./bin/OpenTabletDriver.UX.Gtk
-
-echo "Binaries made executable. [DONE]"

--- a/build.sh
+++ b/build.sh
@@ -4,9 +4,10 @@
 # Uses the same commands as those found in the PKGBUILD for the AUR
 # package.
 
-echo "Building OpenTabletDriver..."
+echo "Building OpenTabletDriver. Projects may need restoration..."
 mkdir ./bin
 
+echo "\nBuilding Daemon...\n"
 dotnet publish OpenTabletDriver.Daemon     \
   --configuration   Release                \
   --framework       net5                   \
@@ -16,6 +17,7 @@ dotnet publish OpenTabletDriver.Daemon     \
   /p:SuppressNETCoreSdkPreviewMessage=true \
   /p:PublishTrimmed=false
 
+echo "\nBuilding Console...\n"
 dotnet publish OpenTabletDriver.Console    \
   --configuration   Release                \
   --framework       net5                   \
@@ -25,6 +27,7 @@ dotnet publish OpenTabletDriver.Console    \
   /p:SuppressNETCoreSdkPreviewMessage=true \
   /p:PublishTrimmed=false
 
+echo "\nBuilding GTK UX...\n"
 dotnet publish OpenTabletDriver.UX.Gtk     \
   --configuration   Release                \
   --framework       net5                   \
@@ -34,4 +37,4 @@ dotnet publish OpenTabletDriver.UX.Gtk     \
   /p:SuppressNETCoreSdkPreviewMessage=true \
   /p:PublishTrimmed=false
 
-echo "Build finished. Binaries created in ./out"
+echo "Build finished. Binaries created in './bin'"

--- a/build.sh
+++ b/build.sh
@@ -4,19 +4,21 @@
 # Uses the same commands as those found in the PKGBUILD for the AUR
 # package.
 
-OPTIONS=--configuration Release --framework net5 --runtime linux-x64 --self-contained false --output "./bin" /p:SuppressNETCoreSdkPreviewMessage=true /p:PublishTrimmed=false
+runtime=${1:-linux-x64}
 
-echo "Building OpenTabletDriver."
+options="--configuration Release --framework net5 --self-contained false --output \"./bin\" /p:SuppressNETCoreSdkPreviewMessage=true /p:PublishTrimmed=false"
+
+echo "Building OpenTabletDriver with runtime $runtime."
 mkdir ./bin
 
 echo -e "\nBuilding Daemon...\n"
-dotnet publish OpenTabletDriver.Daemon $(OPTIONS)
+dotnet publish OpenTabletDriver.Daemon $options --runtime $runtime
 
 echo -e "\nBuilding Console...\n"
-dotnet publish OpenTabletDriver.Console $(OPTIONS)
+dotnet publish OpenTabletDriver.Console $options --runtime $runtime
 
 echo -e "\nBuilding GTK UX...\n"
-dotnet publish OpenTabletDriver.UX.Gtk $(OPTIONS)
+dotnet publish OpenTabletDriver.UX.Gtk $options --runtime $runtime
 
 echo "Build finished. Binaries created in './bin'"
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Simple bash script to easily build on linux to verify functionality.
+# Uses the same commands as those found in the PKGBUILD for the AUR
+# package.
+
+echo "Building OpenTabletDriver..."
+
+dotnet publish OpenTabletDriver.Daemon        \
+  --configuration   Release                   \
+  --framework       net5                      \
+  --runtime         linux-x64                 \
+  --self-contained  false                     \
+  --output          "./$_pkgname/out"         \
+  /p:SuppressNETCoreSdkPreviewMessage=true    \
+  /p:PublishTrimmed=false
+
+dotnet publish OpenTabletDriver.Console       \
+  --configuration   Release                   \
+  --framework       net5                      \
+  --runtime         linux-x64                 \
+  --self-contained  false                     \
+  --output          "./$_pkgname/out"         \
+  /p:SuppressNETCoreSdkPreviewMessage=true    \
+  /p:PublishTrimmed=false
+
+dotnet publish OpenTabletDriver.UX.Gtk        \
+  --configuration   Release                   \
+  --framework       net5                      \
+  --runtime         linux-x64                 \
+  --self-contained  false                     \
+  --output          "./$_pkgname/out"         \
+  /p:SuppressNETCoreSdkPreviewMessage=true    \
+  /p:PublishTrimmed=false

--- a/build.sh
+++ b/build.sh
@@ -5,14 +5,14 @@
 # package.
 
 echo "Building OpenTabletDriver..."
-mkdir ./out
+mkdir ./bin
 
 dotnet publish OpenTabletDriver.Daemon     \
   --configuration   Release                \
   --framework       net5                   \
   --runtime         linux-x64              \
   --self-contained  false                  \
-  --output          "./out"                \
+  --output          "./bin"                \
   /p:SuppressNETCoreSdkPreviewMessage=true \
   /p:PublishTrimmed=false
 
@@ -21,7 +21,7 @@ dotnet publish OpenTabletDriver.Console    \
   --framework       net5                   \
   --runtime         linux-x64              \
   --self-contained  false                  \
-  --output          "./out"                \
+  --output          "./bin"                \
   /p:SuppressNETCoreSdkPreviewMessage=true \
   /p:PublishTrimmed=false
 
@@ -30,7 +30,7 @@ dotnet publish OpenTabletDriver.UX.Gtk     \
   --framework       net5                   \
   --runtime         linux-x64              \
   --self-contained  false                  \
-  --output          "./out"                \
+  --output          "./bin"                \
   /p:SuppressNETCoreSdkPreviewMessage=true \
   /p:PublishTrimmed=false
 

--- a/build.sh
+++ b/build.sh
@@ -4,38 +4,19 @@
 # Uses the same commands as those found in the PKGBUILD for the AUR
 # package.
 
+OPTIONS=--configuration Release --framework net5 --runtime linux-x64 --self-contained false --output "./bin" /p:SuppressNETCoreSdkPreviewMessage=true /p:PublishTrimmed=false
+
 echo "Building OpenTabletDriver."
 mkdir ./bin
 
 echo -e "\nBuilding Daemon...\n"
-dotnet publish OpenTabletDriver.Daemon     \
-  --configuration   Release                \
-  --framework       net5                   \
-  --runtime         linux-x64              \
-  --self-contained  false                  \
-  --output          "./bin"                \
-  /p:SuppressNETCoreSdkPreviewMessage=true \
-  /p:PublishTrimmed=false
+dotnet publish OpenTabletDriver.Daemon $(OPTIONS)
 
 echo -e "\nBuilding Console...\n"
-dotnet publish OpenTabletDriver.Console    \
-  --configuration   Release                \
-  --framework       net5                   \
-  --runtime         linux-x64              \
-  --self-contained  false                  \
-  --output          "./bin"                \
-  /p:SuppressNETCoreSdkPreviewMessage=true \
-  /p:PublishTrimmed=false
+dotnet publish OpenTabletDriver.Console $(OPTIONS)
 
 echo -e "\nBuilding GTK UX...\n"
-dotnet publish OpenTabletDriver.UX.Gtk     \
-  --configuration   Release                \
-  --framework       net5                   \
-  --runtime         linux-x64              \
-  --self-contained  false                  \
-  --output          "./bin"                \
-  /p:SuppressNETCoreSdkPreviewMessage=true \
-  /p:PublishTrimmed=false
+dotnet publish OpenTabletDriver.UX.Gtk $(OPTIONS)
 
 echo "Build finished. Binaries created in './bin'"
 

--- a/build.sh
+++ b/build.sh
@@ -6,21 +6,21 @@
 
 runtime=${1:-linux-x64}
 
-options="--configuration Release --framework net5 --self-contained false --output \"./bin\" /p:SuppressNETCoreSdkPreviewMessage=true /p:PublishTrimmed=false"
+options=(--configuration='Release' --framework='net5' --self-contained='false' --output='./bin' /p:SuppressNETCoreSdkPreviewMessage=true /p:PublishTrimmed=false)
 
 echo "Building OpenTabletDriver with runtime $runtime."
 mkdir ./bin
 
 echo -e "\nBuilding Daemon...\n"
-dotnet publish OpenTabletDriver.Daemon $options --runtime $runtime
+dotnet publish OpenTabletDriver.Daemon ${options[@]} --runtime $runtime
 
 echo -e "\nBuilding Console...\n"
-dotnet publish OpenTabletDriver.Console $options --runtime $runtime
+dotnet publish OpenTabletDriver.Console ${options[@]} --runtime $runtime
 
 echo -e "\nBuilding GTK UX...\n"
-dotnet publish OpenTabletDriver.UX.Gtk $options --runtime $runtime
+dotnet publish OpenTabletDriver.UX.Gtk ${options[@]} --runtime $runtime
 
-echo "Build finished. Binaries created in './bin'"
+echo "Build finished. Binaries created in ./bin"
 
 chmod +x ./bin/OpenTabletDriver.Daemon
 chmod +x ./bin/OpenTabletDriver.Console


### PR DESCRIPTION
Create a build.sh file for linux systems to quickly and easily build the driver. This script uses the same commands as those used to build the AUR package.

Built binaries are created in [proj root]/bin, as an ignore exists for that dir already in .gitignore.

Done as a bash script to avoid dependence on 'make' or similar. Ideally this could also be used to build on MacOS (with an if to detect the difference), though I don't know enough about the setup on that OS to make this script handle that too (eg is the command still 'dotnet'?). Someone else who's more of a Mac guy could write that into this script afterwards.

This also updates the README with details about the script and some more minor info about the extra deps linux has.