### PR TITLE
Add `dotnet format` linting to & clean up .NET workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -88,7 +88,7 @@ jobs:
         env:
           runtime: win-x64
         run: |
-          $options=@('--configuration', 'Release', '-p:PublishSingleFile=true', '-p:DebugType=embedded', '--no-self-contained', '-p:SourceRevisionId=$(git rev-parse --short HEAD)')
+          $options=@("--configuration", "Release", "-p:PublishSingleFile=true", "-p:DebugType=embedded", "--no-self-contained", "-p:SourceRevisionId=$(git rev-parse --short HEAD)")
           dotnet publish OpenTabletDriver.Daemon $options --runtime $ENV:runtime -o build/$ENV:runtime
           dotnet publish OpenTabletDriver.Console $options --runtime $ENV:runtime -o build/$ENV:runtime
           dotnet publish OpenTabletDriver.UX.Wpf $options --runtime $ENV:runtime -o build/$ENV:runtime

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,4 +1,4 @@
-name: .NET Core
+name: .NET CI
 
 on:
   push:
@@ -10,12 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     name: Linux Publish
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout
+        uses: actions/checkout@v2
+
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '6.0'
           include-prerelease: True
+
       - name: Linux Publish
         env:
           runtime: linux-x64
@@ -24,14 +27,16 @@ jobs:
           dotnet publish OpenTabletDriver.Daemon $options --runtime $runtime -o build/$runtime
           dotnet publish OpenTabletDriver.Console $options --runtime $runtime -o build/$runtime
           dotnet publish OpenTabletDriver.UX.Gtk $options --runtime $runtime -o build/$runtime
+
       - name: Upload Linux artifacts
         uses: actions/upload-artifact@master
         with:
           name: OpenTabletDriver linux-x64
           path: build/linux-x64
+
       - name: Generate udev Rules
-        run: |
-          ./generate-rules.sh
+        run: ./generate-rules.sh
+
       - name: Upload udev Rules
         uses: actions/upload-artifact@master
         with:
@@ -42,12 +47,15 @@ jobs:
     runs-on: ubuntu-latest
     name: MacOS Publish
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout
+        uses: actions/checkout@v2
+
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '6.0'
           include-prerelease: True
+
       - name: MacOS Publish
         env:
           runtime: osx-x64
@@ -56,6 +64,7 @@ jobs:
           dotnet publish OpenTabletDriver.Daemon $options --runtime $runtime -o build/$runtime
           dotnet publish OpenTabletDriver.Console $options --runtime $runtime -o build/$runtime
           dotnet publish OpenTabletDriver.UX.MacOS $options --runtime $runtime -o build/$runtime
+
       - name: Upload MacOS artifacts
         uses: actions/upload-artifact@master
         with:
@@ -66,12 +75,15 @@ jobs:
     runs-on: windows-latest
     name: Windows Publish
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout
+        uses: actions/checkout@v2
+
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '6.0'
           include-prerelease: True
+
       - name: Windows Publish
         env:
           runtime: win-x64
@@ -80,8 +92,30 @@ jobs:
           dotnet publish OpenTabletDriver.Daemon $options --runtime $ENV:runtime -o build/$ENV:runtime
           dotnet publish OpenTabletDriver.Console $options --runtime $ENV:runtime -o build/$ENV:runtime
           dotnet publish OpenTabletDriver.UX.Wpf $options --runtime $ENV:runtime -o build/$ENV:runtime
+
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@master
         with:
           name: OpenTabletDriver win-x64
           path: build/win-x64
+
+  linter:
+    name: dotnet format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files
+          fetch-depth: 0
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0'
+          include-prerelease: True
+
+      - name: Lint Changed Files
+        run: |
+          mapfile -t files < <(git diff --name-only --diff-filter=AM HEAD^ HEAD | grep '.*\.cs$')
+          if [ ${#files[@]} -ne 0 ]; then dotnet format --verify-no-changes --include "${files[@]}"; fi

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -23,10 +23,10 @@ jobs:
         env:
           runtime: linux-x64
         run: |
-          options="--configuration Release -p:DebugType=embedded -p:PublishTrimmed=false --no-self-contained -p:SourceRevisionId=$(git rev-parse --short HEAD)"
-          dotnet publish OpenTabletDriver.Daemon $options --runtime $runtime -o build/$runtime
-          dotnet publish OpenTabletDriver.Console $options --runtime $runtime -o build/$runtime
-          dotnet publish OpenTabletDriver.UX.Gtk $options --runtime $runtime -o build/$runtime
+          read -ra options <<< "--configuration Release -p:DebugType=embedded -p:PublishTrimmed=false --no-self-contained -p:SourceRevisionId=$(git rev-parse --short HEAD)"
+          dotnet publish OpenTabletDriver.Daemon "${options[@]}" --runtime "$runtime" -o "build/$runtime"
+          dotnet publish OpenTabletDriver.Console "${options[@]}" --runtime "$runtime" -o "build/$runtime"
+          dotnet publish OpenTabletDriver.UX.Gtk "${options[@]}" --runtime "$runtime" -o "build/$runtime"
 
       - name: Upload Linux artifacts
         uses: actions/upload-artifact@master
@@ -60,10 +60,10 @@ jobs:
         env:
           runtime: osx-x64
         run: |
-          options="--configuration Release -p:DebugType=embedded -p:PublishTrimmed=false --no-self-contained -p:SourceRevisionId=$(git rev-parse --short HEAD)"
-          dotnet publish OpenTabletDriver.Daemon $options --runtime $runtime -o build/$runtime
-          dotnet publish OpenTabletDriver.Console $options --runtime $runtime -o build/$runtime
-          dotnet publish OpenTabletDriver.UX.MacOS $options --runtime $runtime -o build/$runtime
+          read -ra options <<< "--configuration Release -p:DebugType=embedded -p:PublishTrimmed=false --no-self-contained -p:SourceRevisionId=$(git rev-parse --short HEAD)"
+          dotnet publish OpenTabletDriver.Daemon "${options[@]}" --runtime "$runtime" -o "build/$runtime"
+          dotnet publish OpenTabletDriver.Console "${options[@]}" --runtime "$runtime" -o "build/$runtime"
+          dotnet publish OpenTabletDriver.UX.MacOS "${options[@]}" --runtime "$runtime" -o "build/$runtime"
 
       - name: Upload MacOS artifacts
         uses: actions/upload-artifact@master

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,6 +1,7 @@
 name: .NET CI
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 jobs:


### PR DESCRIPTION
## Changes

- Add `dotnet format` linting to the .NET CI, only applies to `.cs` files changed in the current commit.
- Separate all steps with newlines
- Reorder step notation to have name first, add missing names for checkouts
- Bump `actions/checkout@v1` to `v2`
- Rename workflow to ".NET CI"

Sample runs:

- [Passing run with files changed](https://github.com/vedattt/OpenTabletDriver/runs/4645733509)
- [Passing run with no `.cs` files changed](https://github.com/vedattt/OpenTabletDriver/runs/4645718434)
- [Failing run with files changed](https://github.com/vedattt/OpenTabletDriver/runs/4645724398)
- [Another failing run with files changed](https://github.com/vedattt/OpenTabletDriver/runs/4645728715)

On average, the linting seems to take roughly 40 seconds.