### PR TITLE
Fix PTZ-x30/31W hover distance

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3ReportParser.cs
@@ -22,9 +22,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3
             return data[1] switch
             {
                 0xE0 => new IntuosV1TabletReport(data),
-                0xEA => new IntuosV1TabletReport(data),
                 0xA0 => new IntuosV1TabletReport(data),
-                0xAA => new IntuosV1TabletReport(data), 
                 0xF0 => new Intuos3MouseReport(data),
                 0xB0 => new Intuos3MouseReport(data),
                 _ => new DeviceReport(data)

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3ReportParser.cs
@@ -22,6 +22,9 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3
             return data[1] switch
             {
                 0xE0 => new IntuosV1TabletReport(data),
+                0xEA => new IntuosV1TabletReport(data),
+                0xA0 => new IntuosV1TabletReport(data),
+                0xAA => new IntuosV1TabletReport(data), 
                 0xF0 => new Intuos3MouseReport(data),
                 0xB0 => new Intuos3MouseReport(data),
                 _ => new DeviceReport(data)


### PR DESCRIPTION
Currently PTZ-x30/31W tablets have a few mm of their hover cut off ~~and around half of the reports sent when using a ZP-600 pen get ignored (for reasons detailed below).~~

This fixes hover distance and is sent when nearly at max hover distance but still contains proper position data.
```
0xA0 => new IntuosV1TabletReport(data),
```

~~These two fix the ZP-600. For some reason it sends a combination of 0xE0 and 0xEA reports when hovering at low distance and 0xA0 and 0xAA at near max distance.~~
```
0xEA => new IntuosV1TabletReport(data),
0xAA => new IntuosV1TabletReport(data), 
```

~~It is also worth noting that the ZP-600 sends rotation reports so that should be supported eventually. But that is outside the scope of this PR.~~