### PR TITLE
Fix device interface matching  for uc-logic/tablet 1060n on macos

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/UC-Logic/1060N.json
+++ b/OpenTabletDriver.Configurations/Configurations/UC-Logic/1060N.json
@@ -40,6 +40,7 @@
   ],
   "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
-    "libinputoverride": "1"
+    "libinputoverride": "1",
+    "MacInterface": "0"
   }
 }

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -192,6 +192,12 @@ namespace OpenTabletDriver
 
                     return interfaceMatches && keyMatches;
                 }
+                case PluginPlatform.MacOS:
+                {
+                    var devName = device.DevicePath;
+                    bool interfaceMatches = attributes.ContainsKey("MacInterface") ? Regex.IsMatch(devName, $"IOUSBHostInterface@{attributes["MacInterface"]}") : true;
+                    return interfaceMatches;
+                }
                 default:
                 {
                     return true;


### PR DESCRIPTION
There are three interfaces on this tablet.
On macos interfaces are enumerated non-deterministically, so sometimes invalid interface got chosen.