### PR TITLE
Huion 420: Fix exact match device strings

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/420.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/420.json
@@ -27,7 +27,7 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {
-        "6": "420"
+        "6": "^420$"
       },
       "InitializationStrings": [
         100
@@ -43,7 +43,7 @@
       "OutputInitReport": null,
       "DeviceStrings": {
         "6": "^$",
-        "121": "H850_F210"
+        "121": "^H850_F210$"
       },
       "InitializationStrings": [
         100


### PR DESCRIPTION
Fix all exact match regexes only for Huion 420.

e.g: just `420` as a regex also matches `H420`