### PR TITLE
Update: new identifier for Huion H1161

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/H1161.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H1161.json
@@ -34,6 +34,21 @@
       "InitializationStrings": [
         200
       ]
+    },
+    {
+      "VendorID": 9580,
+      "ProductID": 100,
+      "InputReportLength": 12,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "201": "HUION_T191_\\d{6}$"
+      },
+      "InitializationStrings": [
+        200
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [],


### PR DESCRIPTION
My Huion H1161 (bought in November 2021) cannot be recognized by OTD, and I managed to find its `ProductID`.

![image](https://user-images.githubusercontent.com/13536040/149135583-2ac9ba62-2fda-4dfe-a091-d1e49b9a5db3.png)

This PR adds the digitizer identifier for the new model of H1161.