### PR TITLE
DesktopInterop: Use fallback timer on Linux

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/DesktopInterop.cs
+++ b/OpenTabletDriver.Desktop/Interop/DesktopInterop.cs
@@ -72,7 +72,6 @@ namespace OpenTabletDriver.Desktop.Interop
         public static ITimer Timer => CurrentPlatform switch
         {
             PluginPlatform.Windows => new WindowsTimer(),
-            PluginPlatform.Linux   => new LinuxTimer(),
             _                      => new FallbackTimer()
         };
 


### PR DESCRIPTION
This closes #1727 and seems to have good enough performance that we could in theory use this in time for the 0.6.x milestone

It does at least run BezierInterp at 1000Hz which I think is good enough.

Reminder that this opens a new issue, one that restores `LinuxTimer`.