### PR TITLE
Switch to console tab on daemon error

### DIFF
--- a/OpenTabletDriver.UX/Controls/ControlPanel.cs
+++ b/OpenTabletDriver.UX/Controls/ControlPanel.cs
@@ -78,13 +78,13 @@ namespace OpenTabletDriver.UX.Controls
 
             this.Content = tabControl;
 
-            Log.Output += (_, message) =>
+            Log.Output += (_, message) => Application.Instance.AsyncInvoke(() =>
             {
-                if(message.Level > LogLevel.Info)
+                if (message.Level > LogLevel.Info)
                 {
                     tabControl.SelectedPage = consoleTabPage;
                 }
-            };
+            });
         }
 
         private TabControl tabControl;

--- a/OpenTabletDriver.UX/Controls/ControlPanel.cs
+++ b/OpenTabletDriver.UX/Controls/ControlPanel.cs
@@ -17,6 +17,13 @@ namespace OpenTabletDriver.UX.Controls
 {
     public class ControlPanel : Panel
     {
+        private TabPage consoleTabPage = new TabPage
+        {
+            Text = "Console",
+            Padding = 5,
+            Content = new LogView()
+        };
+
         public ControlPanel()
         {
             tabControl = new TabControl
@@ -55,12 +62,7 @@ namespace OpenTabletDriver.UX.Controls
                         Padding = 5,
                         Content = toolEditor = new PluginSettingStoreCollectionEditor<ITool>()
                     },
-                    new TabPage
-                    {
-                        Text = "Console",
-                        Padding = 5,
-                        Content = new LogView()
-                    }
+                    consoleTabPage
                 }
             };
 
@@ -80,7 +82,7 @@ namespace OpenTabletDriver.UX.Controls
             {
                 if(message.Level > LogLevel.Info)
                 {
-                    tabControl.SelectedPage = tabControl.Pages.Last();  
+                    tabControl.SelectedPage = consoleTabPage;
                 }
             };
         }

--- a/OpenTabletDriver.UX/Controls/ControlPanel.cs
+++ b/OpenTabletDriver.UX/Controls/ControlPanel.cs
@@ -75,6 +75,14 @@ namespace OpenTabletDriver.UX.Controls
             outputModeEditor.SetDisplaySize(virtualScreen.Displays);
 
             this.Content = tabControl;
+
+            Log.Output += (_, message) =>
+            {
+                if(message.Level > LogLevel.Info)
+                {
+                    tabControl.SelectedPage = tabControl.Pages.Last();  
+                }
+            };
         }
 
         private TabControl tabControl;


### PR DESCRIPTION
Super tiny PR to make OTD swap to console tab whenever an error with LogLevel > Info happens (so anything that isn't a debug or info message). 

Tested via manually causing an error by installing an outdated plugin - switches to console tab as expected to show the error.

Fixes #1303 