### PR TITLE
Gaomon S56K: Use TabletReportParser

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/S56K.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/S56K.json
@@ -23,7 +23,7 @@
       "ProductID": 109,
       "InputReportLength": 8,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {
@@ -38,7 +38,7 @@
       "ProductID": 110,
       "InputReportLength": 8,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {


### PR DESCRIPTION
Gaomon S56K has no aux keys, therefore it makes no sense to use a parser that checks for aux keys and then falling back on TabletReport.

Closes #1448