### PR TITLE
Add ability for log messages to create desktop notifications

### DIFF
--- a/OpenTabletDriver.Plugin/Log.cs
+++ b/OpenTabletDriver.Plugin/Log.cs
@@ -61,8 +61,8 @@ namespace OpenTabletDriver.Plugin
         /// </summary>
         /// <param name="group">The group in which the <see cref="LogMessage"/> belongs to.</param>
         /// <param name="text">Text for the <see cref="LogMessage"/>.</param>
-        /// <param name="level">Level of severity for the message, see <see cref="LogLevel"/>.</param>
-        public static void WriteNotify(string group, string text, LogLevel level)
+        /// <param name="level">Level of severity for the message, see <see cref="LogLevel"/>. Defaults to Info.</param>
+        public static void WriteNotify(string group, string text, LogLevel level = LogLevel.Info)
         {
             Write(group, text, level, false, true);
         }

--- a/OpenTabletDriver.Plugin/Log.cs
+++ b/OpenTabletDriver.Plugin/Log.cs
@@ -41,16 +41,30 @@ namespace OpenTabletDriver.Plugin
         /// <param name="group">The group in which the <see cref="LogMessage"/> belongs to.</param>
         /// <param name="text">Text for the <see cref="LogMessage"/>.</param>
         /// <param name="level">The severity level of the <see cref="LogMessage"/>.</param>
-        public static void Write(string group, string text, LogLevel level = LogLevel.Info, bool createStackTrace = false)
+        /// <param name="notify">Whether or not the log message should create a notification in the user's desktop environment.</param>
+        public static void Write(string group, string text, LogLevel level = LogLevel.Info, bool createStackTrace = false, bool notify = false)
         {
             var message = new LogMessage
             {
                 Group = group,
                 Message = text,
                 Level = level,
-                StackTrace = createStackTrace ? Environment.StackTrace : null
+                StackTrace = createStackTrace ? Environment.StackTrace : null,
+                Notification = notify
             };
             OnOutput(message);
+        }
+
+        /// <summary>
+        /// Writes to the log event with a group, text and severity level, creating a notification in the user's
+        /// desktop environment.
+        /// </summary>
+        /// <param name="group">The group in which the <see cref="LogMessage"/> belongs to.</param>
+        /// <param name="text">Text for the <see cref="LogMessage"/>.</param>
+        /// <param name="level">Level of severity for the message, see <see cref="LogLevel"/>.</param>
+        public static void WriteNotify(string group, string text, LogLevel level)
+        {
+            Write(group, text, level, false, true);
         }
 
         /// <summary>

--- a/OpenTabletDriver.Plugin/Logging/LogMessage.cs
+++ b/OpenTabletDriver.Plugin/Logging/LogMessage.cs
@@ -11,7 +11,7 @@ namespace OpenTabletDriver.Plugin.Logging
 
         public LogMessage(Exception exception)
         {
-            Group = exception.GetType().Name; 
+            Group = exception.GetType().Name;
             Message = exception.Message;
             Level = LogLevel.Error;
             StackTrace = exception.StackTrace;
@@ -41,6 +41,11 @@ namespace OpenTabletDriver.Plugin.Logging
         /// The severity level of the log message.
         /// </summary>
         public LogLevel Level { set; get; }
+
+        /// <summary>
+        /// True if the log message should create a notification in the user's desktop environment.
+        /// </summary>
+        public bool Notification { set; get; } = false;
 
         public override string ToString()
         {

--- a/OpenTabletDriver.UX/Controls/LogView.cs
+++ b/OpenTabletDriver.UX/Controls/LogView.cs
@@ -134,6 +134,26 @@ namespace OpenTabletDriver.UX.Controls
         private void AddMessage(LogMessage message)
         {
             Application.Instance.AsyncInvoke(() => this.messageStore.Add(message));
+
+            if (message.Notification)
+            {
+                string prettyLevelTitle = message.Level switch
+                {
+                    LogLevel.Debug => "OpenTabletDriver - Debug",
+                    LogLevel.Error => "OpenTabletDriver - Error",
+                    LogLevel.Warning => "OpenTabletDriver - Warning",
+                    LogLevel.Fatal => "OpenTabletDriver - Fatal",
+                    _ => "OpenTabletDriver - Info",
+                };
+                var notify = new Notification
+                {
+                    Title = prettyLevelTitle,
+                    Message = message.Message,
+                    ContentImage = App.Logo,
+                    ID = "log-message-notification"
+                };
+                notify.Show();
+            }
         }
 
         private static void Copy(IEnumerable<LogMessage> messages)

--- a/OpenTabletDriver.UX/Controls/LogView.cs
+++ b/OpenTabletDriver.UX/Controls/LogView.cs
@@ -137,17 +137,9 @@ namespace OpenTabletDriver.UX.Controls
 
             if (message.Notification)
             {
-                string prettyLevelTitle = message.Level switch
-                {
-                    LogLevel.Debug => "OpenTabletDriver - Debug",
-                    LogLevel.Error => "OpenTabletDriver - Error",
-                    LogLevel.Warning => "OpenTabletDriver - Warning",
-                    LogLevel.Fatal => "OpenTabletDriver - Fatal",
-                    _ => "OpenTabletDriver - Info",
-                };
                 var notify = new Notification
                 {
-                    Title = prettyLevelTitle,
+                    Title = "OpenTabletDriver - " + message.Level.ToString(),
                     Message = message.Message,
                     ContentImage = App.Logo,
                     ID = "log-message-notification"


### PR DESCRIPTION
Small PR to make it possible to create log messages that create desktop notifications ("toasts"). This could be useful to make errors more prominent, or even for plugin devs later.

Another PR should probably be made to convert some Error messages into notification-creating messages, as #1564 doesn't appear if the user has the app minimized, so some errors can still be missed. That's outside of the scope of this though, so....