### PR TITLE
Explicitly use librt.so.1

### DIFF
--- a/OpenTabletDriver.Native/Linux/Timers/Timers.cs
+++ b/OpenTabletDriver.Native/Linux/Timers/Timers.cs
@@ -8,16 +8,18 @@ namespace OpenTabletDriver.Native.Linux.Timers
 
     public static class Timers
     {
-        [DllImport("librt", EntryPoint = "timer_create", SetLastError = true)]
+        private const string librt = "librt.so.1";
+
+        [DllImport(librt, EntryPoint = "timer_create", SetLastError = true)]
         public static extern ERRNO TimerCreate(ClockID clockID, ref SigEvent eventPtr, out IntPtr timerID);
 
-        [DllImport("librt", EntryPoint = "timer_settime", SetLastError = true)]
+        [DllImport(librt, EntryPoint = "timer_settime", SetLastError = true)]
         public static extern ERRNO TimerSetTime(IntPtr timerID, TimerFlag flags, ref TimerSpec newValue, ref TimerSpec oldValue);
 
-        [DllImport("librt", EntryPoint = "timer_settime", SetLastError = true)]
+        [DllImport(librt, EntryPoint = "timer_settime", SetLastError = true)]
         public static extern ERRNO TimerSetTime(IntPtr timerID, TimerFlag flags, ref TimerSpec newValue, IntPtr oldValue);
 
-        [DllImport("librt", EntryPoint = "timer_delete", SetLastError = true)]
+        [DllImport(librt, EntryPoint = "timer_delete", SetLastError = true)]
         public static extern ERRNO TimerDelete(IntPtr timerID);
     }
 }


### PR DESCRIPTION
- Fixes interpolator issues with Fedora and Ubuntu.