### PR TITLE
Add UCLogic Tilt Parser

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicTiltReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicTiltReportParser.cs
@@ -1,0 +1,15 @@
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.UCLogic
+{
+    public class UCLogicTiltReportParser : IReportParser<IDeviceReport>
+    {
+        public IDeviceReport Parse(byte[] data)
+        {
+            if (data[1].IsBitSet(6))
+                return new UCLogicAuxReport(data);
+            else
+                return new TiltTabletReport(data);
+        }
+    }
+}

--- a/OpenTabletDriver.Plugin/Tablet/TiltTabletReport.cs
+++ b/OpenTabletDriver.Plugin/Tablet/TiltTabletReport.cs
@@ -5,7 +5,7 @@ namespace OpenTabletDriver.Plugin.Tablet
 {
     public struct TiltTabletReport : ITabletReport, ITiltReport
     {
-        internal TiltTabletReport(byte[] report)
+        public TiltTabletReport(byte[] report)
         {
             Raw = report;
 


### PR DESCRIPTION
This seems missing according to OpenTabletDriver#1445

I've copied the normal UCLogic Parser and changed it to use `TiltTabletReport` instead.