### PR TITLE
Replace manual ReportParserProvider with fast reflection

### DIFF
--- a/OpenTabletDriver.Benchmarks/Parser/ReportParserProviderConstructBenchmark.cs
+++ b/OpenTabletDriver.Benchmarks/Parser/ReportParserProviderConstructBenchmark.cs
@@ -1,0 +1,17 @@
+using BenchmarkDotNet.Attributes;
+using OpenTabletDriver.ComponentProviders;
+
+namespace OpenTabletDriver.Benchmarks.Parser
+{
+    [DryJob]
+    public class ReportParserProviderBenchmark
+    {
+        public ReportParserProvider ReportParserProvider;
+
+        [Benchmark]
+        public void ConstructReportParserProvider()
+        {
+            ReportParserProvider = new ReportParserProvider();
+        }
+    }
+}

--- a/OpenTabletDriver.Tests/ReportParserProviderTest.cs
+++ b/OpenTabletDriver.Tests/ReportParserProviderTest.cs
@@ -1,0 +1,31 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTabletDriver.Plugin.Components;
+using OpenTabletDriver.Tablet;
+using OpenTabletDriver.Vendors.XP_Pen;
+using Xunit;
+
+namespace OpenTabletDriver.Tests
+{
+    public class ReportParserProviderTest
+    {
+        public static TheoryData<string, Type> ReportParserProvider_CanGet_ReportParsers_Data => new()
+        {
+            { typeof(TabletReportParser).FullName!, typeof(TabletReportParser) },
+            { typeof(XP_PenReportParser).FullName!, typeof(XP_PenReportParser) }
+        };
+
+        [Theory]
+        [MemberData(nameof(ReportParserProvider_CanGet_ReportParsers_Data))]
+        public void ReportParserProvider_CanGet_ReportParsers(string reportParserName, Type expectedReportParserType)
+        {
+            var serviceCollection = new DriverServiceCollection();
+            var reportParserProvider = serviceCollection.BuildServiceProvider()
+                .GetRequiredService<IReportParserProvider>();
+
+            var reportParserType = reportParserProvider.GetReportParser(reportParserName).GetType();
+
+            Assert.Equal(expectedReportParserType, reportParserType);
+        }
+    }
+}

--- a/OpenTabletDriver/ComponentProviders/ReportParserProvider.cs
+++ b/OpenTabletDriver/ComponentProviders/ReportParserProvider.cs
@@ -1,38 +1,32 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using OpenTabletDriver.Plugin.Components;
 using OpenTabletDriver.Plugin.Tablet;
-using OpenTabletDriver.Tablet;
 
 namespace OpenTabletDriver.ComponentProviders
 {
     public class ReportParserProvider : IReportParserProvider
     {
-        private static readonly Dictionary<string, Func<IReportParser<IDeviceReport>>> _reportParsers = new()
+        private readonly Dictionary<string, Func<IReportParser<IDeviceReport>>> _reportParsers;
+
+        public ReportParserProvider()
         {
-            { typeof(AuxReportParser).FullName, () => new AuxReportParser() },
-            { typeof(PassthroughReportParser).FullName, () => new PassthroughReportParser() },
-            { typeof(TabletReportParser).FullName, () => new TabletReportParser() },
-            { typeof(TiltTabletReportParser).FullName, () => new TiltTabletReportParser() },
-            { typeof(Vendors.Huion.GianoReportParser).FullName, () => new Vendors.Huion.GianoReportParser() },
-            { typeof(Vendors.SkipByteTabletReportParser).FullName, () => new Vendors.SkipByteTabletReportParser() },
-            { typeof(Vendors.UCLogic.UCLogicReportParser).FullName, () => new Vendors.UCLogic.UCLogicReportParser() },
-            { typeof(Vendors.Veikk.VeikkReportParser).FullName, () => new Vendors.Veikk.VeikkReportParser() },
-            { typeof(Vendors.Wacom.Bamboo.BambooReportParser).FullName, () => new Vendors.Wacom.Bamboo.BambooReportParser() },
-            { typeof(Vendors.Wacom.Intuos.IntuosReportParser).FullName, () => new Vendors.Wacom.Intuos.IntuosReportParser() },
-            { typeof(Vendors.Wacom.Intuos.WacomDriverIntuosReportParser).FullName, () => new Vendors.Wacom.Intuos.WacomDriverIntuosReportParser() },
-            { typeof(Vendors.Wacom.Intuos3.Intuos3ReportParser).FullName, () => new Vendors.Wacom.Intuos3.Intuos3ReportParser() },
-            { typeof(Vendors.Wacom.IntuosV1.IntuosV1ReportParser).FullName, () => new Vendors.Wacom.IntuosV1.IntuosV1ReportParser() },
-            { typeof(Vendors.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser).FullName, () => new Vendors.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser() },
-            { typeof(Vendors.Wacom.IntuosV2.IntuosV2ReportParser).FullName, () => new Vendors.Wacom.IntuosV2.IntuosV2ReportParser() },
-            { typeof(Vendors.Wacom.IntuosV2.WacomDriverIntuosV2ReportParser).FullName, () => new Vendors.Wacom.IntuosV2.WacomDriverIntuosV2ReportParser() },
-            { typeof(Vendors.Wacom.Wacom64bAuxReportParser).FullName, () => new Vendors.Wacom.Wacom64bAuxReportParser() },
-            { typeof(Vendors.XP_Pen.XP_PenReportParser).FullName, () => new Vendors.XP_Pen.XP_PenReportParser() }
-        };
+            _reportParsers = typeof(ReportParserProvider).Assembly.ExportedTypes
+                .Where(t => t.IsAssignableTo(typeof(IReportParser<IDeviceReport>)))
+                .ToDictionary(
+                    t => t.FullName,
+                    t => GetConstructor(t));
+        }
 
         public IReportParser<IDeviceReport> GetReportParser(string reportParserName)
         {
             return _reportParsers[reportParserName].Invoke();
+        }
+
+        private static Func<IReportParser<IDeviceReport>> GetConstructor(Type reportParserType)
+        {
+            return () => (IReportParser<IDeviceReport>)Activator.CreateInstance(reportParserType);
         }
     }
 }


### PR DESCRIPTION
## Changes

- Changed manual references to report parser types with a reflection-based one.
- Added benchmark for report parser provider construction.
- Added test for report parser provider.
- Fixes missing report parsers from default report parser provider.