### PR TITLE
Fix detection of UC-LOGIC/TABLET 1060N.

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/UC-Logic/1060N.json
+++ b/OpenTabletDriver.Configurations/Configurations/UC-Logic/1060N.json
@@ -24,7 +24,7 @@
       "VendorID": 21827,
       "ProductID": 129,
       "InputReportLength": 8,
-      "OutputReportLength": 8,
+      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": [


### PR DESCRIPTION
OutputReportLength is wrong, however it is not checked on early version of OpenTabletDriver.

The checking is added on 14 May.
https://github.com/OpenTabletDriver/OpenTabletDriver/commit/61fc1c104aa2ac9d0645b68c6cfb1e470478ce2c#diff-ead1c5daffc97e81df240ebecb5bab2b579b17e96d74232a1ce1bf828bb60023R161

The configuration is added on 22 Apr 
https://github.com/OpenTabletDriver/OpenTabletDriver/commit/cff55a502702896c060840c8c5184d0b8c4b68fe