### PR TITLE
Expose tool serial and tool ID to libinput 

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -72,8 +72,9 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
             input_absinfo* yTiltPtr = &yTilt;
             Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_TILT_Y, (IntPtr)yTiltPtr);
 
+            var toolId = new input_absinfo();
             Device.EnableType(EventType.EV_MSC);
-            Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_MISC, (IntPtr)yTiltPtr); // tool ID
+            Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_MISC, (IntPtr)((input_absinfo*)&toolId)); // tool ID
             Device.EnableCode(EventType.EV_MSC, EventCode.MSC_SERIAL); // tool serial
 
             Device.EnableTypeCodes(

--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -73,8 +73,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
             Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_TILT_Y, (IntPtr)yTiltPtr);
 
             Device.EnableType(EventType.EV_MSC);
-
-            Device.EnableCode(EventType.EV_ABS, EventCode.ABS_MISC); // tool ID
+            Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_MISC, (IntPtr)yTiltPtr); // tool ID
             Device.EnableCode(EventType.EV_MSC, EventCode.MSC_SERIAL); // tool serial
 
             Device.EnableTypeCodes(

--- a/OpenTabletDriver.Desktop/Output/LinuxArtistMode.cs
+++ b/OpenTabletDriver.Desktop/Output/LinuxArtistMode.cs
@@ -33,6 +33,9 @@ namespace OpenTabletDriver.Desktop.Output
             if (report is IProximityReport proximityReport)
                 VirtualTablet.SetProximity(proximityReport.NearProximity, proximityReport.HoverDistance);
 
+            if (report is IToolReport toolReport)
+                VirtualTablet.RegisterTool(toolReport.RawToolID, toolReport.Serial);
+
             VirtualTablet.Sync();
         }
     }

--- a/OpenTabletDriver.Native/Linux/Evdev/EventType.cs
+++ b/OpenTabletDriver.Native/Linux/Evdev/EventType.cs
@@ -6,6 +6,7 @@ namespace OpenTabletDriver.Native.Linux.Evdev
         EV_KEY = 0x01,
         EV_REL = 0x02,
         EV_ABS = 0x03,
+        EV_MSC = 0x04,
         INPUT_PROP_DIRECT = 0x01
     }
 }

--- a/OpenTabletDriver.Plugin/Platform/Pointer/IVirtualTablet.cs
+++ b/OpenTabletDriver.Plugin/Platform/Pointer/IVirtualTablet.cs
@@ -9,6 +9,7 @@ namespace OpenTabletDriver.Plugin.Platform.Pointer
         void SetButtonState(uint button, bool active);
         void SetEraser(bool isEraser);
         void SetProximity(bool proximity, uint distance);
+        void RegisterTool(uint toolID, ulong toolSerial);
         void Sync();
     }
 }


### PR DESCRIPTION
This allows libinput (and clients) to handle inputs on a per-tool basis, giving a similar experience to the stock Wacom driver.

Relevant reading: [libinput docs on Tracking unique tools](https://wayland.freedesktop.org/libinput/doc/latest/tablet-support.html#tracking-unique-tools)

Pre-PR:
- libinput sees tool- and serial ID `0` for _any_ tool

Post-PR:
- libinput sees actual tool- and serial ID of the tool, if the tablet supports it. Otherwise it falls back to reporting 0.

![image](https://user-images.githubusercontent.com/421345/144153359-ecdf87c6-dacc-4cb6-8f8f-e5da3f66151c.png)

