### PR TITLE
Improve config for UG-LOGIC/1060n

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/UC-Logic/1060N.json
+++ b/OpenTabletDriver.Configurations/Configurations/UC-Logic/1060N.json
@@ -8,7 +8,7 @@
       "MaxY": 30480.0
     },
     "Pen": {
-      "MaxPressure": 8191,
+      "MaxPressure": 2047,
       "Buttons": {
         "ButtonCount": 2
       }
@@ -24,7 +24,7 @@
       "VendorID": 21827,
       "ProductID": 129,
       "InputReportLength": 8,
-      "OutputReportLength": null,
+      "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": [
@@ -36,11 +36,27 @@
       "InitializationStrings": [
         100
       ]
+    },
+    {
+      "VendorID": 21827,
+      "ProductID": 129,
+      "InputReportLength": 8,
+      "OutputReportLength": 0,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
+      "FeatureInitReport": null,
+      "DeviceStrings": {
+        "201": "F600_A60n_E\\d{4}$"
+      },
+      "InitializationStrings": [
+        100
+      ],
+      "Attributes": {
+        "MacInterface": "0"
+      }
     }
   ],
   "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
-    "libinputoverride": "1",
-    "MacInterface": "0"
+    "libinputoverride": "1"
   }
 }

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -27,7 +27,7 @@
 | Huion WH1409                  |     Supported     |
 | Huion WH1409 V2               |     Supported     |
 | Parblo A640 V2                |     Supported     |
-| UC-Logic 1060N                |     Supported     |
+| UC-Logic 1060N                |     Supported     | Windows: Some variants might requires Zadig's WinUSB to be installed on interface 0
 | UC-Logic PF1209               |     Supported     |
 | UGTABLET M708                 |     Supported     |
 | VEIKK A15                     |     Supported     |


### PR DESCRIPTION
I find from old discord message that there are indeed two variants of xp-pen star 03 v1 with same pair of pid/vid and same set of device strings.

This first variant don't have output report, and can only be used on windows with winusb.
[discord](https://discord.com/channels/615607687467761684/615611007951306863/825352999961362433)
I own this one.


The second variant have extra output report for activating the device. No need to use winusb on widows.
[discord](https://discord.com/channels/615607687467761684/615611007951306863/834760454516506674)
[discord](https://discord.com/channels/615607687467761684/615611007951306863/834758580099874816
)

Besides, I find no confirmation for pressure, so the pressure of original config is probably wrong. 
The pressure should be 2047.

Depends on #1793 

