### PR TITLE
Add unit tests for preventing erronous updates and race conditions

### DIFF
--- a/OpenTabletDriver.Console/Program.Commands.cs
+++ b/OpenTabletDriver.Console/Program.Commands.cs
@@ -20,6 +20,24 @@ namespace OpenTabletDriver.Console
 {
     partial class Program
     {
+        #region Update
+
+        private static async Task HasUpdate()
+        {
+            var hasUpdate = await Driver.Instance.HasUpdate();
+            await Out.WriteLineAsync(hasUpdate.ToString().ToLowerInvariant());
+        }
+
+        private static async Task InstallUpdate()
+        {            
+            if (await Driver.Instance.HasUpdate())
+            {
+                await Driver.Instance.InstallUpdate();
+            }
+        }
+
+        #endregion
+
         #region I/O
 
         private static async Task LoadSettings(FileInfo file)

--- a/OpenTabletDriver.Console/Program.cs
+++ b/OpenTabletDriver.Console/Program.cs
@@ -31,6 +31,7 @@ namespace OpenTabletDriver.Console
             root.AddRange(DebugCommands);
             root.AddRange(ModifyCommands);
             root.AddRange(RequestCommands);
+            root.AddRange(UpdateCommands);
             root.AddRange(ListCommands);
             root.AddRange(ScriptingCommands);
 
@@ -83,7 +84,13 @@ namespace OpenTabletDriver.Console
             CreateCommand(GetTools, "Gets the currently enabled tools")
         };
 
-        private static IEnumerable<Command> ListCommands = new Command[]
+        private static readonly IEnumerable<Command> UpdateCommands = new Command[]
+        {
+            CreateCommand(HasUpdate, "Check for any updates"),
+            CreateCommand(InstallUpdate, "Install update")
+        };
+
+        private static readonly IEnumerable<Command> ListCommands = new Command[]
         {
             CreateCommand(ListOutputModes, "Lists all available output modes"),
             CreateCommand(ListFilters, "Lists all available filters"),

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -439,8 +439,7 @@ namespace OpenTabletDriver.Daemon
 
         public Task InstallUpdate()
         {
-            var targetDir = AppDomain.CurrentDomain.BaseDirectory;
-            return Updater?.InstallUpdate(targetDir) ?? Task.CompletedTask;
+            return Updater?.InstallUpdate() ?? Task.CompletedTask;
         }
     }
 }

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -7,11 +7,13 @@ using System.Threading.Tasks;
 using OpenTabletDriver.Desktop;
 using OpenTabletDriver.Desktop.Binding;
 using OpenTabletDriver.Desktop.Contracts;
+using OpenTabletDriver.Desktop.Interop;
 using OpenTabletDriver.Desktop.Migration;
 using OpenTabletDriver.Desktop.Profiles;
 using OpenTabletDriver.Desktop.Reflection;
 using OpenTabletDriver.Desktop.Reflection.Metadata;
 using OpenTabletDriver.Desktop.RPC;
+using OpenTabletDriver.Desktop.Updater;
 using OpenTabletDriver.Interop;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Devices;
@@ -76,6 +78,7 @@ namespace OpenTabletDriver.Daemon
         private Settings? Settings { set; get; }
         private Collection<LogMessage> LogMessages { set; get; } = new Collection<LogMessage>();
         private Collection<ITool> Tools { set; get; } = new Collection<ITool>();
+        private IUpdater Updater = DesktopInterop.Updater;
         private readonly SleepDetectionThread SleepDetection;
 
         private bool debugging;
@@ -427,6 +430,17 @@ namespace OpenTabletDriver.Daemon
         {
             if (report != null && tablet != null)
                 DeviceReport?.Invoke(this, new DebugReportData(tablet, report));
+        }
+
+        public Task<bool> HasUpdate()
+        {
+            return Updater?.HasUpdate ?? Task.FromResult(false);
+        }
+
+        public Task InstallUpdate()
+        {
+            var targetDir = AppDomain.CurrentDomain.BaseDirectory;
+            return Updater?.InstallUpdate(targetDir) ?? Task.CompletedTask;
         }
     }
 }

--- a/OpenTabletDriver.Desktop/Contracts/IDriverDaemon.cs
+++ b/OpenTabletDriver.Desktop/Contracts/IDriverDaemon.cs
@@ -37,5 +37,8 @@ namespace OpenTabletDriver.Desktop.Contracts
         Task<string> RequestDeviceString(int vendorID, int productID, int index);
 
         Task<IEnumerable<LogMessage>> GetCurrentLog();
+
+        Task<bool> HasUpdate();
+        Task InstallUpdate();
     }
 }

--- a/OpenTabletDriver.Desktop/Interop/DesktopInterop.cs
+++ b/OpenTabletDriver.Desktop/Interop/DesktopInterop.cs
@@ -5,6 +5,7 @@ using OpenTabletDriver.Desktop.Interop.Input.Absolute;
 using OpenTabletDriver.Desktop.Interop.Input.Keyboard;
 using OpenTabletDriver.Desktop.Interop.Input.Relative;
 using OpenTabletDriver.Desktop.Interop.Timer;
+using OpenTabletDriver.Desktop.Updater;
 using OpenTabletDriver.Interop;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Platform.Display;
@@ -20,6 +21,7 @@ namespace OpenTabletDriver.Desktop.Interop
         {
         }
 
+        private static IUpdater updater;
         private static IVirtualScreen virtualScreen;
         private static IAbsolutePointer absolutePointer;
         private static IRelativePointer relativePointer;
@@ -59,6 +61,13 @@ namespace OpenTabletDriver.Desktop.Interop
                     break;
             }
         }
+
+        public static IUpdater Updater => CurrentPlatform switch
+        {
+            PluginPlatform.Windows => updater ??= new WindowsUpdater(),
+            PluginPlatform.MacOS   => updater ??= new MacOSUpdater(),
+            _                      => null
+        };
 
         public static ITimer Timer => CurrentPlatform switch
         {

--- a/OpenTabletDriver.Desktop/Updater/IUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/IUpdater.cs
@@ -1,14 +1,10 @@
 using System.Threading.Tasks;
-using Octokit;
 
 namespace OpenTabletDriver.Desktop.Updater
 {
     public interface IUpdater
     {
-        Task<Release> GetLatestRelease();
-        Task Install(Release release);
-        Task Install(Release release, string targetDir);
-        Task<string> Download(Release release);
-        ReleaseAsset GetAsset(Release release);
+        Task<bool> HasUpdate { get; }
+        Task InstallUpdate(string targetDir);
     }
 }

--- a/OpenTabletDriver.Desktop/Updater/IUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/IUpdater.cs
@@ -5,6 +5,6 @@ namespace OpenTabletDriver.Desktop.Updater
     public interface IUpdater
     {
         Task<bool> HasUpdate { get; }
-        Task InstallUpdate(string targetDir);
+        Task InstallUpdate();
     }
 }

--- a/OpenTabletDriver.Desktop/Updater/MacOSUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/MacOSUpdater.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -11,6 +12,14 @@ namespace OpenTabletDriver.Desktop.Updater
 {
     public class MacOSUpdater : Updater
     {
+        public MacOSUpdater() : this(AssemblyVersion)
+        {
+        }
+
+        public MacOSUpdater(Version currentVersion) : base(currentVersion)
+        {
+        }
+
         protected override async Task<string> Download(Release release)
         {
             var binaryDir = Path.Join(AppInfo.Current.TemporaryDirectory, release.TagName);

--- a/OpenTabletDriver.Desktop/Updater/MacOSUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/MacOSUpdater.cs
@@ -11,7 +11,7 @@ namespace OpenTabletDriver.Desktop.Updater
 {
     public class MacOSUpdater : Updater
     {
-        public override async Task<string> Download(Release release)
+        protected override async Task<string> Download(Release release)
         {
             var binaryDir = Path.Join(AppInfo.Current.TemporaryDirectory, release.TagName);
             var asset = GetAsset(release);
@@ -28,12 +28,12 @@ namespace OpenTabletDriver.Desktop.Updater
             return binaryDir;
         }
 
-        public override ReleaseAsset GetAsset(Release release)
+        protected override ReleaseAsset GetAsset(Release release)
         {
             return release.Assets.FirstOrDefault(r => r.Name.Contains("osx-x64"));
         }
 
-        public override async Task Install(Release release, string targetDir)
+        protected override async Task Install(Release release, string targetDir)
         {
             var binaryDir = await Download(release);
             var oldDir = Path.Join(AppInfo.Current.TemporaryDirectory, CurrentVersion + "-old");

--- a/OpenTabletDriver.Desktop/Updater/Updater.cs
+++ b/OpenTabletDriver.Desktop/Updater/Updater.cs
@@ -88,7 +88,7 @@ namespace OpenTabletDriver.Desktop.Updater
             }
         }
 
-        protected static void Move(string source, string targetDir, bool root = true)
+        protected static void Move(string source, string targetDir)
         {
             if (File.Exists(source))
             {
@@ -96,10 +96,19 @@ namespace OpenTabletDriver.Desktop.Updater
             }
             else if (Directory.Exists(source))
             {
+                if (!Directory.Exists(targetDir))
+                    Directory.CreateDirectory(targetDir);
+
                 foreach (var childEntry in Directory.EnumerateFileSystemEntries(source))
                 {
-                    targetDir = root ? targetDir : Path.Join(targetDir, Path.GetFileName(Path.GetDirectoryName(childEntry)));
-                    Move(childEntry, targetDir, false);
+                    if (File.Exists(childEntry))
+                    {
+                        File.Move(childEntry, Path.Join(targetDir, Path.GetFileName(childEntry)));
+                    }
+                    else if (Directory.Exists(childEntry))
+                    {
+                        Directory.Move(childEntry, Path.Join(targetDir, Path.GetFileName(childEntry)));
+                    }
                 }
             }
             else

--- a/OpenTabletDriver.Desktop/Updater/Updater.cs
+++ b/OpenTabletDriver.Desktop/Updater/Updater.cs
@@ -1,62 +1,111 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Octokit;
+
+#nullable enable
 
 namespace OpenTabletDriver.Desktop.Updater
 {
     public abstract class Updater : IUpdater
     {
-        private GitHubClient github = new GitHubClient(new ProductHeaderValue("OpenTabletDriver"));
-        private Release latestRelease;
+        private int updateSentinel = 1;
+        private readonly GitHubClient github = new GitHubClient(new ProductHeaderValue("OpenTabletDriver"));
+        private Release? latestRelease;
 
         protected readonly Version CurrentVersion;
         protected static readonly Version AssemblyVersion = new Version(typeof(IUpdater).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion);
+        protected string BinaryDirectory;
+        protected string AppDataDirectory;
+        protected string RollbackDirectory;
+        protected string DownloadDirectory = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
 
-        public Task<bool> HasUpdate => CheckForUpdates();
+        public Task<bool> HasUpdate => CheckForUpdates(true);
 
-        protected Updater(Version currentVersion)
+        protected Updater(Version? currentVersion, string binaryDir, string appDataDir, string rollbackDir)
         {
-            this.CurrentVersion = currentVersion;
+            CurrentVersion = currentVersion ?? AssemblyVersion;
+            BinaryDirectory = binaryDir;
+            RollbackDirectory = rollbackDir;
+            AppDataDirectory = appDataDir;
+
+            if (!Directory.Exists(RollbackDirectory))
+                Directory.CreateDirectory(RollbackDirectory);
+            if (!Directory.Exists(DownloadDirectory))
+                Directory.CreateDirectory(DownloadDirectory);
         }
 
-        public async Task InstallUpdate(string targetDir)
+        public async Task InstallUpdate()
         {
-            await Install(latestRelease ?? await GetLatestRelease(), targetDir);
+            // Skip if update is already installed, or in the process of installing
+            if (Interlocked.CompareExchange(ref updateSentinel, 0, 1) == 1)
+            {
+                if (await CheckForUpdates(false))
+                {
+                    SetupRollback();
+                    await Install(latestRelease!);
+                }
+            }
         }
 
-        private async Task<bool> CheckForUpdates()
+        protected abstract Task Install(Release release);
+
+        private async Task<bool> CheckForUpdates(bool forced)
         {
-            var latestRelease = await GetLatestRelease();
+            if (forced || latestRelease == null)
+                latestRelease = await github.Repository.Release.GetLatest("OpenTabletDriver", "OpenTabletDriver"); ;
+
             var latestVersion = new Version(latestRelease.TagName[1..]); // remove `v` from `vW.X.Y.Z
             return latestVersion > CurrentVersion;
         }
 
-        private async Task<Release> GetLatestRelease()
+        private void SetupRollback()
         {
-            latestRelease = await github.Repository.Release.GetLatest("OpenTabletDriver", "OpenTabletDriver");
-            return latestRelease;
+            var versionRollbackDir = Path.Join(RollbackDirectory, CurrentVersion + "-old");
+
+            ExclusiveMove(BinaryDirectory, versionRollbackDir, "bin");
+            // ExclusiveMove(AppDataDirectory, versionRollbackDir, "data");
         }
 
-        protected async Task Install(Release release)
+        // Avoid moving the rollback directory if under source directory
+        private static void ExclusiveMove(string source, string versionRollbackDir, string target)
         {
-            var targetDir = AppDomain.CurrentDomain.BaseDirectory;
-            await Install(release, targetDir);
+            var rollbackTarget = Path.Join(versionRollbackDir, target);
+
+            var childEntries = Directory
+                .EnumerateFileSystemEntries(source)
+                .Except(new[] { versionRollbackDir });
+
+            if (!Directory.Exists(rollbackTarget))
+                Directory.CreateDirectory(rollbackTarget);
+
+            foreach (var childEntry in childEntries)
+            {
+                Move(childEntry, rollbackTarget);
+            }
         }
 
-        protected virtual async Task Install(Release release, string targetDir)
+        protected static void Move(string source, string targetDir, bool root = true)
         {
-            var binaryDir = await Download(release);
-            var oldDir = Path.Join(AppInfo.Current.TemporaryDirectory, CurrentVersion + "-old");
-
-            if (Directory.Exists(targetDir))
-                Directory.Move(targetDir, oldDir);
-
-            Directory.Move(binaryDir, targetDir);
+            if (File.Exists(source))
+            {
+                File.Move(source, Path.Join(targetDir, Path.GetFileName(source)));
+            }
+            else if (Directory.Exists(source))
+            {
+                foreach (var childEntry in Directory.EnumerateFileSystemEntries(source))
+                {
+                    targetDir = root ? targetDir : Path.Join(targetDir, Path.GetFileName(Path.GetDirectoryName(childEntry)));
+                    Move(childEntry, targetDir, false);
+                }
+            }
+            else
+            {
+                throw new ArgumentException("Provided source path is not a file or directory", nameof(source));
+            }
         }
-
-        protected abstract Task<string> Download(Release release);
-        protected abstract ReleaseAsset GetAsset(Release release);
     }
 }

--- a/OpenTabletDriver.Desktop/Updater/Updater.cs
+++ b/OpenTabletDriver.Desktop/Updater/Updater.cs
@@ -11,9 +11,15 @@ namespace OpenTabletDriver.Desktop.Updater
         private GitHubClient github = new GitHubClient(new ProductHeaderValue("OpenTabletDriver"));
         private Release latestRelease;
 
-        protected static readonly Version CurrentVersion = new Version(typeof(IUpdater).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion);
+        protected readonly Version CurrentVersion;
+        protected static readonly Version AssemblyVersion = new Version(typeof(IUpdater).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion);
 
         public Task<bool> HasUpdate => CheckForUpdates();
+
+        protected Updater(Version currentVersion)
+        {
+            this.CurrentVersion = currentVersion;
+        }
 
         public async Task InstallUpdate(string targetDir)
         {

--- a/OpenTabletDriver.Desktop/Updater/WindowsUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/WindowsUpdater.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -9,6 +10,14 @@ namespace OpenTabletDriver.Desktop.Updater
 {
     public class WindowsUpdater : Updater
     {
+        public WindowsUpdater() : this(AssemblyVersion)
+        {
+        }
+
+        public WindowsUpdater(Version currentVersion) : base(currentVersion)
+        {
+        }
+
         protected override async Task<string> Download(Release release)
         {
             var binaryDir = Path.Join(AppInfo.Current.TemporaryDirectory, release.TagName);

--- a/OpenTabletDriver.Desktop/Updater/WindowsUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/WindowsUpdater.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -10,7 +9,7 @@ namespace OpenTabletDriver.Desktop.Updater
 {
     public class WindowsUpdater : Updater
     {
-        public override async Task<string> Download(Release release)
+        protected override async Task<string> Download(Release release)
         {
             var binaryDir = Path.Join(AppInfo.Current.TemporaryDirectory, release.TagName);
             var tempZipPath = Path.Join(AppInfo.Current.TemporaryDirectory, Path.GetRandomFileName() + ".zip");
@@ -30,7 +29,7 @@ namespace OpenTabletDriver.Desktop.Updater
             return binaryDir;
         }
 
-        public override ReleaseAsset GetAsset(Release release)
+        protected override ReleaseAsset GetAsset(Release release)
         {
             return release.Assets.FirstOrDefault(r => r.Name.Contains("win-x64"));
         }

--- a/OpenTabletDriver.Desktop/Updater/WindowsUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/WindowsUpdater.cs
@@ -1,46 +1,49 @@
 using System;
-using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Octokit;
 
+#nullable enable
+
 namespace OpenTabletDriver.Desktop.Updater
 {
     public class WindowsUpdater : Updater
     {
-        public WindowsUpdater() : this(AssemblyVersion)
+        public WindowsUpdater()
+           : this(AssemblyVersion,
+               AppDomain.CurrentDomain.BaseDirectory,
+               AppInfo.Current.AppDataDirectory,
+               AppInfo.Current.TemporaryDirectory)
         {
         }
 
-        public WindowsUpdater(Version currentVersion) : base(currentVersion)
+        public WindowsUpdater(Version currentVersion, string binDirectory, string appDataDirectory, string rollBackDirectory)
+            : base(currentVersion,
+                binDirectory,
+                appDataDirectory,
+                rollBackDirectory)
         {
         }
 
-        protected override async Task<string> Download(Release release)
+        protected override async Task Install(Release release)
         {
-            var binaryDir = Path.Join(AppInfo.Current.TemporaryDirectory, release.TagName);
-            var tempZipPath = Path.Join(AppInfo.Current.TemporaryDirectory, Path.GetRandomFileName() + ".zip");
+            await Download(release);
 
-            var asset = GetAsset(release);
+            Move(DownloadDirectory, BinaryDirectory);
+        }
 
-            // Download file to temporary location
+        private async Task Download(Release release)
+        {
+            var asset = release.Assets.First(r => r.Name.Contains("win-x64"));
+
             using (var client = new HttpClient())
             using (var stream = await client.GetStreamAsync(asset.BrowserDownloadUrl))
-            using (var tempZipFile = File.Create(tempZipPath))
+            using (var zipStream = new ZipArchive(stream))
             {
-                await stream.CopyToAsync(tempZipFile);
+                zipStream.ExtractToDirectory(DownloadDirectory);
             }
-
-            // Extract
-            ZipFile.ExtractToDirectory(tempZipPath, binaryDir);
-            return binaryDir;
-        }
-
-        protected override ReleaseAsset GetAsset(Release release)
-        {
-            return release.Assets.FirstOrDefault(r => r.Name.Contains("win-x64"));
         }
     }
 }

--- a/OpenTabletDriver.Tests/UpdaterTests.cs
+++ b/OpenTabletDriver.Tests/UpdaterTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using Moq.Protected;
@@ -100,7 +101,7 @@ namespace OpenTabletDriver.Tests
                 mockUpdater.Protected()
                     .Setup<Task>("Install", ItExpr.IsAny<Release>())
                     .Returns(Task.CompletedTask)
-                    .Callback(() => callCount++);
+                    .Callback(() => Interlocked.Increment(ref callCount));
 
                 var mockUpdaterObject = mockUpdater.Object;
                 var parallelTasks = new Task[]

--- a/OpenTabletDriver.Tests/UpdaterTests.cs
+++ b/OpenTabletDriver.Tests/UpdaterTests.cs
@@ -44,8 +44,7 @@ namespace OpenTabletDriver.Tests
 
             CleanDirectory(tempDir);
 
-            var latest = await updater.GetLatestRelease();
-            await updater.Install(latest, binDir);
+            await updater.InstallUpdate(binDir);
             return binDir;
         }
 

--- a/OpenTabletDriver.Tests/UpdaterTests.cs
+++ b/OpenTabletDriver.Tests/UpdaterTests.cs
@@ -26,7 +26,29 @@ namespace OpenTabletDriver.Tests
             Assert.True(File.Exists(binaryPath));
         }
 
-        public async Task<string> TestInstall(IUpdater updater)
+        public static TheoryData<IUpdater, bool> Updater_ProperlyChecks_Version_Data => new TheoryData<IUpdater, bool>()
+        {
+            // Outdated
+            { new WindowsUpdater(new Version("0.1.0.0")), true },
+            { new MacOSUpdater(new Version("0.1.0.0")), true },
+            // Updated
+            { new WindowsUpdater(), false },
+            { new MacOSUpdater(), false },
+            // From the future
+            { new WindowsUpdater(new Version("99.0.0.0")), false },
+            { new MacOSUpdater(new Version("99.0.0.0")), false }
+        };
+
+        [Theory]
+        [MemberData(nameof(Updater_ProperlyChecks_Version_Data))]
+        public async Task Updater_ProperlyChecks_Version(IUpdater updater, bool expectedUpdateStatus)
+        {
+            var hasUpdate = await updater.HasUpdate;
+
+            Assert.Equal(expectedUpdateStatus, hasUpdate);
+        }
+
+        private async Task<string> TestInstall(IUpdater updater)
         {
             string testDir = Path.Join(
                 Environment.GetEnvironmentVariable("HOME"),

--- a/OpenTabletDriver.Tests/UpdaterTests.cs
+++ b/OpenTabletDriver.Tests/UpdaterTests.cs
@@ -1,9 +1,6 @@
 using System;
-using System.Collections;
 using System.IO;
-using System.Text;
 using System.Threading.Tasks;
-using HidSharp.Reports.Units;
 using OpenTabletDriver.Desktop;
 using OpenTabletDriver.Desktop.Updater;
 using Xunit;
@@ -12,22 +9,21 @@ namespace OpenTabletDriver.Tests
 {
     public class UpdaterTests
     {
-        [Fact]
-        public async Task TestWindowsInstall()
+        public static TheoryData<IUpdater, string> Updater_TestInstall_Data => new TheoryData<IUpdater, string>()
         {
-            var binDir = await TestInstall(new WindowsUpdater());
+            { new WindowsUpdater(), "OpenTabletDriver.UX.Wpf.exe" },
+            { new MacOSUpdater(), "OpenTabletDriver.UX.MacOS" }
+        };
 
-            var wpfUX = Path.Join(binDir, "OpenTabletDriver.UX.Wpf.exe");
-            Assert.True(File.Exists(wpfUX));
-        }
-
-        [Fact]
-        public async Task TestMacOSInstall()
+        [Theory]
+        [MemberData(nameof(Updater_TestInstall_Data))]
+        public async Task Updater_TestInstall(IUpdater updater, string expectedBinary)
         {
-            var binDir = await TestInstall(new MacOSUpdater());
+            var binDir = await TestInstall(updater);
 
-            var macOSUX = Path.Join(binDir, "OpenTabletDriver.UX.MacOS");
-            Assert.True(File.Exists(macOSUX));
+            var binaryPath = Path.Join(binDir, expectedBinary);
+
+            Assert.True(File.Exists(binaryPath));
         }
 
         public async Task<string> TestInstall(IUpdater updater)


### PR DESCRIPTION
- Depends on #1636

## Changes

- Add `Updater_PreventsUpdate_WhenAlreadyUpToDate_Async` unit test.
- Add `Updater_Prevents_ConcurrentAndConsecutive_Updates_Async` unit test.
- Refactor updater classes to remove hard dependencies against `AppInfo`.
- Add `MockEnvironment`.