### PR TITLE
Add help command to OTD.Console

### DIFF
--- a/OpenTabletDriver.Console/Program.Commands.cs
+++ b/OpenTabletDriver.Console/Program.Commands.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
+using System.CommandLine.Help;
+using System.CommandLine.IO;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -366,6 +368,17 @@ namespace OpenTabletDriver.Console
         {
             while (await System.Console.In.ReadLineAsync() is string cmd)
                 await Root.InvokeAsync(cmd);
+        }
+
+        #endregion
+
+        #region Miscellaneous
+
+        private static Task Help()
+        {
+            var helpBuilder = new HelpBuilder(new SystemConsole());
+            helpBuilder.Write(Root);
+            return Task.CompletedTask;
         }
 
         #endregion

--- a/OpenTabletDriver.Console/Program.cs
+++ b/OpenTabletDriver.Console/Program.cs
@@ -33,6 +33,7 @@ namespace OpenTabletDriver.Console
             root.AddRange(RequestCommands);
             root.AddRange(ListCommands);
             root.AddRange(ScriptingCommands);
+            root.AddRange(MiscellaneousCommands);
 
             return root;
         }
@@ -97,6 +98,11 @@ namespace OpenTabletDriver.Console
             CreateCommand(GetDiagnostics, "Gets diagnostic information"),
             CreateCommand(STDIO, "Open with standard input and output", "stdio"),
             CreateCommand(EditSettings, "Opens the settings file with the editor defined in the EDITOR environment variable.", "edit")
+        };
+
+        private static readonly IEnumerable<Command> MiscellaneousCommands = new Command[]
+        {
+            CreateCommand(Help, "Shows this help page")
         };
     }
 }


### PR DESCRIPTION
## Changes

- Add a `help` command to the console, shows the exact same help that `System.CommandLine` normally does.

## Issues

- Closes #1674 

---

Honestly this is more of a mistake on [dotnet/command-line-api](https://github.com/dotnet/command-line-api)'s part and I would guess that they'll do something about it as their API matures, but for the time being this does close an issue here, so.