### PR TITLE
AreaDisplay: Make selected area partially transparent

### DIFF
--- a/OpenTabletDriver.UX/Controls/Output/Area/AreaDisplay.cs
+++ b/OpenTabletDriver.UX/Controls/Output/Area/AreaDisplay.cs
@@ -361,6 +361,7 @@ namespace OpenTabletDriver.UX.Controls.Output.Area
                 graphics.TranslateTransform(-area.Center);
 
                 graphics.FillRectangle(AccentColor, area);
+                graphics.DrawRectangle(SystemColors.ControlText, area);
 
                 var originEllipse = new RectangleF(0, 0, 1, 1);
                 originEllipse.Offset(area.Center - (originEllipse.Size / 2));

--- a/OpenTabletDriver.UX/Controls/Output/Area/AreaDisplay.cs
+++ b/OpenTabletDriver.UX/Controls/Output/Area/AreaDisplay.cs
@@ -223,7 +223,7 @@ namespace OpenTabletDriver.UX.Controls.Output.Area
         private static readonly Font Font = SystemFonts.User(8);
         private static readonly Brush TextBrush = new SolidBrush(SystemColors.ControlText);
 
-        private readonly Color AccentColor = SystemColors.Highlight;
+        private readonly Color AccentColor = new Color(SystemColors.Highlight, 0.5f);
         private readonly Color AreaBoundsFillColor = SystemColors.ControlBackground;
         private readonly Color AreaBoundsBorderColor = SystemInterop.CurrentPlatform switch
         {


### PR DESCRIPTION
This allow for oversized or mismatched areas to be visualised, which fixes OpenTabletDriver#1890

Example on a 1920x1080+2560x1440 side-by-side monitor setup with a ~203x162mm tablet set to 300x168.75mm area
![2022-01-08-191418_grimshot](https://user-images.githubusercontent.com/421345/148655204-6a998fd4-349d-44d2-b4aa-3da6ac264d71.png)

Normal example with border:
![image](https://user-images.githubusercontent.com/421345/163896428-dd1e1b3d-d558-483f-b559-7942992a913b.png)
