### PR TITLE
Improve Wayland/swaywm compatibility

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -10,7 +10,6 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
 {
     public class EvdevVirtualTablet : EvdevVirtualMouse, IAbsolutePointer, IVirtualTablet
     {
-        private const int Max = 1 << 28;
         private static readonly EventCode[] BUTTONS =
         {
             EventCode.BTN_STYLUS,
@@ -19,6 +18,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
         };
 
         private Vector2 ScreenScale = new Vector2(DesktopInterop.VirtualScreen.Width, DesktopInterop.VirtualScreen.Height);
+        private int Resolution = 1000; // subpixels per screen pixel
         private bool IsEraser = false;
         private bool Proximity = true;
 
@@ -31,7 +31,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
 
             var xAbs = new input_absinfo
             {
-                maximum = Max,
+                maximum = (int)(DesktopInterop.VirtualScreen.Width * Resolution),
                 resolution = 100000
             };
             input_absinfo* xPtr = &xAbs;
@@ -39,7 +39,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
 
             var yAbs = new input_absinfo
             {
-                maximum = Max,
+                maximum = (int)(DesktopInterop.VirtualScreen.Height * Resolution),
                 resolution = 100000
             };
             input_absinfo* yPtr = &yAbs;
@@ -96,10 +96,9 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
 
         public void SetPosition(Vector2 pos)
         {
-            var newPos = pos / ScreenScale * Max;
             Device.Write(EventType.EV_KEY, IsEraser ? EventCode.BTN_TOOL_RUBBER : EventCode.BTN_TOOL_PEN, Proximity ? 1 : 0);
-            Device.Write(EventType.EV_ABS, EventCode.ABS_X, (int)newPos.X);
-            Device.Write(EventType.EV_ABS, EventCode.ABS_Y, (int)newPos.Y);
+            Device.Write(EventType.EV_ABS, EventCode.ABS_X, (int)(pos.X * Resolution));
+            Device.Write(EventType.EV_ABS, EventCode.ABS_Y, (int)(pos.Y * Resolution));
         }
 
         public void SetPressure(float percentage)

--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -32,7 +32,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
             var xAbs = new input_absinfo
             {
                 maximum = Max,
-                resolution = 100
+                resolution = 100000
             };
             input_absinfo* xPtr = &xAbs;
             Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_X, (IntPtr)xPtr);
@@ -40,7 +40,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
             var yAbs = new input_absinfo
             {
                 maximum = Max,
-                resolution = 100
+                resolution = 100000
             };
             input_absinfo* yPtr = &yAbs;
             Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_Y, (IntPtr)yPtr);

--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -100,27 +100,23 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
             Device.Write(EventType.EV_KEY, IsEraser ? EventCode.BTN_TOOL_RUBBER : EventCode.BTN_TOOL_PEN, Proximity ? 1 : 0);
             Device.Write(EventType.EV_ABS, EventCode.ABS_X, (int)newPos.X);
             Device.Write(EventType.EV_ABS, EventCode.ABS_Y, (int)newPos.Y);
-            Device.Sync();
         }
 
         public void SetPressure(float percentage)
         {
             Device.Write(EventType.EV_KEY, EventCode.BTN_TOUCH, percentage > 0 ? 1 : 0);
             Device.Write(EventType.EV_ABS, EventCode.ABS_PRESSURE, (int)(MaxPressure * percentage));
-            Device.Sync();
         }
 
         public void SetTilt(Vector2 tilt)
         {
             Device.Write(EventType.EV_ABS, EventCode.ABS_TILT_X, (int)tilt.X);
             Device.Write(EventType.EV_ABS, EventCode.ABS_TILT_Y, (int)tilt.Y);
-            Device.Sync();
         }
 
         public void SetButtonState(uint button, bool active)
         {
             Device.Write(EventType.EV_KEY, BUTTONS[button], active ? 1 : 0);
-            Device.Sync();
         }
 
         public void SetEraser(bool isEraser)
@@ -132,6 +128,10 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
         {
             Proximity = proximity;
             Device.Write(EventType.EV_ABS, EventCode.ABS_DISTANCE, (int)distance);
+        }
+
+        public void Finish()
+        {
             Device.Sync();
         }
 

--- a/OpenTabletDriver.Desktop/Output/LinuxArtistMode.cs
+++ b/OpenTabletDriver.Desktop/Output/LinuxArtistMode.cs
@@ -32,6 +32,8 @@ namespace OpenTabletDriver.Desktop.Output
 
             if (report is IProximityReport proximityReport)
                 VirtualTablet.SetProximity(proximityReport.NearProximity, proximityReport.HoverDistance);
+
+            VirtualTablet.Finish();
         }
     }
 }

--- a/OpenTabletDriver.Plugin/Platform/Pointer/IVirtualTablet.cs
+++ b/OpenTabletDriver.Plugin/Platform/Pointer/IVirtualTablet.cs
@@ -9,5 +9,6 @@ namespace OpenTabletDriver.Plugin.Platform.Pointer
         void SetButtonState(uint button, bool active);
         void SetEraser(bool isEraser);
         void SetProximity(bool proximity, uint distance);
+        void Finish();
     }
 }


### PR DESCRIPTION
This PR introduces a couple of commits, all of which try to standardize OTD's Linux Artist mode behavior to behave more like an upstreamed kernel tablet driver.

## 87446a9:
This batches the different types of reports attached to a report (position, pressure, tilt, etc) and only sends a final `Sync()` when all attributes have been resolved - this is done by adding a `Finish()` function to `IVirtualTablet`.

Most (all?) tablets batch all properties in the same report anyway, so this is likely the desired behavior that clients expect.

## 199ab4b:
This drops the square 1:1 aspect ratio tablet and instead uses a virtual tablet sized similarly to `EvdevAbsolutePointer`, ie. the same as the virtual desktop, but with a bump in resolution to keep subpixel accuracy intact. The change makes lpmm symmetric on both axises, assuming the display and tablet aspect ratios are matched.

## bf86cce:
Wayland (or at least Sway) had some serious cursor spazzing going on in non-Xwayland windows while in Artist mode. This commit significantly increases the reported lpmm of the virtual tablet, which in turn makes the cursor significantly more stable. E.g. my desktop of 4480x1440 results in a virtual tablet size of 44.8x14.4mm, rather than a size that is a few dozen meters on each axis.

Without this specific commit, even with the other changes, the cursor is uncontrollably jittery with sway.

# Summed up:
**Pre-PR**:
- Artist mode sends a `SYN_REPORT` _per property_ which likely introduces overhead, and also might confuse applications
- Artist mode virtual tablet is same size on both axises, resulting in an asymmetric lpmm.
- Artist mode is unusable in non-Xwayland windows with Sway, resulting in the cursor going literally everywhere.

**Post-PR**:
- Artist mode only sends 1 `SYN_REPORT` per tablet report handled.
- Artist mode virtual tablet dimensions are instead sized based off OTD's virtual screen coordinates, which should keep lpmm symmetric in most instances.
- Artist mode's behavior is significantly more stable with Sway, and likely other Wayland compositors - however the latter has been untested.