### PR TITLE
Add a new digitizer identifier for Huion 420

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/420.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/420.json
@@ -32,6 +32,22 @@
       "InitializationStrings": [
         100
       ]
+    },
+    {
+      "VendorID": 9580,
+      "ProductID": 110,
+      "InputReportLength": 8,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "6": "^$",
+        "121": "H850_F210"
+      },
+      "InitializationStrings": [
+        100
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [],


### PR DESCRIPTION
Fixes #1903 
Some Huion 420 (osu! Tablet) can have an empty device string at the index 6.

So I check for an empty string at the index 6 and also check that the index 121 contains `H850_F210`.

Other tablets can have this string at the index 121 but not with also an empty one at the index 6.