### PR TITLE
Fix middle button binding on macos

### DIFF
--- a/OpenTabletDriver.Native/OSX/Generic/CGEventType.cs
+++ b/OpenTabletDriver.Native/OSX/Generic/CGEventType.cs
@@ -12,8 +12,8 @@
         kCGEventRightMouseDragged = 7,
         kCGEventKeyDown = 10,
         kCGEventKeyUp = 11,
-        kCGEventOtherMouseDown = 16,
-        kCGEventOtherMouseUp = 17,
-        kCGEventOtherMouseDragged = 27 // Possibly incorrect, based on other docs
+        kCGEventOtherMouseDown = 25,
+        kCGEventOtherMouseUp = 26,
+        kCGEventOtherMouseDragged = 27
     }
 }


### PR DESCRIPTION
The enum values are incorrect.