### PR TITLE
Release Workflow: Add version suffix input to workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,12 +2,18 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      version_suffix:
+        description: 'The version suffix for this manual build.'
+        required: false
   release:
-    types: [published]
+    types: [ published ]
 jobs:
   unix:
     runs-on: ubuntu-latest
     name: Unix Release
+    env:
+      VERSION_SUFFIX: ${{ github.event.inputs.version_suffix }}
     steps:
       - name: Checkout Packaging Repository
         uses: actions/checkout@v2
@@ -18,40 +24,65 @@ jobs:
         with:
           repository: 'OpenTabletDriver/OpenTabletDriver'
           path: 'src/OpenTabletDriver'
-      - name: Checkout OpenTabletDriver-udev Repository
-        uses: actions/checkout@v2
-        with:
-          repository: 'OpenTabletDriver/OpenTabletDriver-udev'
-          path: 'src/OpenTabletDriver-udev'
-          submodules: false
-      - name: Link modules
-        run: |
-          rm -rf ${GITHUB_WORKSPACE}/src/OpenTabletDriver-udev/.modules/OpenTabletDriver; ln -s ${GITHUB_WORKSPACE}/src/OpenTabletDriver ${GITHUB_WORKSPACE}/src/OpenTabletDriver-udev/.modules/OpenTabletDriver
-          if [ -e ${GITHUB_WORKSPACE}/src/OpenTabletDriver-udev/.modules/OpenTabletDriver ]; then echo "Successfully linked."; else exit 1; fi
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '6.0'
           include-prerelease: True
       - name: Debian Build
-        run: ./Debian/package build
+        run: ./Debian/package
+      - name: RPM Build
+        run: ./Redhat/package
       - name: Generic Linux Build
-        run: ./Linux/package build
+        run: ./Linux/package
       - name: MacOS Build
-        run: ./MacOS/package build
-      - name: Upload release assets
+        run: ./MacOS/package
+
+      - name: Upload all assets (Release)
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
             ./Debian/OpenTabletDriver.deb
+            ./Redhat/OpenTabletDriver.rpm
             ./Linux/OpenTabletDriver.linux-x64.tar.gz
             ./MacOS/OpenTabletDriver.osx-x64.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Debian asset (Dispatch)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/upload-artifact@master
+        with:
+          name: OpenTabletDriver.deb
+          path: ./Debian/OpenTabletDriver.deb
+
+      - name: Upload RPM asset (Dispatch)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/upload-artifact@master
+        with:
+          name: OpenTabletDriver.rpm
+          path: ./Redhat/OpenTabletDriver.rpm
+
+      - name: Upload generic Linux asset (Dispatch)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/upload-artifact@master
+        with:
+          name: OpenTabletDriver.linux-x64.tar.gz
+          path: ./Linux/OpenTabletDriver.linux-x64.tar.gz
+
+      - name: Upload macOS asset (Dispatch)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/upload-artifact@master
+        with:
+          name: OpenTabletDriver.osx-x64.tar.gz
+          path: ./MacOS/OpenTabletDriver.osx-x64.tar.gz
+
   windows:
     runs-on: windows-latest
     name: Windows Release
+    env:
+      VERSION_SUFFIX: ${{ github.event.inputs.version_suffix }}
     steps:
       - name: Checkout Packaging Repository
         uses: actions/checkout@v2
@@ -68,12 +99,19 @@ jobs:
           dotnet-version: '6.0'
           include-prerelease: True
       - name: Package
-        run: ./Windows/package.ps1 build
-      - name: Upload assets for tag
+        run: ./Windows/package.ps1
+
+      - name: Upload Windows asset (Release)
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: |
-            ./Windows/OpenTabletDriver.win-x64.zip
+          files: ./Windows/OpenTabletDriver.win-x64.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Windows asset (Dispatch)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/upload-artifact@master
+        with:
+          name: OpenTabletDriver.win-x64.zip
+          path: ./Windows/OpenTabletDriver.win-x64.zip


### PR DESCRIPTION
This addition allows us to create release candidates with CI from the actions tab. The version suffix input will be appended to the version number which can be used to identify the build.