### PR TITLE
Allow tablet-scoped plugins to request tablet reference

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -151,14 +151,15 @@ namespace OpenTabletDriver.Daemon
 
             Settings = settings ??= Settings.GetDefaults();
 
-            foreach (var dev in Driver.InputDevices)
+            foreach (InputDeviceTree? dev in Driver.InputDevices)
             {
+                var tabletReference = dev.CreateReference();
                 string group = dev.Properties.Name;
                 var profile = Settings.Profiles[dev];
 
                 profile.BindingSettings.MatchSpecifications(dev.Properties.Specifications);
 
-                dev.OutputMode = profile.OutputMode.Construct<IOutputMode>();
+                dev.OutputMode = profile.OutputMode.Construct<IOutputMode>(tabletReference);
 
                 if (dev.OutputMode != null)
                     Log.Write(group, $"Output mode: {profile.OutputMode.Name}");
@@ -171,8 +172,8 @@ namespace OpenTabletDriver.Daemon
 
                 if (dev.OutputMode is IOutputMode outputMode)
                 {
-                    SetOutputModeSettings(dev, outputMode, profile);
-                    SetBindingHandlerSettings(dev, outputMode, profile.BindingSettings);
+                    SetOutputModeSettings(dev, outputMode, profile, tabletReference);
+                    SetBindingHandlerSettings(dev, outputMode, profile.BindingSettings, tabletReference);
                 }
             }
 
@@ -226,19 +227,19 @@ namespace OpenTabletDriver.Daemon
             }
         }
 
-        private void SetOutputModeSettings(InputDeviceTree dev, IOutputMode outputMode, Profile profile)
+    private void SetOutputModeSettings(InputDeviceTree dev, IOutputMode outputMode, Profile profile, TabletReference tabletReference)
         {
             string group = dev.Properties.Name;
             outputMode.Tablet = dev;
 
             var elements = from store in profile.Filters
                 where store.Enable == true
-                let filter = store.Construct<IPositionedPipelineElement<IDeviceReport>>()
+                let filter = store.Construct<IPositionedPipelineElement<IDeviceReport>>(tabletReference)
                 where filter != null
                 select filter;
             outputMode.Elements = elements.ToList();
 
-            if (outputMode.Elements != null && outputMode.Elements.Count() > 0)
+            if (outputMode.Elements != null && outputMode.Elements.Count > 0)
                 Log.Write(group, $"Filters: {string.Join(", ", outputMode.Elements)}");
         }
 
@@ -273,7 +274,7 @@ namespace OpenTabletDriver.Daemon
             Log.Write(group, $"Reset time: {relativeMode.ResetTime}");
         }
 
-        private void SetBindingHandlerSettings(InputDeviceTree dev, IOutputMode outputMode, BindingSettings settings)
+        private void SetBindingHandlerSettings(InputDeviceTree dev, IOutputMode outputMode, BindingSettings settings, TabletReference tabletReference)
         {
             string group = dev.Properties.Name;
             var bindingHandler = new BindingHandler(outputMode);
@@ -291,7 +292,7 @@ namespace OpenTabletDriver.Daemon
 
             var tip = bindingHandler.Tip = new ThresholdBindingState
             {
-                Binding = settings.TipButton?.Construct<IBinding>(bindingServiceProvider),
+                Binding = settings.TipButton?.Construct<IBinding>(bindingServiceProvider, tabletReference),
                 ActivationThreshold = settings.TipActivationPressure
             };
 
@@ -302,7 +303,7 @@ namespace OpenTabletDriver.Daemon
 
             var eraser = bindingHandler.Eraser = new ThresholdBindingState
             {
-                Binding = settings.EraserButton?.Construct<IBinding>(bindingServiceProvider),
+                Binding = settings.EraserButton?.Construct<IBinding>(bindingServiceProvider, tabletReference),
                 ActivationThreshold = settings.EraserActivationPressure
             };
 
@@ -313,30 +314,30 @@ namespace OpenTabletDriver.Daemon
 
             if (settings.PenButtons != null && settings.PenButtons.Any(b => b?.Path != null))
             {
-                SetBindingHandlerCollectionSettings(bindingServiceProvider, settings.PenButtons, bindingHandler.PenButtons);
+                SetBindingHandlerCollectionSettings(bindingServiceProvider, settings.PenButtons, bindingHandler.PenButtons, tabletReference);
                 Log.Write(group, $"Pen Bindings: " + string.Join(", ", bindingHandler.PenButtons.Select(b => b.Value?.Binding)));
             }
 
             if (settings.AuxButtons != null && settings.AuxButtons.Any(b => b?.Path != null))
             {
-                SetBindingHandlerCollectionSettings(bindingServiceProvider, settings.AuxButtons, bindingHandler.AuxButtons);
+                SetBindingHandlerCollectionSettings(bindingServiceProvider, settings.AuxButtons, bindingHandler.AuxButtons, tabletReference);
                 Log.Write(group, $"Express Key Bindings: " + string.Join(", ", bindingHandler.AuxButtons.Select(b => b.Value?.Binding)));
             }
 
             if (settings.MouseButtons != null && settings.MouseButtons.Any(b => b?.Path != null))
             {
-                SetBindingHandlerCollectionSettings(bindingServiceProvider, settings.MouseButtons, bindingHandler.MouseButtons);
+                SetBindingHandlerCollectionSettings(bindingServiceProvider, settings.MouseButtons, bindingHandler.MouseButtons, tabletReference);
                 Log.Write(group, $"Mouse Button Bindings: [" + string.Join("], [", bindingHandler.MouseButtons.Select(b => b.Value?.Binding)) + "]");
             }
 
             var scrollUp = bindingHandler.MouseScrollUp = new BindingState
             {
-                Binding = settings.MouseScrollUp?.Construct<IBinding>(bindingServiceProvider)
+                Binding = settings.MouseScrollUp?.Construct<IBinding>(bindingServiceProvider, tabletReference)
             };
 
             var scrollDown = bindingHandler.MouseScrollDown = new BindingState
             {
-                Binding = settings.MouseScrollDown?.Construct<IBinding>(bindingServiceProvider)
+                Binding = settings.MouseScrollDown?.Construct<IBinding>(bindingServiceProvider, tabletReference)
             };
 
             if (scrollUp.Binding != null || scrollDown.Binding != null)
@@ -345,11 +346,11 @@ namespace OpenTabletDriver.Daemon
             }
         }
 
-        private void SetBindingHandlerCollectionSettings(IServiceManager serviceManager, PluginSettingStoreCollection collection, Dictionary<int, BindingState?> targetDict)
+        private void SetBindingHandlerCollectionSettings(IServiceManager serviceManager, PluginSettingStoreCollection collection, Dictionary<int, BindingState?> targetDict, TabletReference tabletReference)
         {
             for (int index = 0; index < collection.Count; index++)
             {
-                var binding = collection[index]?.Construct<IBinding>(serviceManager);
+                var binding = collection[index]?.Construct<IBinding>(serviceManager, tabletReference);
                 var state = binding == null ? null : new BindingState
                 {
                     Binding = binding

--- a/OpenTabletDriver.Plugin/Attributes/TabletReferenceAttribute.cs
+++ b/OpenTabletDriver.Plugin/Attributes/TabletReferenceAttribute.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace OpenTabletDriver.Plugin.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    public class TabletReferenceAttribute : Attribute
+    {
+    }
+}


### PR DESCRIPTION
## Changes

- Fixes #1407
- Provide `TabletReference` to plugins that ask for it.
- Fixes event method not getting invoked in all cases of `Construct<T>()` overload.