### PR TITLE
Invert Y tilt axis when using UCLogicTiltReportParser

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicTiltReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicTiltReportParser.cs
@@ -9,7 +9,7 @@ namespace OpenTabletDriver.Configurations.Parsers.UCLogic
             if (data[1].IsBitSet(6))
                 return new UCLogicAuxReport(data);
             else
-                return new TiltTabletReport(data);
+                return new TiltTabletReport(data, false, true);
         }
     }
 }

--- a/OpenTabletDriver.Plugin/Tablet/TiltTabletReport.cs
+++ b/OpenTabletDriver.Plugin/Tablet/TiltTabletReport.cs
@@ -5,7 +5,7 @@ namespace OpenTabletDriver.Plugin.Tablet
 {
     public struct TiltTabletReport : ITabletReport, ITiltReport
     {
-        public TiltTabletReport(byte[] report)
+        public TiltTabletReport(byte[] report, bool invertTiltX, bool invertTiltY)
         {
             Raw = report;
 
@@ -16,8 +16,8 @@ namespace OpenTabletDriver.Plugin.Tablet
             };
             Tilt = new Vector2
             {
-                X = (sbyte)report[10],
-                Y = (sbyte)report[11]
+                X = (sbyte)(invertTiltX ? -1 : 1) * (sbyte)report[10],
+                Y = (sbyte)(invertTiltY ? -1 : 1) * (sbyte)report[11]
             };
             Pressure = Unsafe.ReadUnaligned<ushort>(ref report[6]);
 
@@ -28,6 +28,8 @@ namespace OpenTabletDriver.Plugin.Tablet
                 penByte.IsBitSet(2)
             };
         }
+
+        public TiltTabletReport(byte[] report) : this(report, false, false) { }
 
         public byte[] Raw { set; get; }
         public Vector2 Position { set; get; }


### PR DESCRIPTION
## Introduction
While testing UCLogic tilt support using RTP-700 with Krita and MyPaint on Linux, I've observed that the Y tilt axis is inverted. 

## Description
These changes inverts the Y tilt axis when a TiltTabletReport is generated by the UCLogicTiltReportParser.

## Notes
- This assumes that the tilt axes for other devices have no issues when on Linux (making this specific to the UCLogic parser and unlikely somewhere else like libevent)
- Haven't tested on Windows/Mac (If it works properly on other platforms, then it's possible that the problem lies with the libevent integration instead)