### PR TITLE
Redirect FAQ for OpenTabletDriver from Github to the website.

### DIFF
--- a/OpenTabletDriver.UX/App.cs
+++ b/OpenTabletDriver.UX/App.cs
@@ -63,7 +63,7 @@ namespace OpenTabletDriver.UX
 
         public static App Current { get; } = new App();
 
-        public const string FaqUrl = "https://github.com/OpenTabletDriver/OpenTabletDriver/wiki#frequently-asked-questions";
+        public const string FaqUrl = "http://opentabletdriver.net/Wiki";
         public static readonly string Version = Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
 
         public static RpcClient<IDriverDaemon> Driver { get; } = new RpcClient<IDriverDaemon>("OpenTabletDriver.Daemon");

--- a/OpenTabletDriver.UX/App.cs
+++ b/OpenTabletDriver.UX/App.cs
@@ -63,7 +63,7 @@ namespace OpenTabletDriver.UX
 
         public static App Current { get; } = new App();
 
-        public const string FaqUrl = "http://opentabletdriver.net/Wiki";
+        public const string FaqUrl = "https://opentabletdriver.net/Wiki";
         public static readonly string Version = Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
 
         public static RpcClient<IDriverDaemon> Driver { get; } = new RpcClient<IDriverDaemon>("OpenTabletDriver.Daemon");

--- a/OpenTabletDriver.UX/Windows/Greeter/Pages/FAQPage.cs
+++ b/OpenTabletDriver.UX/Windows/Greeter/Pages/FAQPage.cs
@@ -19,7 +19,5 @@ namespace OpenTabletDriver.UX.Windows.Greeter.Pages
                 new PaddingSpacerItem(),
             };
         }
-
-        public const string FAQ_URL = "https://github.com/OpenTabletDriver/OpenTabletDriver/wiki#frequently-asked-questions";
     }
 }

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -89,7 +89,7 @@ namespace OpenTabletDriver
                 Log.Write(
                     "Driver",
                     "The current user does not have the permissions to open the device stream. " +
-                    "Follow the instructions from https://github.com/OpenTabletDriver/OpenTabletDriver/wiki/Linux-FAQ#the-driver-fails-to-open-the-tablet-deviceioexception to resolve this issue.",
+                    "Follow the instructions from http://opentabletdriver.net/Wiki/FAQ/Linux#fail-device-streams to resolve this issue.",
                     LogLevel.Error
                 );
             }
@@ -99,7 +99,7 @@ namespace OpenTabletDriver
                 Log.Write(
                     "Driver",
                     "Device is currently in use by another kernel module. " +
-                    "Follow the instructions from https://github.com/OpenTabletDriver/OpenTabletDriver/wiki/Linux-FAQ#argumentoutofrangeexception-value-0-15 to resolve this issue.",
+                    "Follow the instructions from http://opentabletdriver.net/Wiki/FAQ/Linux#argumentoutofrangeexception to resolve this issue.",
                     LogLevel.Error
                 );
             }

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -89,7 +89,7 @@ namespace OpenTabletDriver
                 Log.Write(
                     "Driver",
                     "The current user does not have the permissions to open the device stream. " +
-                    "Follow the instructions from http://opentabletdriver.net/Wiki/FAQ/Linux#fail-device-streams to resolve this issue.",
+                    "Follow the instructions from https://opentabletdriver.net/Wiki/FAQ/Linux#fail-device-streams to resolve this issue.",
                     LogLevel.Error
                 );
             }
@@ -99,7 +99,7 @@ namespace OpenTabletDriver
                 Log.Write(
                     "Driver",
                     "Device is currently in use by another kernel module. " +
-                    "Follow the instructions from http://opentabletdriver.net/Wiki/FAQ/Linux#argumentoutofrangeexception to resolve this issue.",
+                    "Follow the instructions from https://opentabletdriver.net/Wiki/FAQ/Linux#argumentoutofrangeexception to resolve this issue.",
                     LogLevel.Error
                 );
             }


### PR DESCRIPTION
Redirected the FAQ stuff to the website version as the GitHub wiki is outdated.
Removed what seems to be a completely unused segment  (what i assume to be completely unused).

This is preparations for when the Github wiki is removed for the release of 0.6.0.0.