### PR TITLE
Refactor HandleTabletsChanged in TabletSwitcherPanel to be less redundant

### DIFF
--- a/OpenTabletDriver.Desktop/Profiles/ProfileCollection.cs
+++ b/OpenTabletDriver.Desktop/Profiles/ProfileCollection.cs
@@ -26,7 +26,7 @@ namespace OpenTabletDriver.Desktop.Profiles
         public Profile this[TabletReference tablet]
         {
             set => SetProfile(tablet, value);
-            get => GetProfile(tablet);
+            get => GetProfileOrGenerate(tablet);
         }
 
         public void SetProfile(TabletReference tablet, Profile profile)
@@ -38,7 +38,7 @@ namespace OpenTabletDriver.Desktop.Profiles
             this.Add(profile);
         }
 
-        public Profile GetProfile(TabletReference tablet)
+        public Profile GetProfileOrGenerate(TabletReference tablet)
         {
             return this.FirstOrDefault(t => t.Tablet == tablet.Properties.Name) is Profile profile ? profile : Generate(tablet);
         }

--- a/OpenTabletDriver.UX/Controls/TabletSwitcherPanel.cs
+++ b/OpenTabletDriver.UX/Controls/TabletSwitcherPanel.cs
@@ -123,15 +123,8 @@ namespace OpenTabletDriver.UX.Controls
                 visibleProfiles.Clear();
                 if (tablets.Any())
                 {
-                    var tabletsWithoutProfile = from tablet in tablets
-                        where !profiles.Any(p => p.Tablet == tablet.Properties.Name)
-                        select tablet;
-
-                    foreach (var tablet in tabletsWithoutProfile)
-                        profiles.Generate(tablet);
-
                     foreach (var tablet in tablets)
-                        visibleProfiles.Add(Profiles.FirstOrDefault(p => p.Tablet == tablet.Properties.Name));
+                        visibleProfiles.Add(profiles.GetProfile(tablet));
 
                     if (this.SelectedIndex < 0)
                     {

--- a/OpenTabletDriver.UX/Controls/TabletSwitcherPanel.cs
+++ b/OpenTabletDriver.UX/Controls/TabletSwitcherPanel.cs
@@ -124,7 +124,7 @@ namespace OpenTabletDriver.UX.Controls
                 if (tablets.Any())
                 {
                     foreach (var tablet in tablets)
-                        visibleProfiles.Add(profiles.GetProfile(tablet));
+                        visibleProfiles.Add(profiles.GetProfileOrGenerate(tablet));
 
                     if (this.SelectedIndex < 0)
                     {


### PR DESCRIPTION
Small PR to refactor the `HandleTabletsChanged` function in TabletSwitcherPanel to be a bit cleaner and less redundant, relying on existing functionality instead of checking for existing profiles - instead, we just call `GetProfile` for every tablet, which already generates profiles for tablets without them.

This should be more efficient, resulting in fewer queries of the profile collection (avoids the linq as well) and fewer foreach loops.

I've also renamed the aforementioned `GetProfile` function to `GetProfileOrGenerate` to more accurately reflect its behavior. This probably could/should be in its own PR but it's just a rename.

Tested on my setup with my one tablet, seems to work fine, would appreciate further testing to ensure I haven't caused any regressions or edge cases here. As far as I can tell, it's 1:1 behavior.