### PR TITLE
Move prevoius touch storage to ReportParsers

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2ReportParser.cs
@@ -1,4 +1,5 @@
 using OpenTabletDriver.Plugin.Tablet;
+using OpenTabletDriver.Plugin.Tablet.Touch;
 
 namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
 {
@@ -16,10 +17,12 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
                 {
                     0x10 => new IntuosV2Report(data),
                     0x11 => new IntuosV2AuxReport(data),
-                    0xD2 => new IntuosV2TouchReport(data),
+                    0xD2 => new IntuosV2TouchReport(data, ref prevTouches),
                     _ => new DeviceReport(data)
                 };
             }
         }
+
+        private TouchPoint[] prevTouches;
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2TouchReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2TouchReport.cs
@@ -6,7 +6,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
 {
     public struct IntuosV2TouchReport : ITouchReport
     {
-        public IntuosV2TouchReport(byte[] report)
+        public IntuosV2TouchReport(byte[] report, ref TouchPoint[] prevTouches)
         {
             Raw = report;
             Touches = prevTouches ?? new TouchPoint[MAX_POINTS];
@@ -39,7 +39,6 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
             prevTouches = (TouchPoint[])Touches.Clone();
         }
 
-        private static TouchPoint[] prevTouches;
         public const int MAX_POINTS = 16;
         public byte[] Raw { set; get; }
         public TouchPoint[] Touches { set; get; }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Wacom64bAuxReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Wacom64bAuxReportParser.cs
@@ -1,4 +1,5 @@
 ﻿using OpenTabletDriver.Plugin.Tablet;
+using OpenTabletDriver.Plugin.Tablet.Touch;
 
 namespace OpenTabletDriver.Configurations.Parsers.Wacom
 {
@@ -6,7 +7,9 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom
     {
         public virtual IDeviceReport Parse(byte[] data)
         {
-            return new WacomTouchReport(data);
+            return new WacomTouchReport(data, ref prevTouches);
         }
+
+        private TouchPoint[] prevTouches;
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/WacomTouchReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/WacomTouchReport.cs
@@ -7,7 +7,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom
 {
     public struct WacomTouchReport : ITouchReport, IAuxReport
     {
-        public WacomTouchReport(byte[] report)
+        public WacomTouchReport(byte[] report, ref TouchPoint[] prevTouches)
         {
             Raw = report;
             AuxButtons = Array.Empty<bool>();
@@ -69,7 +69,6 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom
                 mask >>= 1;
             }
         }
-        private static TouchPoint[] prevTouches;
         public const int MAX_POINTS = 16;
         public byte[] Raw { set; get; }
         public bool[] AuxButtons { set; get; }


### PR DESCRIPTION
We should have a report parser per open tablet interface, so now touch should work correctly with multiple touch tablets.
I don't have any tablets at hand atm, so if someone can test this, that would be great

closes #1665