### PR TITLE
build.sh: Exit immediately if a compilation error occurs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,12 +13,12 @@ echo "Building OpenTabletDriver with runtime $runtime."
 mkdir -p ./bin
 
 echo -e "\nBuilding Daemon...\n"
-dotnet publish OpenTabletDriver.Daemon ${options[@]} $@
+dotnet publish OpenTabletDriver.Daemon ${options[@]} $@ || exit 1
 
 echo -e "\nBuilding Console...\n"
-dotnet publish OpenTabletDriver.Console ${options[@]} $@
+dotnet publish OpenTabletDriver.Console ${options[@]} $@ || exit 2
 
 echo -e "\nBuilding GTK UX...\n"
-dotnet publish OpenTabletDriver.UX.Gtk ${options[@]} $@
+dotnet publish OpenTabletDriver.UX.Gtk ${options[@]} $@ || exit 3
 
 echo "Build finished. Binaries created in ./bin"


### PR DESCRIPTION
This PR makes the build script exit immediately if an error occurs during compilation, so that it e.g. doesn't uselessly compile console and UX if Daemon can't compile.

Pre-PR:
- The entire build script would run regardless of whether any issues occured, resulting in confusing output, and wasting the user/developers time.

Post-PR:
- The build script does not emit 'Build finished' unless all 3 `dotnet publish` commands succeeded, and it stops as soon as possible.