### PR TITLE
Update Huion osu!tablet detection configuration

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/osu!tablet.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/osu!tablet.json
@@ -30,6 +30,19 @@
         "200": "HVAN"
       },
       "InitializationStrings": []
+    },
+    {
+      "VendorID": 9580,
+      "ProductID": 110,
+      "InputReportLength": 8,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Vendors.UCLogic.UCLogicReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "200": "HVAN"
+      },
+      "InitializationStrings": []
     }
   ],
   "AuxilaryDeviceIdentifiers": [],


### PR DESCRIPTION
My osu!tablet reports different product id than in default config file, so adding with new DigitizerIdentifier.

Device string reader video as confirmation:
https://user-images.githubusercontent.com/4341517/140655676-45a633f5-6361-4185-af5a-aaaf116ddda1.mp4
