### PR TITLE
Handle OutOfRange reports in tablet debugger

### DIFF
--- a/OpenTabletDriver.UX/Tools/ReportFormatter.cs
+++ b/OpenTabletDriver.UX/Tools/ReportFormatter.cs
@@ -35,6 +35,8 @@ namespace OpenTabletDriver.UX.Tools
                 sb.AppendLines(GetStringFormat(mouseReport));
             if (report is IToolReport toolReport)
                 sb.AppendLines(GetStringFormat(toolReport));
+            if (report is OutOfRangeReport oorReport)
+                sb.AppendLines(GetStringFormat(oorReport));
 
             return sb.ToString();
         }
@@ -90,6 +92,11 @@ namespace OpenTabletDriver.UX.Tools
             yield return $"Tool:{Enum.GetName(typeof(ToolType), toolReport.Tool)}";
             yield return $"RawToolID:{toolReport.RawToolID}";
             yield return $"Serial:{toolReport.Serial}";
+        }
+
+        private static IEnumerable<string> GetStringFormat(OutOfRangeReport oorReport)
+        {
+            yield return $"Pen is out of Range";
         }
 
         private static void AppendLines(this StringBuilder sb, IEnumerable<string> lines)


### PR DESCRIPTION
Fixes #1733

## Pre-PR:
When pen leaves range, tablet debugger "Tablet Report" field is empty.

## Post-PR:
Tablet debugger "Tablet Report" field reports "Pen is out of Range" when pen leaves range.

## Notes:

Note that as of current `master`, tablet debugger throws an exception when pen goes out of range. This is happens regardless of the PR and is tracked in #1771.