### PR TITLE
Add support for XP-Pen Deco 01 V2 (variant 2)

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01 V2 (variant 2).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01 V2 (variant 2).json
@@ -1,5 +1,5 @@
 {
-  "Name": "XP-Pen Deco 01 V2 V2",
+  "Name": "XP-Pen Deco 01 V2 (variant 2)",
   "Specifications": {
     "Digitizer": {
       "Width": 254.0,

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01 V2 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01 V2 V2.json
@@ -1,0 +1,43 @@
+{
+  "Name": "XP-Pen Deco 01 V2 V2",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 254.0,
+      "Height": 158.75,
+      "MaxX": 50800.0,
+      "MaxY": 31750.0
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "Buttons": {
+        "ButtonCount": 2
+      }
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 8
+    },
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 10429,
+      "ProductID": 2309,
+      "InputReportLength": 12,
+      "OutputReportLength": 10,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": [
+        "ArAE"
+      ],
+      "DeviceStrings": {
+        "4": "UG902_BPG1002"
+      },
+      "InitializationStrings": []
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -145,7 +145,7 @@
 | XP-Pen Artist Pro 12          |  Missing Features | Tilt and wheel are unsupported.
 | XP-Pen Artist Pro 15.6        |  Missing Features | Tilt and wheel are unsupported.
 | XP-Pen Deco 01 V2             |  Missing Features | Tilt is unsupported.
-| XP-Pen Deco 01 V2 V2          |  Missing Features | Tilt is unsupported
+| XP-Pen Deco 01 V2 (variant 2) |  Missing Features | Tilt is unsupported
 | XP-Pen Deco 02                |  Missing Features | Wheel is unsupported.
 | XP-Pen Deco 03                |  Missing Features | Wheel is unsupported.
 | XP-Pen Deco mini7             |  Missing Features |

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -145,6 +145,7 @@
 | XP-Pen Artist Pro 12          |  Missing Features | Tilt and wheel are unsupported.
 | XP-Pen Artist Pro 15.6        |  Missing Features | Tilt and wheel are unsupported.
 | XP-Pen Deco 01 V2             |  Missing Features | Tilt is unsupported.
+| XP-Pen Deco 01 V2 V2          |  Missing Features | Tilt is unsupported
 | XP-Pen Deco 02                |  Missing Features | Wheel is unsupported.
 | XP-Pen Deco 03                |  Missing Features | Wheel is unsupported.
 | XP-Pen Deco mini7             |  Missing Features |


### PR DESCRIPTION
Verification: https://discord.com/channels/615607687467761684/930837536585187360/930961622250434601

This tablet is a V2 V2 due to XP-Pen calling this tablet a V2 and this is a variant of this, so therefore this is a V2 V2, however their may be a better way of naming this, but i'm following previous variants that have been added.