### PR TITLE
Make Area Clipping menu entry consistent with ignore entry

### DIFF
--- a/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
@@ -408,7 +408,7 @@ namespace OpenTabletDriver.UX.Controls.Output
 
                 areaClippingCmd = new BooleanCommand
                 {
-                    MenuText = "Area clipping"
+                    MenuText = "Clamp input outside area"
                 };
 
                 ignoreOutsideAreaCmd = new BooleanCommand


### PR DESCRIPTION
Absolute mode editor currently has options to both clamp and ignore input outside area. As the 2 options seemingly does the same but with different behavior, I think it's more sensible to rename it so that it is consistent with the other menu entry.

Pre-PR naming:
- Area Clipping
- Ignore input outside area 

Post-PR naming:
- Clamp input outside area
- Ignore input outside area