### PR TITLE
Kamvas Pro 16: Use Huion.GianoReportParser

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16.json
@@ -25,7 +25,7 @@
       "ProductID": 109,
       "InputReportLength": 12,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {


### PR DESCRIPTION
This fixes wrap-around at X positions > 65535 (rightmost side of the pen display)