### PR TITLE
Fix crash on rapid redetect/change how 'searching' detect logs are logged

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -128,7 +128,8 @@ namespace OpenTabletDriver.Daemon
 
         public async Task<IEnumerable<TabletReference>> DetectTablets()
         {
-            Driver.Detect();
+            if (!Driver.Detect())
+                Log.Write("Detect", "No tablets found.");
 
             foreach (var tablet in Driver.InputDevices)
             {

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -39,10 +39,18 @@ namespace OpenTabletDriver
         public virtual bool Detect()
         {
             bool success = false;
+            string lastManufacturer = "";
 
             InputDevices.Clear();
             foreach (var config in _deviceConfigurationProvider.TabletConfigurations)
             {
+                string currentManufacturer = config.Name.Substring(0, config.Name.IndexOf(' '));
+                if (lastManufacturer != currentManufacturer)
+                {
+                    lastManufacturer = currentManufacturer;
+                    Log.Write("Detect", $"Searching for {currentManufacturer} tablets...");
+                }
+
                 if (Match(config) is InputDeviceTree tree)
                 {
                     success = true;
@@ -63,7 +71,6 @@ namespace OpenTabletDriver
 
         protected virtual InputDeviceTree? Match(TabletConfiguration config)
         {
-            Log.Write("Detect", $"Searching for tablet '{config.Name}'");
             try
             {
                 var devices = new List<InputDevice>();


### PR DESCRIPTION
Idea/theory PR to change how "searching for tablet" messages are logged, in order to make them less spammy. Opened as draft for now to gather feedback on both the code and the "fix path" (do we wanna fix #1498 this way?).

From my testing, this change dramatically cuts down the amount of log messages necessary when searching for tablets, (which appears to be the cause of #1498), which, from my testing involving spamming Ctrl-D to try and cause the crash outlined in #1498, means this PR: 

Fixes #1498 

At the cost of a bit of a loss in info. Now instead of listing each tablet it just lists by manufacturer (which is pulled from the first word of the config's Name). This is overall cleaner IMO, and the driver still indicates the exact tablet(s) it's found when it finds them, or logs "no tablets detected" if none are found.

```
[Detect:Info]	Searching for Artisul tablets...
[Detect:Info]	Searching for Gaomon tablets...
[Detect:Info]	Searching for Genius tablets...
[Detect:Info]	Searching for Huion tablets...
[Detect:Info]	Searching for Parblo tablets...
[Detect:Info]	Searching for UC-Logic tablets...
[Detect:Info]	Searching for UGTABLET tablets...
[Detect:Info]	Searching for VEIKK tablets...
[Detect:Info]	Searching for Wacom tablets...
[Detect:Info]	Searching for XenceLabs tablets...
[Detect:Info]	Searching for XP-Pen tablets...
[Detect:Info]	No tablets found.
```

And that's it. Simple, clean, will scale well as we add more tablets, and doesn't overwhelm the logger.