### PR TITLE
Add unsupported features on Administator warning on startup

### DIFF
--- a/OpenTabletDriver.UX.Wpf/Program.cs
+++ b/OpenTabletDriver.UX.Wpf/Program.cs
@@ -15,7 +15,7 @@ namespace OpenTabletDriver.UX.Wpf
             {
                 _ = new Application(Eto.Platforms.Wpf);
                 MessageBox.Show("OpenTabletDriver should not be run with administrator privileges.\n" + 
-                    "Some features may not work as intended.\n" +
+                    "Some features may not work as intended, such as Plugin Manager and Tablet Debugger.\n" +
                     "If you did not manually set OpenTabletDriver to run with administrator privileges please enable UAC to resolve this.", MessageBoxType.Warning);
                 Eto.Platform.AllowReinitialize = true;
             }


### PR DESCRIPTION
Added a short description on what won't work when starting OpenTabletDriver when running with administrative permissions.