### PR TITLE
Add a way to save presets through UX and Console

### DIFF
--- a/OpenTabletDriver.Console/Program.Commands.cs
+++ b/OpenTabletDriver.Console/Program.Commands.cs
@@ -46,6 +46,19 @@ namespace OpenTabletDriver.Console
             await ApplySettings(preset.GetSettings());
         }
 
+        private static async Task SavePreset(string name)
+        {
+            var presetDir = new DirectoryInfo(AppInfo.Current.PresetDirectory);
+
+            if (!presetDir.Exists)
+                presetDir.Create();
+
+            var settings = await GetSettings();
+            var file = new FileInfo(Path.Combine(presetDir.FullName, name + ".json"));
+
+            settings.Serialize(file);
+        }
+
         #endregion
 
         #region Modify Settings

--- a/OpenTabletDriver.Console/Program.cs
+++ b/OpenTabletDriver.Console/Program.cs
@@ -41,7 +41,8 @@ namespace OpenTabletDriver.Console
         {
             CreateCommand<FileInfo>(LoadSettings, "Load settings from a file", "load"),
             CreateCommand<FileInfo>(SaveSettings, "Save settings to a file", "save"),
-            CreateCommand<string>(ApplyPreset, "Apply a preset from the Presets directory", "preset")
+            CreateCommand<string>(ApplyPreset, "Apply a preset from the Presets directory", "preset"),
+            CreateCommand<string>(SavePreset, "Save the current settings to the Presets directory")
         };
 
         private static readonly IEnumerable<Command> ActionCommands = new Command[]

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -444,7 +444,7 @@ namespace OpenTabletDriver.UX
             }
         }
 
-        public Task LoadPresets()
+        private Task LoadPresets()
         {
             var presetDir = new DirectoryInfo(AppInfo.Current.PresetDirectory);
 

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -159,6 +159,9 @@ namespace OpenTabletDriver.UX
             var refreshPresets = new Command { MenuText = "Refresh presets" };
             refreshPresets.Executed += async (sender, e) => await RefreshPresets();
 
+            var savePreset = new Command { MenuText = "Save as preset..." };
+            savePreset.Executed += (sender, e) => SavePresetDialog();
+
             var detectTablet = new Command { MenuText = "Detect tablet", Shortcut = Application.Instance.CommonModifier | Keys.D };
             detectTablet.Executed += async (sender, e) => await Driver.Instance.DetectTablets();
 
@@ -200,6 +203,7 @@ namespace OpenTabletDriver.UX
                             applySettings,
                             new SeparatorMenuItem(),
                             refreshPresets,
+                            savePreset,
                             new ButtonMenuItem
                             {
                                 Text = "Presets",
@@ -491,6 +495,28 @@ namespace OpenTabletDriver.UX
             }
 
             return Task.CompletedTask;
+        }
+
+        private void SavePresetDialog()
+        {
+            var fileDialog = new SaveFileDialog
+            {
+                Title = "Save OpenTabletDriver settings as preset...",
+                Directory = new Uri(AppInfo.Current.PresetDirectory),
+                Filters =
+                {
+                    new FileFilter("OpenTabletDriver Settings (*.json)", ".json")
+                }
+            };
+            switch (fileDialog.ShowDialog(this))
+            {
+                case DialogResult.Ok:
+                case DialogResult.Yes:
+                    var file = new FileInfo(fileDialog.FileName);
+                    if (App.Current.Settings is Settings settings)
+                        settings.Serialize(file);
+                    break;
+            }
         }
 
         public static void PresetButtonHandler(object sender, EventArgs e)

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -160,7 +160,7 @@ namespace OpenTabletDriver.UX
             refreshPresets.Executed += async (sender, e) => await RefreshPresets();
 
             var savePreset = new Command { MenuText = "Save as preset..." };
-            savePreset.Executed += (sender, e) => SavePresetDialog();
+            savePreset.Executed += async (sender, e) => await SavePresetDialog();
 
             var detectTablet = new Command { MenuText = "Detect tablet", Shortcut = Application.Instance.CommonModifier | Keys.D };
             detectTablet.Executed += async (sender, e) => await Driver.Instance.DetectTablets();
@@ -497,7 +497,7 @@ namespace OpenTabletDriver.UX
             return Task.CompletedTask;
         }
 
-        private void SavePresetDialog()
+        private async Task SavePresetDialog()
         {
             var fileDialog = new SaveFileDialog
             {
@@ -515,6 +515,7 @@ namespace OpenTabletDriver.UX
                     var file = new FileInfo(fileDialog.FileName);
                     if (App.Current.Settings is Settings settings)
                         settings.Serialize(file);
+                        await RefreshPresets();
                     break;
             }
         }


### PR DESCRIPTION
## Changes

- Add a new "Save as preset..." item right under the existing "Refresh presets" item. 
  - I thought "Save settings as preset..." would've been better as it's more explicit, but that ends up making the entire File menu wider, so maybe not worth it.
  - The item opens up a file dialog to the presets directory, which is not as "elegant" as a special window for it, but this does give more control into the directory. Not sure what's best here.
- Added console command `savepreset <name>` which saves the current settings into the presets directory with the name provided.

## Issues
- Closes #1742 