### PR TITLE
Add an extra case for touch reports in IntuosV2

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2ReportParser.cs
@@ -17,6 +17,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
                 {
                     0x10 => new IntuosV2Report(data),
                     0x11 => new IntuosV2AuxReport(data),
+                    0x21 => new IntuosV2TouchReport(data, ref prevTouches),
                     0xD2 => new IntuosV2TouchReport(data, ref prevTouches),
                     _ => new DeviceReport(data)
                 };


### PR DESCRIPTION
The original `0xD2` case was occurring when the official driver was installed, when it's not `data[0]` for touch is `0x21`.