### PR TITLE
Fix `detect tablet` not disposing outdated pipelines

### DIFF
--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -160,7 +160,7 @@ namespace OpenTabletDriver.UX
             refreshPresets.Executed += async (sender, e) => await RefreshPresets();
 
             var detectTablet = new Command { MenuText = "Detect tablet", Shortcut = Application.Instance.CommonModifier | Keys.D };
-            detectTablet.Executed += async (sender, e) => await Driver.Instance.DetectTablets();
+            detectTablet.Executed += async (sender, e) => await DetectTablet();
 
             var showTabletDebugger = new Command { MenuText = "Tablet debugger..." };
             showTabletDebugger.Executed += (sender, e) => App.Current.DebuggerWindow.Show();
@@ -500,6 +500,12 @@ namespace OpenTabletDriver.UX
             App.Current.Settings = preset.GetSettings();
             App.Driver.Instance.SetSettings(App.Current.Settings);
             Log.Write("Settings", $"Applied preset '{preset.Name}'");
+        }
+
+        private async Task DetectTablet()
+        {
+            await Driver.Instance.DetectTablets();
+            await Driver.Instance.SetSettings(await Driver.Instance.GetSettings());
         }
 
         private async Task ExportDiagnostics()

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -201,8 +201,8 @@ namespace OpenTabletDriver
 
         public void Dispose()
         {
-            foreach (InputDeviceTree tree in InputDevices)
-                foreach (InputDevice dev in tree.InputDevices)
+            foreach (InputDeviceTree tree in InputDevices.ToList())
+                foreach (InputDevice dev in tree.InputDevices.ToList())
                     dev.Dispose();
         }
     }

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -42,6 +42,7 @@ namespace OpenTabletDriver
 
             Log.Write("Detect", "Searching for tablets...");
 
+            Dispose();
             InputDevices.Clear();
             foreach (var config in _deviceConfigurationProvider.TabletConfigurations)
             {

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -28,7 +28,7 @@ namespace OpenTabletDriver
         public event EventHandler<IEnumerable<TabletReference>>? TabletsChanged;
 
         public ICompositeDeviceHub CompositeDeviceHub { get; }
-        public IList<InputDeviceTree> InputDevices { get; } = new List<InputDeviceTree>();
+        public InputDeviceTreeList InputDevices { get; } = new();
         public IEnumerable<TabletReference> Tablets => InputDevices.Select(c => c.CreateReference());
 
         public IReportParser<IDeviceReport> GetReportParser(DeviceIdentifier identifier)
@@ -42,7 +42,6 @@ namespace OpenTabletDriver
 
             Log.Write("Detect", "Searching for tablets...");
 
-            Dispose();
             InputDevices.Clear();
             foreach (var config in _deviceConfigurationProvider.TabletConfigurations)
             {

--- a/OpenTabletDriver/InputDeviceTreeList.cs
+++ b/OpenTabletDriver/InputDeviceTreeList.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace OpenTabletDriver
+{
+    public class InputDeviceTreeList : Collection<InputDeviceTree>
+    {
+        public new void Clear()
+        {
+            var outdatedDevices = new List<InputDevice>();
+            foreach (var tree in base.Items)
+                foreach (var dev in tree.InputDevices)
+                    outdatedDevices.Add(dev);
+            
+            foreach (var dev in outdatedDevices)
+                dev.Dispose();
+            
+            base.Clear();
+        }
+    }
+}

--- a/OpenTabletDriver/InputDeviceTreeList.cs
+++ b/OpenTabletDriver/InputDeviceTreeList.cs
@@ -5,7 +5,7 @@ namespace OpenTabletDriver
 {
     public class InputDeviceTreeList : Collection<InputDeviceTree>
     {
-        public new void Clear()
+        protected override void ClearItems()
         {
             var outdatedDevices = new List<InputDevice>();
             foreach (var tree in base.Items)
@@ -15,7 +15,7 @@ namespace OpenTabletDriver
             foreach (var dev in outdatedDevices)
                 dev.Dispose();
             
-            base.Clear();
+            base.ClearItems();
         }
     }
 }


### PR DESCRIPTION
Seems to work on my end, #1745 is no longer reproducible after following the steps in the video.
Haven't noticed any other side effects.

## Changes

- Add a call to `Dispose` during tablet detection in `Driver`.
- Modify `Dispose` to use `List`s since .NET doesn't allow modifications during enumeration.

## Issues
- Closes #1745 
