### PR TITLE
build.sh: Clean old artifacts before building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Build Artifacts
 obj/
 bin/
+bin_/
 nupkg/
 [Bb]uild/
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 # Build Artifacts
 obj/
 bin/
-bin_/
 nupkg/
 [Bb]uild/
 

--- a/build.sh
+++ b/build.sh
@@ -11,12 +11,18 @@ config=(--configuration='Release')
 
 options=(${config} --framework='net6.0' --self-contained='false' --output='./bin' /p:SuppressNETCoreSdkPreviewMessage=true /p:PublishTrimmed=false --runtime=$runtime)
 
+# change dir to script root, in case people run the script outside of the folder
+cd "$(dirname "$0")"
+
+# sanity check
+if [ ! -d OpenTabletDriver ]; then
+    echo "Could not find OpenTabletDriver folder! Chickening out..."
+    exit 1
+fi
+
 echo "Cleaning old build dirs"
 if [ -d ./bin ]; then
-    if [ -d ./bin_ ]; then
-        rm -r ./bin_
-    fi
-    mv ./bin ./bin_
+    rm -r ./bin
 fi
 dotnet clean ${config[@]}
 

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,18 @@
 runtime=${1:-linux-x64}
 shift
 
-options=(--configuration='Release' --framework='net6.0' --self-contained='false' --output='./bin' /p:SuppressNETCoreSdkPreviewMessage=true /p:PublishTrimmed=false --runtime=$runtime)
+config=(--configuration='Release')
+
+options=(${config} --framework='net6.0' --self-contained='false' --output='./bin' /p:SuppressNETCoreSdkPreviewMessage=true /p:PublishTrimmed=false --runtime=$runtime)
+
+echo "Cleaning old build dirs"
+if [ -d ./bin ]; then
+    if [ -d ./bin_ ]; then
+        rm -r ./bin_
+    fi
+    mv ./bin ./bin_
+fi
+dotnet clean ${config[@]}
 
 echo "Building OpenTabletDriver with runtime $runtime."
 mkdir -p ./bin


### PR DESCRIPTION
`dotnet publish` doesn't seem to handle consecutive builds well if code contents have changed in the mean time

This was an issue in OpenTabletDriver/OpenTabletDriver#1719

**Pre-PR**:
Old `./bin` folder is left as-is, resulting in changed files not being rebuilt, seemingly.

**Post-PR**:
We effectively `rm -r ./bin` before the build process starts.
We also run `dotnet clean` for extra insurance.
It also moves the `./bin` folder to a temporary spot (`./bin_`) in case the user runs the script in the wrong location - this can be changed, since I'm unsure of what best practice is.
