### PR TITLE
Improve unloadable plugin exception logging

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -82,7 +82,7 @@ namespace OpenTabletDriver.Daemon
 
         public Task WriteMessage(LogMessage message)
         {
-            Log.OnOutput(message);
+            Log.Write(message);
             return Task.CompletedTask;
         }
 

--- a/OpenTabletDriver.Desktop/Reflection/PluginManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginManager.cs
@@ -168,10 +168,13 @@ namespace OpenTabletDriver.Desktop.Reflection
                 _ = asm.DefinedTypes;
                 return true;
             }
-            catch
+            catch (Exception ex)
             {
                 var asmName = asm.GetName();
-                Log.Write("Plugin", $"Plugin '{asmName.Name}, Version={asmName.Version}' can't be loaded and is likely out of date.", LogLevel.Warning);
+                var hResultHex = ex.HResult.ToString("X");
+                Log.Write("Plugin", $"Plugin '{asmName.Name}, Version={asmName.Version}' can't be loaded and is likely out of date. (HResult: 0x{hResultHex})", LogLevel.Warning);
+                Log.Write("Plugin", $"Plugin '{asmName.Name}' Exception message: {ex.Message}", LogLevel.Debug);
+                Log.Write("Plugin", $"Plugin '{asmName.Name}' Exception stack trace: {ex.StackTrace}", LogLevel.Debug);
                 return false;
             }
         }

--- a/OpenTabletDriver.Desktop/Reflection/PluginManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginManager.cs
@@ -7,6 +7,7 @@ using System.Runtime.Loader;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Attributes;
 using OpenTabletDriver.Plugin.DependencyInjection;
+using OpenTabletDriver.Plugin.Logging;
 
 namespace OpenTabletDriver.Desktop.Reflection
 {
@@ -172,9 +173,14 @@ namespace OpenTabletDriver.Desktop.Reflection
             {
                 var asmName = asm.GetName();
                 var hResultHex = ex.HResult.ToString("X");
-                Log.Write("Plugin", $"Plugin '{asmName.Name}, Version={asmName.Version}' can't be loaded and is likely out of date. (HResult: 0x{hResultHex})", LogLevel.Warning);
-                Log.Write("Plugin", $"Plugin '{asmName.Name}' Exception message: {ex.Message}", LogLevel.Debug);
-                Log.Write("Plugin", $"Plugin '{asmName.Name}' Exception stack trace: {ex.StackTrace}", LogLevel.Debug);
+                var message = new LogMessage
+                {
+                    Group = "Plugin",
+                    Level = LogLevel.Warning,
+                    Message = $"Plugin '{asmName.Name}, Version={asmName.Version}' can't be loaded and is likely out of date. (HResult: 0x{hResultHex})",
+                    StackTrace = ex.Message + Environment.NewLine + ex.StackTrace
+                };
+                Log.OnOutput(message);
                 return false;
             }
         }

--- a/OpenTabletDriver.Desktop/Reflection/PluginManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginManager.cs
@@ -180,7 +180,7 @@ namespace OpenTabletDriver.Desktop.Reflection
                     Message = $"Plugin '{asmName.Name}, Version={asmName.Version}' can't be loaded and is likely out of date. (HResult: 0x{hResultHex})",
                     StackTrace = ex.Message + Environment.NewLine + ex.StackTrace
                 };
-                Log.OnOutput(message);
+                Log.Write(message);
                 return false;
             }
         }

--- a/OpenTabletDriver.Plugin/Log.cs
+++ b/OpenTabletDriver.Plugin/Log.cs
@@ -14,7 +14,7 @@ namespace OpenTabletDriver.Plugin
         /// Invoke sending a log message.
         /// </summary>
         /// <param name="message">The message to be passed to the <see cref="Output"/> event.</param>
-        public static void OnOutput(LogMessage message)
+        public static void Write(LogMessage message)
         {
             Output?.Invoke(null, message);
         }
@@ -50,7 +50,7 @@ namespace OpenTabletDriver.Plugin
                 Level = level,
                 StackTrace = createStackTrace ? Environment.StackTrace : null
             };
-            OnOutput(message);
+            Write(message);
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace OpenTabletDriver.Plugin
                 return;
 
             var message = new LogMessage(ex);
-            OnOutput(message);
+            Write(message);
         }
     }
 }

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -414,7 +414,7 @@ namespace OpenTabletDriver.UX
                     Message = message,
                     StackTrace = stack
                 };
-                Log.OnOutput(logMessage);
+                Log.Write(logMessage);
             }
         }
 


### PR DESCRIPTION
Plugin development/debugging is harder than it needs to be, especially when porting to the new API.
This PR increases the verbosity when plugins are unable to be loaded, which will make it more obvious why plugins aren't loading.

## Pre-PR:
- Console only tells us that the plugin could not be loaded, and that it is likely out of date

## Post-PR:
- Console now also tells us the `HRESULT` as well giving us the exception message and stacktrace at the debug info level.