### PR TITLE
Add try/catch to prevent crashing when OTD can't save settings/tablet configs

### DIFF
--- a/OpenTabletDriver.Desktop/Settings.cs
+++ b/OpenTabletDriver.Desktop/Settings.cs
@@ -154,7 +154,7 @@ namespace OpenTabletDriver.Desktop
             }
             catch (System.UnauthorizedAccessException)
             {
-                Log.Write("Settings", "OpenTabletDriver doesn't have permission to save persistent settings.", LogLevel.Error);
+                Log.Write("Settings", $"OpenTabletDriver doesn't have permission to save persistent settings to {file.DirectoryName}", LogLevel.Error);
             }
         }
 

--- a/OpenTabletDriver.Desktop/Settings.cs
+++ b/OpenTabletDriver.Desktop/Settings.cs
@@ -1,9 +1,7 @@
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
-using System.Linq;
 using System.Text.RegularExpressions;
+using System;
 using Newtonsoft.Json;
 using OpenTabletDriver.Desktop.Migration;
 using OpenTabletDriver.Desktop.Profiles;
@@ -152,7 +150,7 @@ namespace OpenTabletDriver.Desktop
                 using (var jw = new JsonTextWriter(sw))
                     serializer.Serialize(jw, this);
             }
-            catch (System.UnauthorizedAccessException)
+            catch (UnauthorizedAccessException)
             {
                 Log.Write("Settings", $"OpenTabletDriver doesn't have permission to save persistent settings to {file.DirectoryName}", LogLevel.Error);
             }

--- a/OpenTabletDriver.Desktop/Settings.cs
+++ b/OpenTabletDriver.Desktop/Settings.cs
@@ -143,12 +143,19 @@ namespace OpenTabletDriver.Desktop
 
         public void Serialize(FileInfo file)
         {
-            if (file.Exists)
-                file.Delete();
+            try
+            {
+                if (file.Exists)
+                    file.Delete();
 
-            using (var sw = file.CreateText())
-            using (var jw = new JsonTextWriter(sw))
-                serializer.Serialize(jw, this);
+                using (var sw = file.CreateText())
+                using (var jw = new JsonTextWriter(sw))
+                    serializer.Serialize(jw, this);
+            }
+            catch (System.UnauthorizedAccessException)
+            {
+                Log.Write("Settings", "OpenTabletDriver doesn't have permission to save persistent settings.", LogLevel.Error);
+            }
         }
 
         #endregion

--- a/OpenTabletDriver.UX/Windows/Configurations/ConfigurationEditor.cs
+++ b/OpenTabletDriver.UX/Windows/Configurations/ConfigurationEditor.cs
@@ -158,7 +158,9 @@ namespace OpenTabletDriver.UX.Windows.Configurations
                     if (!file.Directory.Exists)
                         file.Directory.Create();
                     Serialization.Serialize(file, config);
-                } catch (System.UnauthorizedAccessException) {
+                } 
+                catch (UnauthorizedAccessException)
+                {
                     Log.Write("Configuration", $"OpenTabletDriver doesn't have permission to save persistent tablet config to {path}.", LogLevel.Error);
                 }
             }

--- a/OpenTabletDriver.UX/Windows/Configurations/ConfigurationEditor.cs
+++ b/OpenTabletDriver.UX/Windows/Configurations/ConfigurationEditor.cs
@@ -159,7 +159,7 @@ namespace OpenTabletDriver.UX.Windows.Configurations
                         file.Directory.Create();
                     Serialization.Serialize(file, config);
                 } catch (System.UnauthorizedAccessException) {
-                    Log.Write("Configuration", "OpenTabletDriver doesn't have permission to save persistent tablet configs.", LogLevel.Error);
+                    Log.Write("Configuration", $"OpenTabletDriver doesn't have permission to save persistent tablet config to {path}.", LogLevel.Error);
                 }
             }
         }

--- a/OpenTabletDriver.UX/Windows/Configurations/ConfigurationEditor.cs
+++ b/OpenTabletDriver.UX/Windows/Configurations/ConfigurationEditor.cs
@@ -153,9 +153,14 @@ namespace OpenTabletDriver.UX.Windows.Configurations
 
                 var path = Path.Join(dir.FullName, manufacturer, string.Format("{0}.json", tabletName));
                 var file = new FileInfo(path);
-                if (!file.Directory.Exists)
-                    file.Directory.Create();
-                Serialization.Serialize(file, config);
+                try
+                {
+                    if (!file.Directory.Exists)
+                        file.Directory.Create();
+                    Serialization.Serialize(file, config);
+                } catch (System.UnauthorizedAccessException) {
+                    Log.Write("Configuration", "OpenTabletDriver doesn't have permission to save persistent tablet configs.", LogLevel.Error);
+                }
             }
         }
 


### PR DESCRIPTION
Tiny PR to add an exception catch to Settings.Serialize to handle "no permissions" exception. Prints a log message to console instead, as per InfinityGhost's request [here](https://github.com/OpenTabletDriver/OpenTabletDriver/issues/860#issuecomment-798919593).

Tested via denying myself permission to create/delete files in the config dir (~/.config/OpenTabletDriver), and trying to save settings. Prints log error, doesn't crash, still applies settings.

Fixes #860 