### PR TITLE
build.sh: Do not continue building if an error occurs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,12 +13,12 @@ echo "Building OpenTabletDriver with runtime $runtime."
 mkdir -p ./bin
 
 echo -e "\nBuilding Daemon...\n"
-dotnet publish OpenTabletDriver.Daemon ${options[@]} $@
+dotnet publish OpenTabletDriver.Daemon ${options[@]} $@ || echo "Error building Daemon" && exit 1
 
 echo -e "\nBuilding Console...\n"
-dotnet publish OpenTabletDriver.Console ${options[@]} $@
+dotnet publish OpenTabletDriver.Console ${options[@]} $@ || echo "Error building Console" && exit 1
 
 echo -e "\nBuilding GTK UX...\n"
-dotnet publish OpenTabletDriver.UX.Gtk ${options[@]} $@
+dotnet publish OpenTabletDriver.UX.Gtk ${options[@]} $@ || echo "Error building GTK UX" && exit 1
 
 echo "Build finished. Binaries created in ./bin"


### PR DESCRIPTION
This can save the user some time if something errors out early, and it also has the nice side effect of not scrolling build errors out of view.

Pre-PR:
`./build.sh` builds everything unconditionally, even if an earlier project failed

Post-PR:
`./build.sh` exits ASAP with an error code if any of the `dotnet publish` commands fail