### PR TITLE
Notify user on tablet detect when vanguard is running

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -89,14 +89,13 @@ namespace OpenTabletDriver.Daemon
         /// Checks for any problematic processes running on the user's computer that may
         /// impair function or detection of tablets.
         /// </summary>
-        private Task CheckForProblematicProcesses()
+        private void CheckForProblematicProcesses()
         {
             if (SystemInterop.CurrentPlatform == PluginPlatform.Windows)
             {
                 if (Process.GetProcessesByName("vgc").Length > 0)
                     Log.Write("Detect", "Valorant's anti-cheat program Vanguard is detected. Tablet function may be impaired.", LogLevel.Warning);
             }
-            return Task.CompletedTask;
         }
 
         public Task WriteMessage(LogMessage message)
@@ -148,7 +147,7 @@ namespace OpenTabletDriver.Daemon
         public async Task<IEnumerable<TabletReference>> DetectTablets()
         {
             Driver.Detect();
-            await CheckForProblematicProcesses();
+            await Task.Run(CheckForProblematicProcesses);
 
             foreach (var tablet in Driver.InputDevices)
             {

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -70,11 +70,6 @@ namespace OpenTabletDriver.Daemon
             });
 
             SleepDetection.Start();
-
-            if (SystemInterop.CurrentPlatform == PluginPlatform.Windows && Process.GetProcessesByName("vanguard").Length > 0)
-            {
-                Log.Write("Detect", "Valorant's anti-cheat program Vanguard is detected. Tablet function may be impaired.", LogLevel.Warning);
-            }
         }
 
         public event EventHandler<LogMessage>? Message;
@@ -89,6 +84,20 @@ namespace OpenTabletDriver.Daemon
         private readonly SleepDetectionThread SleepDetection;
 
         private bool debugging;
+
+        /// <summary>
+        /// Checks for any problematic processes running on the user's computer that may
+        /// impair function or detection of tablets.
+        /// </summary>
+        private Task CheckForProblematicProcesses()
+        {
+            if (SystemInterop.CurrentPlatform == PluginPlatform.Windows)
+            {
+                if (Process.GetProcessesByName("vgc").Length > 0)
+                    Log.Write("Detect", "Valorant's anti-cheat program Vanguard is detected. Tablet function may be impaired.", LogLevel.Warning);
+            }
+            return Task.CompletedTask;
+        }
 
         public Task WriteMessage(LogMessage message)
         {
@@ -139,6 +148,7 @@ namespace OpenTabletDriver.Daemon
         public async Task<IEnumerable<TabletReference>> DetectTablets()
         {
             Driver.Detect();
+            await CheckForProblematicProcesses();
 
             foreach (var tablet in Driver.InputDevices)
             {

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -85,19 +85,6 @@ namespace OpenTabletDriver.Daemon
 
         private bool debugging;
 
-        /// <summary>
-        /// Checks for any problematic processes running on the user's computer that may
-        /// impair function or detection of tablets.
-        /// </summary>
-        private void CheckForProblematicProcesses()
-        {
-            if (SystemInterop.CurrentPlatform == PluginPlatform.Windows)
-            {
-                if (Process.GetProcessesByName("vgc").Length > 0)
-                    Log.Write("Detect", "Valorant's anti-cheat program Vanguard is detected. Tablet function may be impaired.", LogLevel.Warning);
-            }
-        }
-
         public Task WriteMessage(LogMessage message)
         {
             Log.Write(message);
@@ -147,7 +134,7 @@ namespace OpenTabletDriver.Daemon
         public async Task<IEnumerable<TabletReference>> DetectTablets()
         {
             Driver.Detect();
-            await Task.Run(CheckForProblematicProcesses);
+            await Task.Run(CheckForProblematicProcesses).ConfigureAwait(false);
 
             foreach (var tablet in Driver.InputDevices)
             {
@@ -291,6 +278,19 @@ namespace OpenTabletDriver.Daemon
 
             relativeMode.ResetTime = settings.ResetTime;
             Log.Write(group, $"Reset time: {relativeMode.ResetTime}");
+        }
+
+        /// <summary>
+        /// Checks for any problematic processes running on the user's computer that may
+        /// impair function or detection of tablets, such as video game anti-cheat software.
+        /// </summary>
+        private void CheckForProblematicProcesses()
+        {
+            if (SystemInterop.CurrentPlatform == PluginPlatform.Windows)
+            {
+                if (Process.GetProcessesByName("vgc").Any())
+                    Log.Write("Detect", "Valorant's anti-cheat program Vanguard is detected. Tablet function may be impaired.", LogLevel.Warning);
+            }
         }
 
         private void SetBindingHandlerSettings(InputDeviceTree dev, IOutputMode outputMode, BindingSettings settings, TabletReference tabletReference)

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -290,6 +290,8 @@ namespace OpenTabletDriver.Daemon
             {
                 if (Process.GetProcessesByName("vgc").Any())
                     Log.Write("Detect", "Valorant's anti-cheat program Vanguard is detected. Tablet function may be impaired.", LogLevel.Warning);
+                if (Process.GetProcessesByName("VALORANT-Win64-Shipping").Any())
+                    Log.Write("Detect", "Valorant is detected. Tablet function may be impaired.", LogLevel.Warning);
             }
         }
 

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Diagnostics;
 using Octokit;
 using OpenTabletDriver.Desktop;
 using OpenTabletDriver.Desktop.Binding;
@@ -69,6 +70,11 @@ namespace OpenTabletDriver.Daemon
             });
 
             SleepDetection.Start();
+
+            if (SystemInterop.CurrentPlatform == PluginPlatform.Windows && Process.GetProcessesByName("vanguard").Length > 0)
+            {
+                Log.Write("Detect", "Valorant's anti-cheat program Vanguard is detected. Tablet function may be impaired.", LogLevel.Warning);
+            }
         }
 
         public event EventHandler<LogMessage>? Message;


### PR DESCRIPTION
Small PR to add a warning notification when the daemon starts, if vanguard (valorant's anti cheat) is found to be running. It's fairly common for this to cause issues even when the user isn't actually playing valorant - this might allow a struggling user to self-troubleshoot, or give us a head's up in diagnostics.

Opened as draft as I can't personally test this (don't have valorant installed as I don't play it, not sure if I have the process name right), will open fully once someone can confirm it works.