### PR TITLE
Always show most of UI even with no tablets detected

### DIFF
--- a/OpenTabletDriver.UX/Controls/ControlPanel.cs
+++ b/OpenTabletDriver.UX/Controls/ControlPanel.cs
@@ -62,11 +62,6 @@ namespace OpenTabletDriver.UX.Controls
                 }
             };
 
-            placeholder = new Placeholder
-            {
-                Text = "No tablets detected."
-            };
-
             outputModeEditor.ProfileBinding.Bind(ProfileBinding);
             penBindingEditor.ProfileBinding.Bind(ProfileBinding);
             auxBindingEditor.ProfileBinding.Bind(ProfileBinding);
@@ -80,7 +75,10 @@ namespace OpenTabletDriver.UX.Controls
         }
 
         private TabControl tabControl;
-        private readonly Placeholder placeholder;
+        private readonly Placeholder placeholder = new Placeholder
+        {
+            Text = "No tablets detected. Ensure a supported tablet is connected properly, and check the Console tab for any errors."
+        };
         private OutputModeEditor outputModeEditor;
         private BindingEditor penBindingEditor, auxBindingEditor, mouseBindingEditor;
         private PluginSettingStoreCollectionEditor<IPositionedPipelineElement<IDeviceReport>> filterEditor;

--- a/OpenTabletDriver.UX/Controls/ControlPanel.cs
+++ b/OpenTabletDriver.UX/Controls/ControlPanel.cs
@@ -62,6 +62,11 @@ namespace OpenTabletDriver.UX.Controls
                 }
             };
 
+            placeholder = new Placeholder
+            {
+                Text = "No tablets detected."
+            };
+
             outputModeEditor.ProfileBinding.Bind(ProfileBinding);
             penBindingEditor.ProfileBinding.Bind(ProfileBinding);
             auxBindingEditor.ProfileBinding.Bind(ProfileBinding);
@@ -75,6 +80,7 @@ namespace OpenTabletDriver.UX.Controls
         }
 
         private TabControl tabControl;
+        private readonly Placeholder placeholder;
         private OutputModeEditor outputModeEditor;
         private BindingEditor penBindingEditor, auxBindingEditor, mouseBindingEditor;
         private PluginSettingStoreCollectionEditor<IPositionedPipelineElement<IDeviceReport>> filterEditor;
@@ -100,9 +106,21 @@ namespace OpenTabletDriver.UX.Controls
             {
                 Application.Instance.AsyncInvoke(() => 
                 {
+                    tabControl.Pages.Single(p => p.Text == "Output").Content = outputModeEditor;
                     penBindingEditor.Parent.Visible = tablet.Properties.Specifications.Pen != null;
                     auxBindingEditor.Parent.Visible = tablet.Properties.Specifications.AuxiliaryButtons != null;
                     mouseBindingEditor.Parent.Visible = tablet.Properties.Specifications.MouseButtons != null;
+                });
+            }
+            else //no tablets connected, or Profile otherwise null
+            {
+                Application.Instance.AsyncInvoke(() =>
+                {
+                    tabControl.Pages.Single(p => p.Text == "Output").Content = placeholder;
+                    //hide the 3 tabs related to having a tablet connected
+                    penBindingEditor.Parent.Visible   = false;
+                    auxBindingEditor.Parent.Visible   = false;
+                    mouseBindingEditor.Parent.Visible = false;
                 });
             }
         }

--- a/OpenTabletDriver.UX/Controls/TabletSwitcherPanel.cs
+++ b/OpenTabletDriver.UX/Controls/TabletSwitcherPanel.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using Eto.Drawing;
 using Eto.Forms;
 using OpenTabletDriver.Desktop.Profiles;
-using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.UX.Controls
@@ -14,7 +13,7 @@ namespace OpenTabletDriver.UX.Controls
     {
         public TabletSwitcherPanel()
         {
-            base.Content = layout = new StackLayout
+            base.Content = new StackLayout
             {
                 HorizontalContentAlignment = HorizontalAlignment.Stretch,
                 Items =
@@ -56,8 +55,6 @@ namespace OpenTabletDriver.UX.Controls
             Application.Instance.AsyncInvoke(async () => HandleTabletsChanged(this, await App.Driver.Instance.GetTablets()));
         }
 
-        private StackLayout layout;
-        private Placeholder placeholder;
         private TabletSwitcher tabletSwitcher;
         private ControlPanel controlPanel;
         private Panel commandsPanel;
@@ -70,10 +67,6 @@ namespace OpenTabletDriver.UX.Controls
 
         private void HandleTabletsChanged(object sender, IEnumerable<TabletReference> tablets) => Application.Instance.AsyncInvoke(() =>
         {
-            this.Content = tablets.Any() ? layout : placeholder ??= new Placeholder
-            {
-                Text = "No tablets are detected."
-            };
             tabletSwitcher.HandleTabletsChanged(sender, tablets);
         });
 


### PR DESCRIPTION
This PR changes the structure of the UI to allow for showing the tab bar even when no tablets are connected.

Previously, the entire UI save for the "File, Tablets, etc" menubar would get blocked out by a placeholder, preventing the user from accessing the console tab or plugin tabs. This made it pretty hard to determine why, having to open up daemon.log manually and all that.

Combined with #1564, this allows us to show the user errors in the console tab even if we can't detect a tablet, this lets error messages like "OEM drivers are installed" and the like to be visible. No more having to pop up a message box. With #1564 it even will flip the tab to console upon such an error, so everything works smoothly.

This is how it looks now:

![New-No-Tablets-Screen](https://user-images.githubusercontent.com/10090332/139706681-239ff3a0-62ba-441d-af1c-67cba2de7bca.png)

As you can see, only the Output tab's content itself is placeholdered. The aux, pen and mouse binding tabs are also hidden when no tablets are detected, as expected. Everything else, the plugin tabs (can still un/install plugins or configure them as that doesn't require a tablet), the profile switcher, the console tab, etc is all still visible and usable.

As soon as a tablet is successfully detected, the output tab is returned to normal and the aforementioned binding tabs are shown as fitting for the tablet (no change from current behavior).

Testing - Tested on GTK (Linux) by starting the UI without a tablet plugged in, plugging in a tablet, then unplugging the tablet. All works. 

Fixes #1405 