### PR TITLE
Refresh PluginSettingStoreCollectionEditor's Content when assemblies change

### DIFF
--- a/OpenTabletDriver.UX/Controls/PluginSettingStoreCollectionEditor.cs
+++ b/OpenTabletDriver.UX/Controls/PluginSettingStoreCollectionEditor.cs
@@ -47,6 +47,8 @@ namespace OpenTabletDriver.UX.Controls
 
             if (!Platform.IsMac) // Don't do this on macOS, causes poor UI performance.
                 settingStoreEditor.BackgroundColor = SystemColors.WindowBackground;
+
+            AppInfo.PluginManager.AssembliesChanged += HandleAssembliesChanged;
         }
 
         private Placeholder placeholder;
@@ -70,7 +72,14 @@ namespace OpenTabletDriver.UX.Controls
         protected virtual void OnStoreCollectionChanged()
         {
             StoreCollectionChanged?.Invoke(this, new EventArgs());
-            this.Content = sourceSelector.DataStore?.Any() ?? false ? mainContent : placeholder;
+            RefreshContent();
+        }
+
+        private void HandleAssembliesChanged(object sender, EventArgs e) => Application.Instance.AsyncInvoke(RefreshContent);
+
+        private void RefreshContent()
+        {
+            this.Content = AppInfo.PluginManager.GetChildTypes<TSource>().Any() ? mainContent : placeholder;
         }
 
         public BindableBinding<PluginSettingStoreCollectionEditor<TSource>, PluginSettingStoreCollection> StoreCollectionBinding


### PR DESCRIPTION
This allows plugins to be displayed in the Filters or Tools tab when they are first added.
Changed from `sourceSelector.DataStore` to getting child types directly to avoid depending on a specific execution order.
`TypeListBox` was used as the main point of reference.

Closes #1402

My understanding is that the plugin list (when it's there) is refreshing using this, so I ported it over to `PluginSettingStoreCollectionEditor` to also refresh the tabs: https://github.com/OpenTabletDriver/OpenTabletDriver/blob/d75802318360092d4d2c287fd923a797c636569c/OpenTabletDriver.UX/Controls/Generic/Reflection/TypeListBox.cs#L45-L53