### PR TITLE
Simplify update interface

### DIFF
--- a/OpenTabletDriver.Desktop/Updater/IUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/IUpdater.cs
@@ -1,14 +1,10 @@
 using System.Threading.Tasks;
-using Octokit;
 
 namespace OpenTabletDriver.Desktop.Updater
 {
     public interface IUpdater
     {
-        Task<Release> GetLatestRelease();
-        Task Install(Release release);
-        Task Install(Release release, string targetDir);
-        Task<string> Download(Release release);
-        ReleaseAsset GetAsset(Release release);
+        Task<bool> HasUpdate { get; }
+        Task InstallUpdate(string targetDir);
     }
 }

--- a/OpenTabletDriver.Desktop/Updater/MacOSUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/MacOSUpdater.cs
@@ -11,7 +11,7 @@ namespace OpenTabletDriver.Desktop.Updater
 {
     public class MacOSUpdater : Updater
     {
-        public override async Task<string> Download(Release release)
+        protected override async Task<string> Download(Release release)
         {
             var binaryDir = Path.Join(AppInfo.Current.TemporaryDirectory, release.TagName);
             var asset = GetAsset(release);
@@ -28,12 +28,12 @@ namespace OpenTabletDriver.Desktop.Updater
             return binaryDir;
         }
 
-        public override ReleaseAsset GetAsset(Release release)
+        protected override ReleaseAsset GetAsset(Release release)
         {
             return release.Assets.FirstOrDefault(r => r.Name.Contains("osx-x64"));
         }
 
-        public override async Task Install(Release release, string targetDir)
+        protected override async Task Install(Release release, string targetDir)
         {
             var binaryDir = await Download(release);
             var oldDir = Path.Join(AppInfo.Current.TemporaryDirectory, CurrentVersion + "-old");

--- a/OpenTabletDriver.Desktop/Updater/WindowsUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/WindowsUpdater.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -10,7 +9,7 @@ namespace OpenTabletDriver.Desktop.Updater
 {
     public class WindowsUpdater : Updater
     {
-        public override async Task<string> Download(Release release)
+        protected override async Task<string> Download(Release release)
         {
             var binaryDir = Path.Join(AppInfo.Current.TemporaryDirectory, release.TagName);
             var tempZipPath = Path.Join(AppInfo.Current.TemporaryDirectory, Path.GetRandomFileName() + ".zip");
@@ -30,7 +29,7 @@ namespace OpenTabletDriver.Desktop.Updater
             return binaryDir;
         }
 
-        public override ReleaseAsset GetAsset(Release release)
+        protected override ReleaseAsset GetAsset(Release release)
         {
             return release.Assets.FirstOrDefault(r => r.Name.Contains("win-x64"));
         }

--- a/OpenTabletDriver.Tests/UpdaterTests.cs
+++ b/OpenTabletDriver.Tests/UpdaterTests.cs
@@ -44,8 +44,7 @@ namespace OpenTabletDriver.Tests
 
             CleanDirectory(tempDir);
 
-            var latest = await updater.GetLatestRelease();
-            await updater.Install(latest, binDir);
+            await updater.InstallUpdate(binDir);
             return binDir;
         }
 

--- a/OpenTabletDriver.Tests/UpdaterTests.cs
+++ b/OpenTabletDriver.Tests/UpdaterTests.cs
@@ -1,9 +1,6 @@
 using System;
-using System.Collections;
 using System.IO;
-using System.Text;
 using System.Threading.Tasks;
-using HidSharp.Reports.Units;
 using OpenTabletDriver.Desktop;
 using OpenTabletDriver.Desktop.Updater;
 using Xunit;
@@ -12,22 +9,21 @@ namespace OpenTabletDriver.Tests
 {
     public class UpdaterTests
     {
-        [Fact]
-        public async Task TestWindowsInstall()
+        public static TheoryData<IUpdater, string> Updater_TestInstall_Data => new TheoryData<IUpdater, string>()
         {
-            var binDir = await TestInstall(new WindowsUpdater());
+            { new WindowsUpdater(), "OpenTabletDriver.UX.Wpf.exe" },
+            { new MacOSUpdater(), "OpenTabletDriver.UX.MacOS" }
+        };
 
-            var wpfUX = Path.Join(binDir, "OpenTabletDriver.UX.Wpf.exe");
-            Assert.True(File.Exists(wpfUX));
-        }
-
-        [Fact]
-        public async Task TestMacOSInstall()
+        [Theory]
+        [MemberData(nameof(Updater_TestInstall_Data))]
+        public async Task Updater_TestInstall(IUpdater updater, string expectedBinary)
         {
-            var binDir = await TestInstall(new MacOSUpdater());
+            var binDir = await TestInstall(updater);
 
-            var macOSUX = Path.Join(binDir, "OpenTabletDriver.UX.MacOS");
-            Assert.True(File.Exists(macOSUX));
+            var binaryPath = Path.Join(binDir, expectedBinary);
+
+            Assert.True(File.Exists(binaryPath));
         }
 
         public async Task<string> TestInstall(IUpdater updater)


### PR DESCRIPTION
- Depends on #1630

## Changes

- Simplify interface to just `bool HasUpdate` and `InstallUpdate`.
- Remove explicit dependency to `Octokit`.