### PR TITLE
Adjust sizes of various UX elements

### DIFF
--- a/OpenTabletDriver.UX/DesktopForm.cs
+++ b/OpenTabletDriver.UX/DesktopForm.cs
@@ -22,7 +22,7 @@ namespace OpenTabletDriver.UX
         }
 
         private bool platformInit;
-        public const int DEFAULT_CLIENT_WIDTH = 1024;
+        public const int DEFAULT_CLIENT_WIDTH = 980;
         public const int DEFAULT_CLIENT_HEIGHT = 760;
 
         public event EventHandler<EventArgs> InitializePlatform;

--- a/OpenTabletDriver.UX/DesktopForm.cs
+++ b/OpenTabletDriver.UX/DesktopForm.cs
@@ -22,8 +22,8 @@ namespace OpenTabletDriver.UX
         }
 
         private bool platformInit;
-        public const int DEFAULT_CLIENT_WIDTH = 960;
-        public const int DEFAULT_CLIENT_HEIGHT = 760;
+        public const int DEFAULT_CLIENT_WIDTH = 1024;
+        public const int DEFAULT_CLIENT_HEIGHT = 810;
 
         public event EventHandler<EventArgs> InitializePlatform;
 

--- a/OpenTabletDriver.UX/DesktopForm.cs
+++ b/OpenTabletDriver.UX/DesktopForm.cs
@@ -23,7 +23,7 @@ namespace OpenTabletDriver.UX
 
         private bool platformInit;
         public const int DEFAULT_CLIENT_WIDTH = 1024;
-        public const int DEFAULT_CLIENT_HEIGHT = 810;
+        public const int DEFAULT_CLIENT_HEIGHT = 760;
 
         public event EventHandler<EventArgs> InitializePlatform;
 

--- a/OpenTabletDriver.UX/Windows/Plugins/PluginManagerWindow.cs
+++ b/OpenTabletDriver.UX/Windows/Plugins/PluginManagerWindow.cs
@@ -18,7 +18,7 @@ namespace OpenTabletDriver.UX.Windows.Plugins
         public PluginManagerWindow()
         {
             this.Title = "Plugin Manager";
-            this.ClientSize = new Size(900, 720);
+            this.ClientSize = new Size(1000, 800);
             this.AllowDrop = true;
 
             this.Menu = ConstructMenu();
@@ -35,7 +35,7 @@ namespace OpenTabletDriver.UX.Windows.Plugins
                             Expand = true,
                             Control = new Splitter
                             {
-                                Panel1MinimumSize = 250,
+                                Panel1MinimumSize = 300,
                                 Panel1 = pluginList = new PluginMetadataList(),
                                 Panel2 = metadataViewer = new MetadataViewer()
                             }

--- a/OpenTabletDriver.UX/Windows/Plugins/PluginManagerWindow.cs
+++ b/OpenTabletDriver.UX/Windows/Plugins/PluginManagerWindow.cs
@@ -18,7 +18,7 @@ namespace OpenTabletDriver.UX.Windows.Plugins
         public PluginManagerWindow()
         {
             this.Title = "Plugin Manager";
-            this.ClientSize = new Size(1000, 800);
+            this.ClientSize = new Size(1000, 750);
             this.AllowDrop = true;
 
             this.Menu = ConstructMenu();

--- a/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
+++ b/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
@@ -119,8 +119,8 @@ namespace OpenTabletDriver.UX.Windows.Tablet
             this.Content = new Splitter
             {
                 Orientation = Orientation.Vertical,
-                Width = 640,
-                Height = 800,
+                Width = 700,
+                Height = 875,
                 FixedPanel = SplitterFixedPanel.Panel2,
                 Panel1 = new DebuggerGroup
                 {

--- a/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
+++ b/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
@@ -119,8 +119,8 @@ namespace OpenTabletDriver.UX.Windows.Tablet
             this.Content = new Splitter
             {
                 Orientation = Orientation.Vertical,
-                Width = 700,
-                Height = 875,
+                Width = 640,
+                Height = 840,
                 FixedPanel = SplitterFixedPanel.Panel2,
                 Panel1 = new DebuggerGroup
                 {

--- a/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
+++ b/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
@@ -25,7 +25,7 @@ namespace OpenTabletDriver.UX.Windows.Tablet
             var debugger = new StackLayout
             {
                 HorizontalContentAlignment = HorizontalAlignment.Stretch,
-                Height = 400,
+                Height = 370,
                 Padding = 5,
                 Spacing = 5,
                 Items =
@@ -119,8 +119,8 @@ namespace OpenTabletDriver.UX.Windows.Tablet
             this.Content = new Splitter
             {
                 Orientation = Orientation.Vertical,
-                Width = 640,
-                Height = 840,
+                Width = 650,
+                Height = 800,
                 FixedPanel = SplitterFixedPanel.Panel2,
                 Panel1 = new DebuggerGroup
                 {

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # OpenTabletDriver
 
-English | [한국어](README_KO.md) | [Español](README_ES.md) | [Русский](README_RU.md) | [简体中文](README_CN.md)
+English | [한국어](README_KO.md) | [Español](README_ES.md) | [Русский](README_RU.md) | [简体中文](README_CN.md) | [Français](README_FR.md)
 
 OpenTabletDriver is an open source, cross platform, user mode tablet driver. The goal of OpenTabletDriver is to be cross platform as possible with the highest compatibility in an easily configurable graphical user interface.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -2,7 +2,7 @@
 
 # OpenTabletDriver
 
-[English](README.md) | [한국어](README_KO.md) | [Español](README_ES.md) | [Русский](README_RU.md) | 简体中文
+[English](README.md) | [한국어](README_KO.md) | [Español](README_ES.md) | [Русский](README_RU.md) | 简体中文 | [Français](README_FR.md)
 
 OpenTabletDriver是一个开源的，跨平台的数位板驱动。其目标是在拥有直观的可自定义的界面的同时能跨平台并兼容尽可能多的设备。
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -2,7 +2,7 @@
 
 # OpenTabletDriver
 
-[English](README.md) | [한국어](README_KO.md) | Español | [Русский](README_RU.md) | [简体中文](README_CN.md)
+[English](README.md) | [한국어](README_KO.md) | Español | [Русский](README_RU.md) | [简体中文](README_CN.md) | [Français](README_FR.md)
 
 OpenTabletDriver es un driver de tabletas multiplataforma, open-source y en modo de usuario. El objetivo de OpenTabletDriver es ser lo más multiplataforma posible con la mayor compatibilidad en una interfaz de usuario fácil de configurar.
 

--- a/README_FR.md
+++ b/README_FR.md
@@ -4,7 +4,7 @@
 
 [English](README.md) | [한국어](README_KO.md) | [Español](README_ES.md) | [Русский](README_RU.md) | [简体中文](README_CN.md) | Français
 
-OpenTabletDriver est un driver de tablette en mode utilisateur, open source et multiplateforme. Le but d'OpenTabletDriver est d'être compatible avec le plus de plateforme possibles, et ce avec une interface graphique utilisateur facilement configurable.
+OpenTabletDriver est un driver de tablette en mode utilisateur, open source et multiplateforme. Le but d'OpenTabletDriver est d'être compatible avec le plus de plateforme possibles, et ce grâce à une interface graphique utilisateur facilement configurable.
 
 <p align="middle">
   <img src="https://i.imgur.com/XDYf62e.png" width="410" align="middle"/>
@@ -53,7 +53,7 @@ Paquets requis (certains paquets peuvent-être pré-installés pour votre distri
 
 Pour pouvoir build sur Linux, exécutez le 'build.sh' fourni. Ceci va également exécuter
 la command 'dotnet publish' utilisée pour build le paquet AUR, 
-cela va également produire des binaires utilisables dans 'OpenTabletDriver/bin'.
+cela va également produire des exécutables utilisables dans 'OpenTabletDriver/bin'.
 
 Pour build sur ARM Linux, exécutez le 'build.sh' fourni 
 avec les arguments d'exécution appropriés. Pour arm64, c'est 

--- a/README_FR.md
+++ b/README_FR.md
@@ -34,7 +34,7 @@ Les exigences pour build OpenTabletDriver sont cohérentes sur toutes les platef
 
 ### Toutes les plateformes
 
-- .NET 5 SDK
+- .NET 5 SDK (peut-être obtenu [Ici](https://dotnet.microsoft.com/download/dotnet/5.0) - Prendre le SDK pour votre plateforme, les utilisateurs Linux doivent installer via un gestionnaire de paquets qui fournit le paquet .NET 5)
 
 #### Windows
 
@@ -42,10 +42,30 @@ Aucune autre dépendance.
 
 #### Linux
 
+Paquets requis (certains paquets peuvent-être pré-installés pour votre distribution)
+
 - libx11
 - libxrandr
 - libevdev2
 - GTK+3
+
+Pour pouvoir build sur Linux, exécutez le 'build.sh' fourni. Ceci va également exécuter
+la command 'dotnet publish' utilisée pour build le paquet AUR, 
+cela va également produire des binaires utilisables dans 'OpenTabletDriver/bin'.
+
+Pour build un ARM Linux, exécutez le 'build.sh' fourni 
+avec les arguments d'exécution appropriés. Pour arm64, c'est 
+'linux-arm64'.
+
+Note: Si vous buildez pour la première fois, 
+exécutez le script generate-rules.sh inclu.
+Cela va générer plusieurs règles udev 
+dans OpenTabletDriver/bin appelées '99-opentabletdriver.rules'. 
+Ce fichier doit-être déplacé dans `/etc/udev/rules.d/`:
+
+```
+sudo mv ./bin/99-opentabletdriver.rules /etc/udev/rules.d/
+```
 
 #### MacOS [Expérimental]
 

--- a/README_FR.md
+++ b/README_FR.md
@@ -49,15 +49,6 @@ Paquets requis (certains paquets peuvent-être pré-installés pour votre distri
 - libx11
 - libxrandr
 - libevdev2
-
-Sur Fedora ou d'autres distributions, libevdev2 peut-être présentes,
-mais requière un symlink car le nom du binaire est différent de ce que .NET attend.
-
-Commande symlink utilisée sur Fedora 34:
-
-```
-sudo ln -s /lib64/libevdev.so.2 /lib64/libevdev.so
-```
 - GTK+3
 
 Pour pouvoir build sur Linux, exécutez le 'build.sh' fourni. Ceci va également exécuter

--- a/README_FR.md
+++ b/README_FR.md
@@ -67,13 +67,8 @@ Aucune autre dépendance.
 - Positionnement relatif du curseur
   - Sensibilité horizontal et vertical (px/mm)
 - Raccourcis du stylet
-
-
-  - Tip by pressure bindings // A TRAD
-  - Express key bindings // A TRAD
-
-
-
+  - Raccourcis de pression de la pointe
+  - Raccourcis express
   - Raccourcis boutons stylet
   - Raccourcis boutons souris
   - Raccourcis clavier

--- a/README_FR.md
+++ b/README_FR.md
@@ -49,6 +49,15 @@ Paquets requis (certains paquets peuvent-être pré-installés pour votre distri
 - libx11
 - libxrandr
 - libevdev2
+
+Sur Fedora ou d'autres distributions, libevdev2 peut-être présentes,
+mais requière un symlink car le nom du binaire est différent de ce que .NET attend.
+
+Commande symlink utilisée sur Fedora 34:
+
+```
+sudo ln -s /lib64/libevdev.so.2 /lib64/libevdev.so
+```
 - GTK+3
 
 Pour pouvoir build sur Linux, exécutez le 'build.sh' fourni. Ceci va également exécuter

--- a/README_FR.md
+++ b/README_FR.md
@@ -24,7 +24,7 @@ Tous les modèles de tablettes supportés, non testées, et prévus pour être s
 - [Linux](https://opentabletdriver.net/Wiki/Install/Linux)
 - [MacOS](https://opentabletdriver.net/Wiki/Install/MacOS)
 
-# Exécuter un binaire OpenTabletDriver
+# Executer OpenTabletDriver
 
 Le fonctionnement d'OpenTabletDriver est basé sur l'utilisation de deux processus séparés qui interagissent parfaitement entre eux. Le programme actif qui permet le traitement des données est `OpenTabletDriver.Daemon`, tandis que l'interface graphique est `OpenTabletDriver.UX.*`, où `*` dépend de votre plateforme<sup>1</sup>. Pour que tout fonctionne correctement, Le programme actif daemon doit être exécuté. Si vous avez des paramètres existants, ils vont s'appliquer lors de son exécution.
 
@@ -64,7 +64,7 @@ Pour pouvoir build sur Linux, exécutez le 'build.sh' fourni. Ceci va également
 la command 'dotnet publish' utilisée pour build le paquet AUR, 
 cela va également produire des binaires utilisables dans 'OpenTabletDriver/bin'.
 
-Pour build un ARM Linux, exécutez le 'build.sh' fourni 
+Pour build sur ARM Linux, exécutez le 'build.sh' fourni 
 avec les arguments d'exécution appropriés. Pour arm64, c'est 
 'linux-arm64'.
 
@@ -99,7 +99,7 @@ Aucune autre dépendance.
   - Sensibilité horizontal et vertical (px/mm)
 - Raccourcis du stylet
   - Raccourcis de pression de la pointe
-  - Raccourcis express
+  - Raccourcis touches express
   - Raccourcis boutons stylet
   - Raccourcis boutons souris
   - Raccourcis clavier

--- a/README_FR.md
+++ b/README_FR.md
@@ -32,7 +32,7 @@ Le fonctionnement d'OpenTabletDriver est basé sur l'utilisation de deux process
 > <sup>1</sup>Windows utilise `Wpf`, Linux utilise `Gtk`, et MacOS utilise `MacOS` respectivement. Celà peut-être ignoré dans la plupart des cas si vous ne tentez pas de build à partir de la source, car seule la bonne version sera fournie.
 ## Build OpenTabletDriver à partir de la source
 
-Les exigences pour build OpenTabletDriver sont cohérentes sur toutes les plateformes. L'éxécution d'OpenTabletDriver requière des dépendances différentes.
+Les exigences pour build OpenTabletDriver sont cohérentes sur toutes les plateformes. L'exécution d'OpenTabletDriver requière des dépendances différentes.
 
 ### Toutes les plateformes
 

--- a/README_FR.md
+++ b/README_FR.md
@@ -1,0 +1,95 @@
+[![Actions Status](https://github.com/OpenTabletDriver/OpenTabletDriver/workflows/.NET%20Core/badge.svg)](https://github.com/OpenTabletDriver/OpenTabletDriver/actions) [![CodeFactor](https://www.codefactor.io/repository/github/OpenTabletDriver/OpenTabletDriver/badge/master)](https://www.codefactor.io/repository/github/OpenTabletDriver/OpenTabletDriver/overview/master) [![Total Download Count](https://img.shields.io/github/downloads/OpenTabletDriver/OpenTabletDriver/total.svg)](https://github.com/OpenTabletDriver/OpenTabletDriver/releases/latest)
+
+# OpenTabletDriver
+
+[English](README.md) | [한국어](README_KO.md) | [Español](README_ES.md) | [Русский](README_RU.md) | [简体中文](README_CN.md) | Français
+
+OpenTabletDriver est un driver de tablette en mode utilisateur, open source et multiplateforme. Le but d'OpenTabletDriver est d'être compatible avec le plus de plateforme possibles, et ce avec une interface graphique utilisateur facilement configurable.
+
+<p align="middle">
+  <img src="https://i.imgur.com/XDYf62e.png" width="410" align="middle"/>
+  <img src="https://i.imgur.com/jBW8NpU.png" width="410" align="middle"/>
+  <img src="https://i.imgur.com/ZLCy6wz.png" width="410" align="middle"/>
+</p>
+
+# Tablettes supportées
+
+Tous les modèles de tablettes supportés, non testées, et prévus pour être supportés peuvent-être trouvés ici. Des solutions alternatives peuvent-être trouvées sur le wiki pour votre plateforme.
+
+- [Tablettes supportées](https://github.com/OpenTabletDriver/OpenTabletDriver/blob/master/TABLETS.md)
+
+# Installation
+
+- [Guide d'installation](https://github.com/OpenTabletDriver/OpenTabletDriver/wiki/Installation-Guide)
+
+# Exécuter un binaire OpenTabletDriver
+
+Le fonctionnement d'OpenTabletDriver est basé sur l'utilisation de deux processus séparés qui interagissent parfaitement entre eux. Le programme actif qui permet le traitement des données est `OpenTabletDriver.Daemon`, tandis que l'interface graphique est `OpenTabletDriver.UX.*`, où `*` dépend de votre plateforme<sup>1</sup>. Pour que tout fonctionne correctement, Le programme actif daemon doit être exécuté. Si vous avez des paramètres existants, ils vont s'appliquer lors de son exécution.
+
+
+> <sup>1</sup>Windows utilise `Wpf`, Linux utilise `Gtk`, et MacOS utilise `MacOS` respectivement. Celà peut-être ignoré dans la plupart des cas si vous ne tentez pas de build à partir de la source, car seule la bonne version sera fournie.
+## Build OpenTabletDriver à partir de la source
+
+Les exigences pour build OpenTabletDriver sont cohérentes sur toutes les plateformes. L'éxécution d'OpenTabletDriver requière des dépendances différentes.
+
+### Toutes les plateformes
+
+- .NET 5 SDK
+
+#### Windows
+
+Aucune autre dépendance.
+
+#### Linux
+
+- libx11
+- libxrandr
+- libevdev2
+- GTK+3
+
+#### MacOS [Expérimental]
+
+Aucune autre dépendance.
+
+# Fonctionnalités
+
+- GUI entièrement natif pour toutes les plateformes
+  - Windows: `Windows Presentation Foundation`
+  - Linux: `GTK+3`
+  - MacOS: `MonoMac`
+- Outil de console à part entière
+  - Obtient, modifie, charge ou sauvegarde rapidement les paramètres
+  - Support de script (sortie json)
+- Positionnement absolu du curseur
+  - Zone de l'écran ainsi que la zone de la tablette
+  - Décalages par rapport au centre
+  - Rotations précises de la zone
+- Positionnement relatif du curseur
+  - Sensibilité horizontal et vertical (px/mm)
+- Raccourcis du stylet
+
+
+  - Tip by pressure bindings // A TRAD
+  - Express key bindings // A TRAD
+
+
+
+  - Raccourcis boutons stylet
+  - Raccourcis boutons souris
+  - Raccourcis clavier
+  - Plugin de raccourcis externe
+- Sauvegarder et charger des paramètres
+  - Charge automatiquement les paramètres utilisateur via `settings.json` dans l'utilisateur actif `%localappdata%` ou le `.config` du dossier répertoire racine des paramètres.
+- Éditeur de configuration
+  - Vous permets de créer, modifier ou supprimer des configurations.
+  - Génère des configurations venant des appareils HID visibles
+- Plugins
+  - Filtres
+  - Modes de sorties
+  - Outils
+
+# Contribuer à OpenTabletDriver
+
+Si vous souhaitez contribuer à OpenTabletDriver, regardez le [Traqueur d'incidents](https://github.com/OpenTabletDriver/OpenTabletDriver/issues).
+
+Si vous avez des problèmes ou des suggestions, [ouvrez un ticket](https://github.com/OpenTabletDriver/OpenTabletDriver/issues/new/choose).

--- a/README_FR.md
+++ b/README_FR.md
@@ -16,7 +16,7 @@ OpenTabletDriver est un driver de tablette en mode utilisateur, open source et m
 
 Tous les modèles de tablettes supportés, non testées, et prévus pour être supportés peuvent-être trouvés ici. Des solutions alternatives peuvent-être trouvées sur le wiki pour votre plateforme.
 
-- [Tablettes supportées](https://github.com/OpenTabletDriver/OpenTabletDriver/blob/master/TABLETS.md)
+- [Tablettes supportées](https://opentabletdriver.net/Tablets)
 
 # Installation
 

--- a/README_FR.md
+++ b/README_FR.md
@@ -20,7 +20,9 @@ Tous les modèles de tablettes supportés, non testées, et prévus pour être s
 
 # Installation
 
-- [Guide d'installation](https://github.com/OpenTabletDriver/OpenTabletDriver/wiki/Installation-Guide)
+- [Windows](https://opentabletdriver.net/Wiki/Install/Windows)
+- [Linux](https://opentabletdriver.net/Wiki/Install/Linux)
+- [MacOS](https://opentabletdriver.net/Wiki/Install/MacOS)
 
 # Exécuter un binaire OpenTabletDriver
 

--- a/README_FR.md
+++ b/README_FR.md
@@ -24,7 +24,7 @@ Tous les modèles de tablettes supportés, non testées, et prévus pour être s
 - [Linux](https://opentabletdriver.net/Wiki/Install/Linux)
 - [MacOS](https://opentabletdriver.net/Wiki/Install/MacOS)
 
-# Executer OpenTabletDriver
+# Exécuter OpenTabletDriver
 
 Le fonctionnement d'OpenTabletDriver est basé sur l'utilisation de deux processus séparés qui interagissent parfaitement entre eux. Le programme actif qui permet le traitement des données est `OpenTabletDriver.Daemon`, tandis que l'interface graphique est `OpenTabletDriver.UX.*`, où `*` dépend de votre plateforme<sup>1</sup>. Pour que tout fonctionne correctement, Le programme actif daemon doit être exécuté. Si vous avez des paramètres existants, ils vont s'appliquer lors de son exécution.
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -2,7 +2,7 @@
 
 # OpenTabletDriver
 
-[English](README.md) | 한국어 | [Español](README_ES.md) | [Русский](README_RU.md) | [简体中文](README_CN.md)
+[English](README.md) | 한국어 | [Español](README_ES.md) | [Русский](README_RU.md) | [简体中文](README_CN.md) | [Français](README_FR.md)
 
 OpenTabletDriver는 관리자 권한 없이 여러 플랫폼에서 작동하는 오픈 소스 타블렛 드라이버입니다. OpenTabletDriver는 쉽게 사용 가능한 유저 인터페이스를 제공함과 동시에 가능한 한 여러 플랫폼에서 무리 없이 작동하도록 하는 것을 목표로 하고 있습니다.
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -2,7 +2,7 @@
 
 # OpenTabletDriver
 
-[English](README.md) | [한국어](README_KO.md) | [Español](README_ES.md) | Русский | [简体中文](README_CN.md)
+[English](README.md) | [한국어](README_KO.md) | [Español](README_ES.md) | Русский | [简体中文](README_CN.md) | [Français](README_FR.md)
 
 OpenTabletDriver — кроссплатформенный драйвер с открытым исходным кодом для графических планшетов. Целью проекта является поддержка максимального числа устройств и платформ, а также создание простого и удобного интерфейса для настройки драйвера.
 


### PR DESCRIPTION
Adjusted the size of the Main OpenTabletDriver window making it slightly larger.
Adjusted the size of the plugin manager so that Plugin names don't get cut off.
Adjusted the size of the Tablet Debugger so that the Tablet Visualizer is larger.