### PR TITLE
Load only required assemblies for reflection

### DIFF
--- a/OpenTabletDriver.Desktop/Reflection/PluginManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginManager.cs
@@ -21,7 +21,7 @@ namespace OpenTabletDriver.Desktop.Reflection
                 Assembly.Load("OpenTabletDriver.Configurations")
             };
 
-            libTypes = (from type in Assembly.GetAssembly(typeof(IDriver)).GetExportedTypes()
+            libTypes = (from type in typeof(IDriver).Assembly.GetExportedTypes()
                 where type.IsAbstract || type.IsInterface
                 select type).ToArray();
 

--- a/OpenTabletDriver.Desktop/Reflection/PluginManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginManager.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.Loader;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Attributes;
 using OpenTabletDriver.Plugin.DependencyInjection;
@@ -16,16 +15,17 @@ namespace OpenTabletDriver.Desktop.Reflection
     {
         public PluginManager()
         {
-            // FIXME: Forced assembly load by class references
-            var forcedAssemblies = new Assembly[]
+            var assemblies = new[]
             {
-                typeof(Configurations.DeviceConfigurationProvider).Assembly,
-                typeof(Native.Linux.ERRNO).Assembly
+                Assembly.Load("OpenTabletDriver.Desktop"),
+                Assembly.Load("OpenTabletDriver.Configurations")
             };
-            var assemblies = AssemblyLoadContext.Default.Assemblies.Concat(forcedAssemblies);
+
+            libTypes = (from type in Assembly.GetAssembly(typeof(IDriver)).GetExportedTypes()
+                where type.IsAbstract || type.IsInterface
+                select type).ToArray();
 
             var internalTypes = from asm in assemblies
-                where IsLoadable(asm)
                 from type in asm.DefinedTypes
                 where type.IsPublic && !(type.IsInterface || type.IsAbstract)
                 where IsPluginType(type)
@@ -38,10 +38,7 @@ namespace OpenTabletDriver.Desktop.Reflection
         public IReadOnlyCollection<TypeInfo> PluginTypes => pluginTypes;
         protected ConcurrentBag<TypeInfo> pluginTypes;
 
-        protected readonly static IEnumerable<Type> libTypes =
-            from type in Assembly.GetAssembly(typeof(IDriver)).GetExportedTypes()
-                where type.IsAbstract || type.IsInterface
-                select type;
+        protected readonly Type[] libTypes;
 
         public virtual T ConstructObject<T>(string name, object[] args = null) where T : class
         {


### PR DESCRIPTION
and also removed static modifier to libTypes, for better GC behaviour and explicit load order.

Already tested on single-file published assemblies.