### PR TITLE
Fix area editor sticking to cursor

### DIFF
--- a/OpenTabletDriver.UX/Controls/Output/Area/AreaDisplay.cs
+++ b/OpenTabletDriver.UX/Controls/Output/Area/AreaDisplay.cs
@@ -231,10 +231,11 @@ namespace OpenTabletDriver.UX.Controls.Output.Area
             switch (e.Buttons)
             {
                 case MouseButtons.Primary:
-                {
                     mouseDragging = true;
                     break;
-                }
+                default:
+                    mouseDragging = false;
+                    break;
             }
         }
 


### PR DESCRIPTION
Microscopic PR to fix the area editor sticking to the cursor if the user right clicks while dragging the area around.

Fixes #1073 (dunno why this was backlogged as it's literally a 2 line fix)