### PR TITLE
Fix logging UI deadlock

### DIFF
--- a/OpenTabletDriver.UX/Controls/LogView.cs
+++ b/OpenTabletDriver.UX/Controls/LogView.cs
@@ -88,7 +88,7 @@ namespace OpenTabletDriver.UX.Controls
                 where message is LogMessage
                 select message;
 
-            foreach (var message in currentMessages)
+            foreach (var message in currentMessages.Take(150))
                 AddMessage(message);
 
             App.Driver.AddConnectionHook(i => i.Message += (sender, message) => AddMessage(message));
@@ -104,7 +104,7 @@ namespace OpenTabletDriver.UX.Controls
                     HeaderText = "Time",
                     DataCell = new TextBoxCell
                     {
-                        Binding = Eto.Forms.Binding.Property<LogMessage, string>(m => m.Time.ToLongTimeString())
+                        Binding = Binding.Property<LogMessage, string>(m => m.Time.ToLongTimeString())
                     }
                 },
                 new GridColumn
@@ -112,7 +112,7 @@ namespace OpenTabletDriver.UX.Controls
                     HeaderText = "Level",
                     DataCell = new TextBoxCell
                     {
-                        Binding = Eto.Forms.Binding.Property<LogMessage, string>(m => m.Level.GetName())
+                        Binding = Binding.Property<LogMessage, string>(m => m.Level.GetName())
                     }
                 },
                 new GridColumn
@@ -120,7 +120,7 @@ namespace OpenTabletDriver.UX.Controls
                     HeaderText = "Group",
                     DataCell = new TextBoxCell
                     {
-                        Binding = Eto.Forms.Binding.Property<LogMessage, string>(m => m.Group)
+                        Binding = Binding.Property<LogMessage, string>(m => m.Group)
                     }
                 },
                 new GridColumn
@@ -128,7 +128,7 @@ namespace OpenTabletDriver.UX.Controls
                     HeaderText = "Message",
                     DataCell = new TextBoxCell
                     {
-                        Binding = Eto.Forms.Binding.Property<LogMessage, string>(m => m.Message)
+                        Binding = Binding.Property<LogMessage, string>(m => m.Message)
                     }
                 }
             }
@@ -160,7 +160,7 @@ namespace OpenTabletDriver.UX.Controls
         {
             public FilterDropDown(LogLevel activeFilter = LogLevel.Info)
             {
-                base.SelectedValue = activeFilter;
+                SelectedValue = activeFilter;
             }
         }
     }

--- a/OpenTabletDriver.UX/Controls/LogView.cs
+++ b/OpenTabletDriver.UX/Controls/LogView.cs
@@ -61,7 +61,17 @@ namespace OpenTabletDriver.UX.Controls
                 }
             };
 
-            messageList.DataStore = this.messageStore;
+            this.Items.Add(new StackLayoutItem(messageList, HorizontalAlignment.Stretch, true));
+            this.Items.Add(new StackLayoutItem(toolbar, HorizontalAlignment.Stretch));
+
+            _ = InitializeAsync();
+        }
+
+        private async Task InitializeAsync()
+        {
+            var currentMessages = await App.Driver.Instance.GetCurrentLog();
+            messageList.DataStore = messageStore = new LogDataStore(currentMessages);
+
             this.messageStore.CollectionChanged += (sender, e) =>
             {
                 Application.Instance.AsyncInvoke(() =>
@@ -75,21 +85,6 @@ namespace OpenTabletDriver.UX.Controls
                     }
                 });
             };
-
-            this.Items.Add(new StackLayoutItem(messageList, HorizontalAlignment.Stretch, true));
-            this.Items.Add(new StackLayoutItem(toolbar, HorizontalAlignment.Stretch));
-
-            _ = InitializeAsync();
-        }
-
-        private async Task InitializeAsync()
-        {
-            var currentMessages = from message in await App.Driver.Instance.GetCurrentLog()
-                where message is LogMessage
-                select message;
-
-            foreach (var message in currentMessages.Take(150))
-                AddMessage(message);
 
             App.Driver.AddConnectionHook(i => i.Message += (sender, message) => AddMessage(message));
         }
@@ -134,7 +129,7 @@ namespace OpenTabletDriver.UX.Controls
             }
         };
 
-        private readonly LogDataStore messageStore = new LogDataStore();
+        private LogDataStore messageStore;
 
         private void AddMessage(LogMessage message)
         {

--- a/OpenTabletDriver.UX/Tools/LogDataStore.cs
+++ b/OpenTabletDriver.UX/Tools/LogDataStore.cs
@@ -13,13 +13,7 @@ namespace OpenTabletDriver.UX.Tools
     {
         public LogDataStore(IEnumerable<LogMessage> currentMessages)
         {
-            var messageList = currentMessages.ToArray();
-            if (messageList.Length > MAX_NUM_MESSAGES)
-            {
-                var startIndex = messageList.Length - MAX_NUM_MESSAGES;
-                messageList = messageList[startIndex..^0];
-            }
-            messages = new ConcurrentQueue<LogMessage>(messageList);
+            messages = new ConcurrentQueue<LogMessage>(currentMessages.TakeLast(MAX_NUM_MESSAGES));
         }
 
         private const int MAX_NUM_MESSAGES = 250;

--- a/OpenTabletDriver.UX/Tools/LogDataStore.cs
+++ b/OpenTabletDriver.UX/Tools/LogDataStore.cs
@@ -10,7 +10,7 @@ namespace OpenTabletDriver.UX.Tools
 {
     public class LogDataStore : INotifyCollectionChanged, IEnumerable<LogMessage>
     {
-        private readonly BlockingCollection<LogMessage> messages = new BlockingCollection<LogMessage>(500);
+        private readonly ConcurrentQueue<LogMessage> messages = new ConcurrentQueue<LogMessage>();
 
         private IEnumerable<LogMessage> filteredMessages =>
             from message in this.messages
@@ -36,7 +36,7 @@ namespace OpenTabletDriver.UX.Tools
 
         public void Add(LogMessage message)
         {
-            this.messages.Add(message);
+            this.messages.Enqueue(message);
             if (message.Level >= this.Filter)
                 OnCollectionChanged(NotifyCollectionChangedAction.Add, message);
         }
@@ -55,7 +55,7 @@ namespace OpenTabletDriver.UX.Tools
 
         public IEnumerator<LogMessage> GetEnumerator()
         {
-            return (this.filteredMessages as IEnumerable<LogMessage>).GetEnumerator();
+            return this.filteredMessages.GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()


### PR DESCRIPTION
The blocking collection causes the UI to freeze when logging from separate threads, this returns it to a concurrent collection to mitigate this.