### PR TITLE
Colorize entries in console tab based on LogLevel

### DIFF
--- a/OpenTabletDriver.UX/Controls/LogView.cs
+++ b/OpenTabletDriver.UX/Controls/LogView.cs
@@ -77,7 +77,7 @@ namespace OpenTabletDriver.UX.Controls
             };
 
             //Console coloring causes non-accelerated drawing on MacOS, cannot be done without performance hit
-            if (OpenTabletDriver.Interop.SystemInterop.CurrentPlatform != PluginPlatform.MacOS)
+            if (Interop.SystemInterop.CurrentPlatform != PluginPlatform.MacOS)
             {
                 messageList.CellFormatting += (_, entry) =>
                 {

--- a/OpenTabletDriver.UX/Controls/LogView.cs
+++ b/OpenTabletDriver.UX/Controls/LogView.cs
@@ -130,6 +130,7 @@ namespace OpenTabletDriver.UX.Controls
         private readonly GridView<LogMessage> messageList = new GridView<LogMessage>
         {
             AllowMultipleSelection = true,
+            GridLines = GridLines.None,
             Columns =
             {
                 new GridColumn

--- a/OpenTabletDriver.UX/Controls/LogView.cs
+++ b/OpenTabletDriver.UX/Controls/LogView.cs
@@ -99,8 +99,8 @@ namespace OpenTabletDriver.UX.Controls
                         entry.BackgroundColor = Colors.DarkRed;
                         break;
                     default:
-                        entry.ForegroundColor = Colors.Black;
-                        entry.BackgroundColor = Colors.White;
+                        entry.ForegroundColor = SystemColors.ControlText;
+                        entry.BackgroundColor = SystemColors.ControlBackground;
                         break;
                 }
 			};

--- a/OpenTabletDriver.UX/Controls/LogView.cs
+++ b/OpenTabletDriver.UX/Controls/LogView.cs
@@ -76,6 +76,35 @@ namespace OpenTabletDriver.UX.Controls
                 });
             };
 
+            messageList.CellFormatting += (_, entry) =>
+			{
+                var entryLogMessage = entry.Item as LogMessage;
+
+                switch (entryLogMessage.Level)
+                {
+                    case LogLevel.Debug:
+                        entry.ForegroundColor = Colors.Black;
+                        entry.BackgroundColor = Colors.LightBlue;
+                        break;
+                    case LogLevel.Warning:
+                        entry.ForegroundColor = Colors.Black;
+                        entry.BackgroundColor = Colors.Yellow;
+                        break;
+                    case LogLevel.Error:
+                        entry.ForegroundColor = Colors.Black;
+                        entry.BackgroundColor = Colors.Pink;
+                        break;
+                    case LogLevel.Fatal:
+                        entry.ForegroundColor = Colors.White;
+                        entry.BackgroundColor = Colors.DarkRed;
+                        break;
+                    default:
+                        entry.ForegroundColor = Colors.Black;
+                        entry.BackgroundColor = Colors.White;
+                        break;
+                }
+			};
+
             this.Items.Add(new StackLayoutItem(messageList, HorizontalAlignment.Stretch, true));
             this.Items.Add(new StackLayoutItem(toolbar, HorizontalAlignment.Stretch));
 

--- a/OpenTabletDriver.UX/Controls/LogView.cs
+++ b/OpenTabletDriver.UX/Controls/LogView.cs
@@ -76,34 +76,38 @@ namespace OpenTabletDriver.UX.Controls
                 });
             };
 
-            messageList.CellFormatting += (_, entry) =>
-			{
-                var entryLogMessage = entry.Item as LogMessage;
-
-                switch (entryLogMessage.Level)
+            //Console coloring causes non-accelerated drawing on MacOS, cannot be done without performance hit
+            if (OpenTabletDriver.Interop.SystemInterop.CurrentPlatform != PluginPlatform.MacOS)
+            {
+                messageList.CellFormatting += (_, entry) =>
                 {
-                    case LogLevel.Debug:
-                        entry.ForegroundColor = Colors.Black;
-                        entry.BackgroundColor = Colors.LightBlue;
-                        break;
-                    case LogLevel.Warning:
-                        entry.ForegroundColor = Colors.Black;
-                        entry.BackgroundColor = Colors.Yellow;
-                        break;
-                    case LogLevel.Error:
-                        entry.ForegroundColor = Colors.Black;
-                        entry.BackgroundColor = Colors.Pink;
-                        break;
-                    case LogLevel.Fatal:
-                        entry.ForegroundColor = Colors.White;
-                        entry.BackgroundColor = Colors.DarkRed;
-                        break;
-                    default:
-                        entry.ForegroundColor = SystemColors.ControlText;
-                        entry.BackgroundColor = SystemColors.ControlBackground;
-                        break;
-                }
-			};
+                    var entryLogMessage = entry.Item as LogMessage;
+
+                    switch (entryLogMessage.Level)
+                    {
+                        case LogLevel.Debug:
+                            entry.ForegroundColor = Colors.Black;
+                            entry.BackgroundColor = Colors.LightBlue;
+                            break;
+                        case LogLevel.Warning:
+                            entry.ForegroundColor = Colors.Black;
+                            entry.BackgroundColor = Colors.Yellow;
+                            break;
+                        case LogLevel.Error:
+                            entry.ForegroundColor = Colors.Black;
+                            entry.BackgroundColor = Colors.Pink;
+                            break;
+                        case LogLevel.Fatal:
+                            entry.ForegroundColor = Colors.White;
+                            entry.BackgroundColor = Colors.DarkRed;
+                            break;
+                        default:
+                            entry.ForegroundColor = SystemColors.ControlText;
+                            entry.BackgroundColor = SystemColors.ControlBackground;
+                            break;
+                    }
+                };
+            }
 
             this.Items.Add(new StackLayoutItem(messageList, HorizontalAlignment.Stretch, true));
             this.Items.Add(new StackLayoutItem(toolbar, HorizontalAlignment.Stretch));


### PR DESCRIPTION
A small enhancement PR to add code to colorize entries in the Console tab based on their LogLevel severity. Creates greater visual clarity (easy to spot errors quickly) and uses black text on light pastel colors to ensure readability with the exception of Fatal errors, which use white text on a dark red to really stand out.

An image of how it looks with different types of LogLevel messages printed out manually is attached. Open to feedback on the colors, and whether or not the Debug level should be colorized or remain black on white like Info still is.

![Console coloration](https://user-images.githubusercontent.com/10090332/139507727-702ee59e-5ff6-407e-a89c-cae9595aff34.png)
