### PR TITLE
PluginMetadataCollection: Delete directory before extracting

### DIFF
--- a/OpenTabletDriver.Desktop/Reflection/Metadata/PluginMetadataCollection.cs
+++ b/OpenTabletDriver.Desktop/Reflection/Metadata/PluginMetadataCollection.cs
@@ -67,8 +67,9 @@ namespace OpenTabletDriver.Desktop.Reflection.Metadata
                 string hash = CalculateSHA256(memStream);
                 string cacheDir = Path.Join(AppInfo.Current.CacheDirectory, $"{hash}-OpenTabletDriver-PluginMetadata");
 
-                if (!Directory.Exists(cacheDir))
-                    archive.ExtractContents(cacheDir);
+                if (Directory.Exists(cacheDir))
+                    Directory.Delete(cacheDir, true);
+                archive.ExtractContents(cacheDir);
 
                 var collection = EnumeratePluginMetadata(cacheDir);
                 var metadataCollection = new PluginMetadataCollection(collection);


### PR DESCRIPTION
Note: This breaks caching of plugin metadata, however the repo is relatively small so it wasn't saving much data in the first place.

Closes #1898 