### PR TITLE
DriverDaemon.cs: Check for stdout before blindly assuming it exists

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -37,7 +37,8 @@ namespace OpenTabletDriver.Daemon
             Log.Output += (sender, message) =>
             {
                 LogMessages.Add(message);
-                Console.WriteLine(Log.GetStringFormat(message));
+                if (((StreamWriter)Console.Out).BaseStream != null)
+                    Console.WriteLine(Log.GetStringFormat(message));
                 Message?.Invoke(sender, message);
             };
 


### PR DESCRIPTION
On some systems stdout might be missing.

This handles that by checking if the `BaseStream` exists before doing a `WriteLine`.

Fixes OpenTabletDriver#1855