### PR TITLE
Add backup directory for settings and migration

### DIFF
--- a/OpenTabletDriver.Desktop/AppInfo.cs
+++ b/OpenTabletDriver.Desktop/AppInfo.cs
@@ -17,6 +17,7 @@ namespace OpenTabletDriver.Desktop
             presetDirectory,
             temporaryDirectory,
             cacheDirectory,
+            backupDirectory,
             trashDirectory;
 
         private static AppInfo current;
@@ -88,6 +89,12 @@ namespace OpenTabletDriver.Desktop
             get => this.cacheDirectory ?? GetDefaultCacheDirectory();
         }
 
+        public string BackupDirectory
+        {
+            set => this.backupDirectory = value;
+            get => this.backupDirectory ?? GetDefaultBackupDirectory();
+        }
+
         public string TrashDirectory
         {
             set => this.trashDirectory = value;
@@ -125,6 +132,7 @@ namespace OpenTabletDriver.Desktop
         private string GetDefaultPresetDirectory() => Path.Join(AppDataDirectory, "Presets");
         private string GetDefaultTemporaryDirectory() => Path.Join(AppDataDirectory, "Temp");
         private string GetDefaultCacheDirectory() => Path.Join(AppDataDirectory, "Cache");
+        private string GetDefaultBackupDirectory() => Path.Join(AppDataDirectory, "Backup");
         private string GetDefaultTrashDirectory() => Path.Join(AppDataDirectory, "Trash");
     }
 }

--- a/OpenTabletDriver.Desktop/Migration/SettingsMigrator.cs
+++ b/OpenTabletDriver.Desktop/Migration/SettingsMigrator.cs
@@ -24,7 +24,12 @@ namespace OpenTabletDriver.Desktop.Migration
                 Log.Write("Settings", "Settings have been migrated.");
 
                 // Back up existing settings file for safety
-                file.CopyTo(file.FullName + ".old", true);
+                var backupDir = AppInfo.Current.BackupDirectory;
+                if (!Directory.Exists(backupDir))
+                    Directory.CreateDirectory(backupDir);
+
+                var backupPath = Path.Join(backupDir, file.Name + ".old");
+                file.CopyTo(backupPath, true);
 
                 Serialization.Serialize(file, settings);
             }

--- a/OpenTabletDriver.Desktop/Migration/SettingsMigrator.cs
+++ b/OpenTabletDriver.Desktop/Migration/SettingsMigrator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -28,7 +29,8 @@ namespace OpenTabletDriver.Desktop.Migration
                 if (!Directory.Exists(backupDir))
                     Directory.CreateDirectory(backupDir);
 
-                var backupPath = Path.Join(backupDir, file.Name + ".old");
+                string timestamp = DateTime.UtcNow.ToString(".yyyy-MM-dd_hh-mm-ss");
+                var backupPath = Path.Join(backupDir, file.Name + timestamp + ".old");
                 file.CopyTo(backupPath, true);
 
                 Serialization.Serialize(file, settings);

--- a/OpenTabletDriver.Desktop/Updater/MacOSUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/MacOSUpdater.cs
@@ -19,7 +19,7 @@ namespace OpenTabletDriver.Desktop.Updater
             : this(AssemblyVersion,
                 AppDomain.CurrentDomain.BaseDirectory,
                 AppInfo.Current.AppDataDirectory,
-                AppInfo.Current.TemporaryDirectory)
+                AppInfo.Current.BackupDirectory)
         {
         }
 

--- a/OpenTabletDriver.Desktop/Updater/Updater.cs
+++ b/OpenTabletDriver.Desktop/Updater/Updater.cs
@@ -126,8 +126,9 @@ namespace OpenTabletDriver.Desktop.Updater
                 .EnumerateFileSystemEntries(source)
                 .Except(new[] { rollbackDir, versionRollbackDir, Path.Join(source, "userdata") });
 
-            if (!Directory.Exists(rollbackTarget))
-                Directory.CreateDirectory(rollbackTarget);
+            if (Directory.Exists(rollbackTarget))
+                Directory.Delete(rollbackTarget, true);
+            Directory.CreateDirectory(rollbackTarget);
 
             foreach (var childEntry in childEntries)
             {

--- a/OpenTabletDriver.Desktop/Updater/Updater.cs
+++ b/OpenTabletDriver.Desktop/Updater/Updater.cs
@@ -21,12 +21,14 @@ namespace OpenTabletDriver.Desktop.Updater
         private readonly GitHubClient github = new GitHubClient(new ProductHeaderValue("OpenTabletDriver"));
         private Release? latestRelease;
 
-        protected readonly Version CurrentVersion;
+        protected Version CurrentVersion { get; }
         protected static readonly Version AssemblyVersion = typeof(IUpdater).Assembly.GetName().Version!;
-        protected string BinaryDirectory;
-        protected string AppDataDirectory;
-        protected string RollbackDirectory;
-        protected string DownloadDirectory = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
+        protected string BinaryDirectory { get; }
+        protected string AppDataDirectory { get; }
+        protected string RollbackDirectory { get; }
+        protected string DownloadDirectory { get; } = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
+
+        public string? VersionedRollbackDirectory { private set; get; }
 
         protected Updater(Version? currentVersion, string binaryDir, string appDataDir, string rollbackDir)
         {
@@ -98,11 +100,12 @@ namespace OpenTabletDriver.Desktop.Updater
 
         protected void SetupRollback()
         {
-            var versionRollbackDir = Path.Join(RollbackDirectory, CurrentVersion + "-old");
+            string timestamp = DateTime.UtcNow.ToString("-yyyy-MM-dd_hh-mm-ss");
+            VersionedRollbackDirectory = Path.Join(RollbackDirectory, CurrentVersion + timestamp);
 
-            ExclusiveFileOp(BinaryDirectory, RollbackDirectory, versionRollbackDir, "bin",
+            ExclusiveFileOp(BinaryDirectory, RollbackDirectory, VersionedRollbackDirectory, "bin",
                 static (source, target) => Move(source, target));
-            ExclusiveFileOp(AppDataDirectory, RollbackDirectory, versionRollbackDir, "appdata",
+            ExclusiveFileOp(AppDataDirectory, RollbackDirectory, VersionedRollbackDirectory, "appdata",
                 static (source, target) => Copy(source, target));
         }
 

--- a/OpenTabletDriver.Desktop/Updater/WindowsUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/WindowsUpdater.cs
@@ -15,7 +15,7 @@ namespace OpenTabletDriver.Desktop.Updater
            : this(AssemblyVersion,
                AppDomain.CurrentDomain.BaseDirectory,
                AppInfo.Current.AppDataDirectory,
-               AppInfo.Current.TemporaryDirectory)
+               AppInfo.Current.BackupDirectory)
         {
         }
 

--- a/OpenTabletDriver.Tests/UpdaterTests.cs
+++ b/OpenTabletDriver.Tests/UpdaterTests.cs
@@ -156,7 +156,7 @@ namespace OpenTabletDriver.Tests
         {
             return MockEnvironmentAsync(async (updaterEnv) =>
             {
-                var mockUpdaterObject = CreateMockUpdater<Updater>(updaterEnv).Object;
+                var mockUpdater = CreateMockUpdater<Updater>(updaterEnv).Object;
                 var wpfFile = Encoding.UTF8.GetBytes("OpenTabletDriver.UX.Wpf");
                 var daemonFile = Encoding.UTF8.GetBytes("OpenTabletDriver.Daemon");
                 var settingsFile = Encoding.UTF8.GetBytes("settings.json");
@@ -174,9 +174,9 @@ namespace OpenTabletDriver.Tests
                 };
                 await SetupFakeBinaryFilesAsync(updaterEnv, fakeBinaryFiles, fakeAppDataFiles);
 
-                await mockUpdaterObject.InstallUpdate();
+                await mockUpdater.InstallUpdate();
 
-                await VerifyFakeBinaryFilesAsync(updaterEnv, fakeBinaryFiles, fakeAppDataFiles);
+                await VerifyFakeBinaryFilesAsync(updaterEnv, mockUpdater, fakeBinaryFiles, fakeAppDataFiles);
             });
         }
 
@@ -267,11 +267,14 @@ namespace OpenTabletDriver.Tests
             }
         }
 
-        private static async Task VerifyFakeBinaryFilesAsync(UpdaterEnvironment updaterEnv,
+        private static async Task VerifyFakeBinaryFilesAsync(
+            UpdaterEnvironment updaterEnv,
+            Updater updater,
             Dictionary<string, byte[]>? fakeBinaryFiles = null,
-            Dictionary<string, byte[]>? fakeAppDataFiles = null)
+            Dictionary<string, byte[]>? fakeAppDataFiles = null
+        )
         {
-            var rollbackDir = Path.Join(updaterEnv.RollBackDir, updaterEnv.Version + "-old");
+            var rollbackDir = updater.VersionedRollbackDirectory!;
             await VerifyFakeFilesAsync(updaterEnv.BinaryDir, Path.Join(rollbackDir, "bin"), fakeBinaryFiles);
             await VerifyFakeFilesAsync(updaterEnv.AppDataDir, Path.Join(rollbackDir, "appdata"), fakeAppDataFiles);
         }

--- a/OpenTabletDriver.UX/Windows/Updater/UpdaterWindow.cs
+++ b/OpenTabletDriver.UX/Windows/Updater/UpdaterWindow.cs
@@ -77,6 +77,9 @@ namespace OpenTabletDriver.UX.Windows.Updater
                 _ => throw new NotSupportedException("Current platform does not support updating.")
             };
 
+            // Disallow multiple invocations
+            (sender as Control)!.Enabled = false;
+
             await App.Driver.Instance.InstallUpdate();
 
             Process.Start(path);


### PR DESCRIPTION
This resolves the situation where backups are stored within volatile temporary directories. This unifies all backups to a single directory.

- Closes #1948 