### PR TITLE
Backup settings file before migrating

### DIFF
--- a/OpenTabletDriver.Desktop/Migration/SettingsMigrator.cs
+++ b/OpenTabletDriver.Desktop/Migration/SettingsMigrator.cs
@@ -18,6 +18,11 @@ namespace OpenTabletDriver.Desktop.Migration
         public static void Migrate(AppInfo appInfo)
         {
             var file = new FileInfo(appInfo.SettingsFile);
+
+            // Back up existing settings file for safety, in case migration goes wrong
+            var fileCopy = file.CopyTo(file.Name + ".old");
+            Log.Write("Settings", $"Old settings found, and have been backed up to {fileCopy.FullName}.");
+
             if (Migrate(file) is Settings settings)
             {
                 Log.Write("Settings", "Settings have been migrated.");

--- a/OpenTabletDriver.Desktop/Migration/SettingsMigrator.cs
+++ b/OpenTabletDriver.Desktop/Migration/SettingsMigrator.cs
@@ -19,13 +19,13 @@ namespace OpenTabletDriver.Desktop.Migration
         {
             var file = new FileInfo(appInfo.SettingsFile);
 
-            // Back up existing settings file for safety, in case migration goes wrong
-            var fileCopy = file.CopyTo(file.Name + ".old");
-            Log.Write("Settings", $"Old settings found, and have been backed up to {fileCopy.FullName}.");
-
             if (Migrate(file) is Settings settings)
             {
                 Log.Write("Settings", "Settings have been migrated.");
+
+                // Back up existing settings file for safety
+                file.CopyTo(file.Name + ".old", true);
+
                 Serialization.Serialize(file, settings);
             }
         }


### PR DESCRIPTION
Small PR to make the existing settings file be backed up to `settings.json.old` before migration happens. 