### PR TITLE
Disable running TimerTests in parallel with other unit tests

### DIFF
--- a/OpenTabletDriver.Tests/TimerTests.cs
+++ b/OpenTabletDriver.Tests/TimerTests.cs
@@ -8,6 +8,8 @@ using Xunit;
 
 namespace OpenTabletDriver.Tests
 {
+    [CollectionDefinition(nameof(TimerTests), DisableParallelization = true)]
+    [Collection(nameof(TimerTests))]
     public class TimerTests
     {
         private const double TOLERANCE = 0.075;


### PR DESCRIPTION
Helps in improving the test result's reliability when running multiple tests at once.