### PR TITLE
Update M10K.json

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M10K.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M10K.json
@@ -14,7 +14,7 @@
       }
     },
     "AuxiliaryButtons": {
-      "ButtonCount": 10
+      "ButtonCount": 11
     },
     "MouseButtons": null,
     "Touch": null


### PR DESCRIPTION
Gaomon M10K has 11 auxiliary buttons.