### PR TITLE
Use saner default file dialog locations in UX

### DIFF
--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -330,6 +330,7 @@ namespace OpenTabletDriver.UX
             var fileDialog = new OpenFileDialog
             {
                 Title = "Load OpenTabletDriver settings...",
+                Directory = new Uri(Eto.EtoEnvironment.GetFolderPath(Eto.EtoSpecialFolder.Documents)),
                 Filters =
                 {
                     new FileFilter("OpenTabletDriver Settings (*.json)", ".json")
@@ -354,7 +355,7 @@ namespace OpenTabletDriver.UX
             var fileDialog = new SaveFileDialog
             {
                 Title = "Save OpenTabletDriver settings...",
-                Directory = new Uri(AppInfo.Current.AppDataDirectory),
+                Directory = new Uri(Eto.EtoEnvironment.GetFolderPath(Eto.EtoSpecialFolder.Documents)),
                 Filters =
                 {
                     new FileFilter("OpenTabletDriver Settings (*.json)", ".json")
@@ -427,6 +428,7 @@ namespace OpenTabletDriver.UX
                 var fileDialog = new SaveFileDialog
                 {
                     Title = "Exporting diagnostic information...",
+                    Directory = new Uri(Eto.EtoEnvironment.GetFolderPath(Eto.EtoSpecialFolder.Documents)),
                     Filters =
                     {
                         new FileFilter("Diagnostic information", ".json")

--- a/OpenTabletDriver.UX/Windows/Plugins/PluginManagerWindow.cs
+++ b/OpenTabletDriver.UX/Windows/Plugins/PluginManagerWindow.cs
@@ -172,6 +172,7 @@ namespace OpenTabletDriver.UX.Windows.Plugins
             var dialog = new OpenFileDialog()
             {
                 Title = "Choose a plugin to install...",
+                Directory = new Uri(Eto.EtoEnvironment.GetFolderPath(Eto.EtoSpecialFolder.Documents)),
                 MultiSelect = true,
                 Filters =
                 {


### PR DESCRIPTION
Currently, we either use nothing, or working directory (typically install location)

This is annoying for Linux users typically because of the lack of write access, and likely unwanted for Windows users as well.

This PR changes it to Documents which is very likely to be what the user wants.