### PR TITLE
Specify full path for settings backup

### DIFF
--- a/OpenTabletDriver.Desktop/Migration/SettingsMigrator.cs
+++ b/OpenTabletDriver.Desktop/Migration/SettingsMigrator.cs
@@ -24,7 +24,7 @@ namespace OpenTabletDriver.Desktop.Migration
                 Log.Write("Settings", "Settings have been migrated.");
 
                 // Back up existing settings file for safety
-                file.CopyTo(file.Name + ".old", true);
+                file.CopyTo(file.FullName + ".old", true);
 
                 Serialization.Serialize(file, settings);
             }


### PR DESCRIPTION
Fixes issues with `settings.json.old` getting written to an inaccessible directory.