### PR TITLE
Fix CT430 formatting error on the feature init line

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/CT430.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/CT430.json
@@ -24,9 +24,7 @@
       "InputReportLength": 12,
       "OutputReportLength": 10,
       "ReportParser": "OpenTabletDriver.Vendors.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": [
-        null
-      ],
+      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
       ],


### PR DESCRIPTION
Fixed a formatting error in the XP-PEN CT430 config.