### PR TITLE
Handle out of range reports (in Linux Artist Mode)

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1ReportParser.cs
@@ -21,6 +21,8 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1
         {
             if (report[0] == 0x10 && report[1] == 0x20)
                 return new DeviceReport(report);
+            if (report[1] == 0x80)
+                return new OutOfRangeReport(report);
             if (report[1].IsBitSet(5))
                 return new IntuosV1TabletReport(report);
             else if (report[1] == 0xC2)

--- a/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenReportParser.cs
@@ -6,6 +6,9 @@ namespace OpenTabletDriver.Configurations.Parsers.XP_Pen
     {
         public IDeviceReport Parse(byte[] report)
         {
+            if (report[1] == 0xC0)
+                return new OutOfRangeReport(report);
+
             if (report[1].IsBitSet(4))
                 return new XP_PenAuxReport(report);
 

--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -129,6 +129,21 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
             Device.Write(EventType.EV_ABS, EventCode.ABS_DISTANCE, (int)distance);
         }
 
+        public void ResetButtons()
+        {
+            // Zero out everything except position and tilt
+            Device.Write(EventType.EV_KEY, EventCode.BTN_TOOL_RUBBER, 0);
+            Device.Write(EventType.EV_KEY, EventCode.BTN_TOOL_PEN, 0);
+            Device.Write(EventType.EV_KEY, EventCode.BTN_TOUCH, 0);
+            Device.Write(EventType.EV_ABS, EventCode.ABS_PRESSURE, 0);
+            Device.Write(EventType.EV_KEY, EventCode.BTN_STYLUS, 0);
+            Device.Write(EventType.EV_KEY, EventCode.BTN_STYLUS2, 0);
+            Device.Write(EventType.EV_KEY, EventCode.BTN_STYLUS3, 0);
+
+            IsEraser = false;
+            Proximity = true; // we counterintuitively set this to true since its the initial state
+        }
+
         public void Sync() => Device.Sync();
 
         protected override EventCode? GetCode(MouseButton button) => null;

--- a/OpenTabletDriver.Desktop/Output/LinuxArtistMode.cs
+++ b/OpenTabletDriver.Desktop/Output/LinuxArtistMode.cs
@@ -33,6 +33,9 @@ namespace OpenTabletDriver.Desktop.Output
             if (report is IProximityReport proximityReport)
                 VirtualTablet.SetProximity(proximityReport.NearProximity, proximityReport.HoverDistance);
 
+            if (report is OpenTabletDriver.Tablet.OutOfRangeReport)
+                VirtualTablet.ResetButtons();
+
             VirtualTablet.Sync();
         }
     }

--- a/OpenTabletDriver.Desktop/Output/LinuxArtistMode.cs
+++ b/OpenTabletDriver.Desktop/Output/LinuxArtistMode.cs
@@ -33,7 +33,7 @@ namespace OpenTabletDriver.Desktop.Output
             if (report is IProximityReport proximityReport)
                 VirtualTablet.SetProximity(proximityReport.NearProximity, proximityReport.HoverDistance);
 
-            if (report is OpenTabletDriver.Tablet.OutOfRangeReport)
+            if (report is OutOfRangeReport)
                 VirtualTablet.ResetButtons();
 
             VirtualTablet.Sync();

--- a/OpenTabletDriver.Plugin/Platform/Pointer/IVirtualTablet.cs
+++ b/OpenTabletDriver.Plugin/Platform/Pointer/IVirtualTablet.cs
@@ -9,6 +9,7 @@ namespace OpenTabletDriver.Plugin.Platform.Pointer
         void SetButtonState(uint button, bool active);
         void SetEraser(bool isEraser);
         void SetProximity(bool proximity, uint distance);
+        void ResetButtons();
         void Sync();
     }
 }

--- a/OpenTabletDriver.Plugin/Tablet/OutOfRangeReport.cs
+++ b/OpenTabletDriver.Plugin/Tablet/OutOfRangeReport.cs
@@ -1,6 +1,6 @@
 using OpenTabletDriver.Plugin.Tablet;
 
-namespace OpenTabletDriver.Plugin
+namespace OpenTabletDriver.Plugin.Tablet
 {
     public struct OutOfRangeReport : IDeviceReport
     {

--- a/OpenTabletDriver.Plugin/Tablet/OutOfRangeReport.cs
+++ b/OpenTabletDriver.Plugin/Tablet/OutOfRangeReport.cs
@@ -1,0 +1,14 @@
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Plugin
+{
+    public struct OutOfRangeReport : IDeviceReport
+    {
+        public OutOfRangeReport(byte[] report)
+        {
+            Raw = report;
+        }
+
+        public byte[] Raw { set; get; }
+    }
+}


### PR DESCRIPTION
This PR addresses a few weak points on some edge cases with Linux' Artist mode, like buttons remaining clicked when pen leaves the area.

We have a thread on Out of Range reports on the Discord ([thread link](https://discord.com/channels/615607687467761684/907410063394758696/907410064720158740)) and the general consensus that this was desirable.

This is an initial implementation which as least handles Out of Range reports for Linux' Artist mode on a few tablets, but seems reasonable to extend to the rest of the project eventually.

There is a chance it might be interesting to also have this as an interface (somehow), so that plugins (or internals) can know whether a parser will send out of range reports via this method or not. Guidance is appreciated.

## 9260d28d3c9e229fe1ac6bc04bb5a17ae16c447f:
This adds and implements `OutOfRange` reports in the IntuosV1 parser (tested working on a GD-0608) **There is a chance this might not work on other IntuosV1-parsed tablet configs**

## 1baecbfa00a400cc00c177841786fa569e644633:
This adds and implements `ResetButtons()` which is called whenever a report is an `OutOfRange` report. `ResetButtons()` resets pressure, touch, tool state (eraser/pen), tip and barrel buttons.

---

Pre-PR:
- States (buttons, tool mode) could often be left hanging when the pen loses connection to the tablet unexpectedly, such as the pen laying down on the tablet, resulting in stuff like both eraser and pen ends being detected simultaneously.

Post-PR:
- IntuosV1-parsed tablets seems far more resilient against weird internal OTD/libinput states from happening
- Other parsers can easily implement OutOfRange reporting with typically 2 lines of code, enabling them to be more resilient as well.