### PR TITLE
Resize Tablet Debugger and Plugin Manager

### DIFF
--- a/OpenTabletDriver.UX/Windows/Plugins/PluginManagerWindow.cs
+++ b/OpenTabletDriver.UX/Windows/Plugins/PluginManagerWindow.cs
@@ -18,7 +18,7 @@ namespace OpenTabletDriver.UX.Windows.Plugins
         public PluginManagerWindow()
         {
             this.Title = "Plugin Manager";
-            this.ClientSize = new Size(900, 720);
+            this.ClientSize = new Size(1000, 750);
             this.AllowDrop = true;
 
             this.Menu = ConstructMenu();
@@ -35,7 +35,7 @@ namespace OpenTabletDriver.UX.Windows.Plugins
                             Expand = true,
                             Control = new Splitter
                             {
-                                Panel1MinimumSize = 250,
+                                Panel1MinimumSize = 300,
                                 Panel1 = pluginList = new PluginMetadataList(),
                                 Panel2 = metadataViewer = new MetadataViewer()
                             }

--- a/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
+++ b/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
@@ -25,7 +25,7 @@ namespace OpenTabletDriver.UX.Windows.Tablet
             var debugger = new StackLayout
             {
                 HorizontalContentAlignment = HorizontalAlignment.Stretch,
-                Height = 400,
+                Height = 370,
                 Padding = 5,
                 Spacing = 5,
                 Items =
@@ -119,7 +119,7 @@ namespace OpenTabletDriver.UX.Windows.Tablet
             this.Content = new Splitter
             {
                 Orientation = Orientation.Vertical,
-                Width = 640,
+                Width = 660,
                 Height = 800,
                 FixedPanel = SplitterFixedPanel.Panel2,
                 Panel1 = new DebuggerGroup


### PR DESCRIPTION
Resized the Tablet Debugger and Plugin Manager, Tablet Debuggers visualizer is slightly taller to stop clipping on 6x4 inch tablets and Plugin manager was resized so that the sidebar is wider to stop plugin names from being cut off.