### PR TITLE
Hide unsupported remote plugins from Plugin Manager

### DIFF
--- a/OpenTabletDriver.Desktop/Reflection/Metadata/PluginMetadata.cs
+++ b/OpenTabletDriver.Desktop/Reflection/Metadata/PluginMetadata.cs
@@ -110,6 +110,23 @@ namespace OpenTabletDriver.Desktop.Reflection.Metadata
             }
         }
 
+        public bool IsSupportedBy(Version appVersion)
+        {
+            // Always return false when major and minor is not equal (x.y.0.0).
+            if (SupportedDriverVersion.Major != appVersion.Major)
+                return false;
+            if (SupportedDriverVersion.Minor != appVersion.Minor)
+                return false;
+
+            // Always return false when driver's version is older than plugin's declared support version (0.0.x.0).
+            // We do this because the driver will bump build version when a non-breaking feature is introduced.
+            // Newer plugins may start using these new features not available in older drivers.
+            if (SupportedDriverVersion.Build > appVersion.Build)
+                return false;
+
+            return true;
+        }
+
         public static bool Match(PluginMetadata primary, PluginMetadata secondary)
         {
             if (primary == null || secondary == null)

--- a/OpenTabletDriver.Tests/PluginMetadataTest.cs
+++ b/OpenTabletDriver.Tests/PluginMetadataTest.cs
@@ -1,0 +1,37 @@
+using System;
+using OpenTabletDriver.Desktop.Reflection.Metadata;
+using Xunit;
+
+namespace OpenTabletDriver.Tests
+{
+    public class PluginMetadataTest
+    {
+        public static TheoryData<Version, Version, bool> PluginMetadata_DeclaresDriverSupport_Properly_Data => new()
+        {
+            // Updated plugin
+            { new Version("0.5.3.3"), new Version("0.5.3.3"), true },
+            // Outdated plugin
+            { new Version("0.5.3.3"), new Version("0.6.0.0"), false },
+            // Slightly outdated plugin
+            { new Version("0.5.2.0"), new Version("0.5.3.3"), true },
+            // Slightly outdated driver
+            { new Version("0.5.3.3"), new Version("0.5.2.0"), false },
+            // Outdated driver
+            { new Version("0.6.0.0"), new Version("0.5.3.3"), false }
+        };
+
+        [Theory]
+        [MemberData(nameof(PluginMetadata_DeclaresDriverSupport_Properly_Data))]
+        public void PluginMetadata_DeclaresDriverSupport_Properly(Version supportedDriverVersion, Version driverVersion, bool expectedSupport)
+        {
+            var pluginMetaData = new PluginMetadata()
+            {
+                SupportedDriverVersion = supportedDriverVersion
+            };
+
+            var supportStatus = pluginMetaData.IsSupportedBy(driverVersion);
+
+            Assert.Equal(expectedSupport, supportStatus);
+        }
+    }
+}

--- a/OpenTabletDriver.UX/Windows/Plugins/PluginMetadataList.cs
+++ b/OpenTabletDriver.UX/Windows/Plugins/PluginMetadataList.cs
@@ -48,7 +48,7 @@ namespace OpenTabletDriver.UX.Windows.Plugins
                 select ctx.GetMetadata();
 
             var remote = from meta in Repository
-                where meta.SupportedDriverVersion <= AppVersion
+                where meta.IsSupportedBy(AppVersion)
                 where !local.Any(m => PluginMetadata.Match(m, meta))
                 select meta;
 


### PR DESCRIPTION
- Fixes #1414

## Changes

- Add `PluginMetadata.IsSupportedBy(Version)`.
- Add `PluginMetadata` version support tests.

![image](https://user-images.githubusercontent.com/10338031/139801112-d77491c3-c2e0-4c90-8dc4-5eab28c6202e.png)
> A screenshot of Plugin Manager only showing currently installed plugin, and none of the release-only remote plugins.