### PR TITLE
Correct the Deco Mini4 name

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Mini4.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Mini4.json
@@ -1,5 +1,5 @@
 {
-  "Name": "XP-Pen Deco Mini 4",
+  "Name": "XP-Pen Deco Mini4",
   "Specifications": {
     "Digitizer": {
       "Width": 101.6,

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco mini4.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco mini4.json
@@ -1,5 +1,5 @@
 {
-  "Name": "XP-Pen Deco Mini4",
+  "Name": "XP-Pen Deco mini4",
   "Specifications": {
     "Digitizer": {
       "Width": 101.6,

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -71,7 +71,7 @@
 | XP-Pen CT460                  |     Supported     |
 | XP-Pen Deco Fun L (CT1060)    |     Supported     |
 | XP-Pen Deco 01                |     Supported     |
-| XP-Pen Deco Mini4             |     Supported     |
+| XP-Pen Deco mini4             |     Supported     |
 | XP-Pen Star 03                |     Supported     |
 | XP-Pen Star G430              |     Supported     | Windows: Zadig's WinUSB on interface 1 required for older variations
 | XP-Pen Star G430S             |     Supported     |

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -71,7 +71,7 @@
 | XP-Pen CT460                  |     Supported     |
 | XP-Pen Deco Fun L (CT1060)    |     Supported     |
 | XP-Pen Deco 01                |     Supported     |
-| XP-Pen Deco Mini 4            |     Supported     |
+| XP-Pen Deco Mini4             |     Supported     |
 | XP-Pen Star 03                |     Supported     |
 | XP-Pen Star G430              |     Supported     | Windows: Zadig's WinUSB on interface 1 required for older variations
 | XP-Pen Star G430S             |     Supported     |


### PR DESCRIPTION
The Deco Mini4 name was incorrect, having a space where it shouldn't be and i have corrected this.