### PR TITLE
Fix NPE on macos

### DIFF
--- a/OpenTabletDriver.UX/TrayIcon.cs
+++ b/OpenTabletDriver.UX/TrayIcon.cs
@@ -17,7 +17,7 @@ namespace OpenTabletDriver.UX
                 Title = "OpenTabletDriver",
                 Image = App.Logo
             };
-			Indicator.Activated += (object sender, System.EventArgs e) =>
+
             RefreshMenuItems();
 
             Indicator.Activated += (object sender, System.EventArgs e) =>


### PR DESCRIPTION
On macos TrayIndicator can not be shown with null menu