### PR TITLE
Fix IntuosReportParser to read out NearProximity==false reports (hover range fix)

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos/IntuosReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos/IntuosReportParser.cs
@@ -15,7 +15,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos
 
         private IDeviceReport GetToolReport(byte[] report)
         {
-            if (report[1].IsBitSet(5))
+            if (report[1].IsBitSet(6))
                 return new IntuosTabletReport(report);
 
             return new DeviceReport(report);


### PR DESCRIPTION
This seems to be an off-by-one error. Should fix issues with the following tablets having reduced hover range, which is a regression from 0.5.3.

Closes #1401

Needs testing:
- [ ] CTE-430
- [ ] CTE-440
- [ ] CTE-450
- [ ] CTE-460
- [ ] CTE-630
- [ ] CTE-640
- [ ] CTE-650
- [ ] CTF-430
- [ ] CTH-460
- [ ] CTH-470
- [ ] CTH-661
- [ ] CTH-670
- [ ] CTL-671
- [ ] CTL-672
- [ ] CTL-680
- [ ] ET-0405A-U
- [ ] FT-0405-U
- [x] CTH-461
- [x] CTH-480
- [x] CTH-680
- [x] CTL-460
- [x] CTL-470
- [x] CTL-471
- [x] CTL-472
- [x] CTL-480
