### PR TITLE
Linux per-user tablet configuration

### DIFF
--- a/OpenTabletDriver.Desktop/AppInfo.cs
+++ b/OpenTabletDriver.Desktop/AppInfo.cs
@@ -100,6 +100,7 @@ namespace OpenTabletDriver.Desktop
         }
 
         private string GetDefaultConfigurationDirectory() => GetDirectoryIfExists(
+            Path.Join(AppDataDirectory, "Configurations"),
             Path.Join(ProgramDirectory, "Configurations"),
             Path.Join(Environment.CurrentDirectory, "Configurations")
         );


### PR DESCRIPTION
Closes #1597

I'm not sure it's the right order to put the paths in, however.

Post-PR:
OTD will load configs from a user-accessible directory e.g. `~/.config/OpenTabletDriver/Configurations/` 