### PR TITLE
BindingState: Only invoke IInterruptBinding handler when state has changed

### DIFF
--- a/OpenTabletDriver.Desktop/Binding/BindingState.cs
+++ b/OpenTabletDriver.Desktop/Binding/BindingState.cs
@@ -23,7 +23,8 @@ namespace OpenTabletDriver.Desktop.Binding
 
             if (Binding is IInterruptBinding interruptBinding)
             {
-                interruptBinding.Invoke(tablet, report);
+                if ((newState && !PreviousState) || (!newState && PreviousState))
+                    interruptBinding.Invoke(tablet, report);
             }
 
             PreviousState = newState;

--- a/OpenTabletDriver.Desktop/Binding/BindingState.cs
+++ b/OpenTabletDriver.Desktop/Binding/BindingState.cs
@@ -23,7 +23,7 @@ namespace OpenTabletDriver.Desktop.Binding
 
             if (Binding is IInterruptBinding interruptBinding)
             {
-                if ((newState && !PreviousState) || (!newState && PreviousState))
+                if (newState != PreviousState)
                     interruptBinding.Invoke(tablet, report);
             }
 


### PR DESCRIPTION
This caused some headaches in attempting to implement passthrough aux keys, as the binding handler seems to iterate over all aux keys bindings when any key is pressed, resulting in `IInterruptBinding`s being invoked when they weren't actually intended to be.

Pre-PR:
`IInterruptBinding`s are invoked if any key in the matrix is activated, even if that key itself isn't bound to it; ie if aux binding 1 (b1) has pen passthrough but aux binding 3 (b3) does not - clicking b3 still activated the pen passthrough feature.

Post-PR
`IInterruptBinding`s are only invoked when state has changed, likely resulting in more accurate results.

As a side note, if you're using a tablet which supports multiple held keys simultaneously, it is possible to get non-Passthrough buttons "stuck" in an activated state (using the example above, holding b3 while pressing b1, and then keeping b3 held while releasing b1 will result in the system thinking b3 is active until another pen passthrough aux report is parsed again)

This can also happen pre-PR on non-Aux `IInterruptBinding`s so this PR brings it more in line with `IStateBinding`s.