### PR TITLE
Updater: Add file IncludeList

### DIFF
--- a/OpenTabletDriver.Desktop/Updater/MacOSUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/MacOSUpdater.cs
@@ -34,7 +34,7 @@ namespace OpenTabletDriver.Desktop.Updater
         protected override async Task Install(Release release)
         {
             await Download(release);
-            SetupRollback();
+            PerformBackup();
 
             // Mark the binaries executable, SharpZipLib doesn't do this.
             var subPath = Path.Join(DownloadDirectory, "OpenTabletDriver.app", "Contents", "MacOS");

--- a/OpenTabletDriver.Desktop/Updater/Updater.cs
+++ b/OpenTabletDriver.Desktop/Updater/Updater.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -99,21 +100,21 @@ namespace OpenTabletDriver.Desktop.Updater
             }
         }
 
-        protected void SetupRollback()
+        protected void PerformBackup()
         {
             string timestamp = DateTime.UtcNow.ToString("-yyyy-MM-dd_hh-mm-ss");
             VersionedRollbackDirectory = Path.Join(RollbackDirectory, CurrentVersion + timestamp);
 
-            ExclusiveFileOp(BinaryDirectory, RollbackDirectory, VersionedRollbackDirectory, "bin",
+            InclusiveFileOp(BinaryDirectory, VersionedRollbackDirectory, "bin",
                 static (source, target) => Move(source, target));
-            ExclusiveFileOp(AppDataDirectory, RollbackDirectory, VersionedRollbackDirectory, "appdata",
+            ExclusiveFileOp(AppDataDirectory, RollbackDirectory, "appdata", VersionedRollbackDirectory,
                 static (source, target) => Copy(source, target));
         }
 
         protected virtual async Task Install(Release release)
         {
             await Download(release);
-            SetupRollback();
+            PerformBackup();
 
             Move(DownloadDirectory, BinaryDirectory);
         }
@@ -121,32 +122,46 @@ namespace OpenTabletDriver.Desktop.Updater
         protected abstract Task Download(Release release);
 
         // Avoid moving/copying the rollback directory if under source directory
-        protected virtual void ExclusiveFileOp(string source, string rollbackDir, string versionRollbackDir, string target,
-            Action<string, string> fileOp)
+        private void ExclusiveFileOp(string source, string backupDir, string target, string versionBackupDir, Action<string, string> fileOp)
         {
-            var rollbackTarget = Path.Join(versionRollbackDir, target);
+            var backupTarget = Path.Join(versionBackupDir, target);
 
             var excludeList = new[]
             {
-                rollbackDir,
-                versionRollbackDir,
+                backupDir,
+                versionBackupDir,
                 Path.Join(source, "userdata")
             };
 
-            var childEntries = Directory
-                .EnumerateFileSystemEntries(source)
+            var childEntries = Directory.EnumerateFileSystemEntries(source)
                 .Except(excludeList);
 
+            PerformFileOperations(fileOp, backupTarget, childEntries);
+        }
+
+        private void InclusiveFileOp(string source, string backupDir, string target, Action<string, string> fileOp)
+        {
+            var backupTarget = Path.Join(backupDir, target);
+
+            var entries = Directory.EnumerateFileSystemEntries(source);
+
             if (IncludeList != null)
-                childEntries = childEntries.Intersect(IncludeList.Select(t => Path.Join(source, t)));
+                entries = entries.Intersect(IncludeList.Select(t => Path.Join(source, t)));
 
-            if (Directory.Exists(rollbackTarget))
-                Directory.Delete(rollbackTarget, true);
-            Directory.CreateDirectory(rollbackTarget);
+            PerformFileOperations(fileOp, backupTarget, entries);
+        }
 
-            foreach (var childEntry in childEntries)
+        private static void PerformFileOperations(Action<string, string> fileOp, string targetParentDir, IEnumerable<string> entries)
+        {
+            if (Directory.Exists(targetParentDir))
+                Directory.Delete(targetParentDir, true);
+            Directory.CreateDirectory(targetParentDir);
+
+            foreach (var entry in entries)
             {
-                fileOp(childEntry, Path.Join(rollbackTarget, Path.GetFileName(childEntry)));
+                var fileName = Path.GetFileName(entry);
+                var path = Path.Join(targetParentDir, fileName);
+                fileOp(entry, path);
             }
         }
 

--- a/OpenTabletDriver.Desktop/Updater/Updater.cs
+++ b/OpenTabletDriver.Desktop/Updater/Updater.cs
@@ -138,7 +138,7 @@ namespace OpenTabletDriver.Desktop.Updater
                 .Except(excludeList);
 
             if (IncludeList != null)
-                childEntries = childEntries.Intersect(IncludeList.Select(Path.Join(source, IncludeList)));
+                childEntries = childEntries.Intersect(IncludeList.Select(t => Path.Join(source, t)));
 
             if (Directory.Exists(rollbackTarget))
                 Directory.Delete(rollbackTarget, true);

--- a/OpenTabletDriver.Desktop/Updater/Updater.cs
+++ b/OpenTabletDriver.Desktop/Updater/Updater.cs
@@ -138,7 +138,7 @@ namespace OpenTabletDriver.Desktop.Updater
                 .Except(excludeList);
 
             if (IncludeList != null)
-                childEntries = childEntries.Intersect(IncludeList);
+                childEntries = childEntries.Intersect(IncludeList.Select(Path.Join(source, IncludeList)));
 
             if (Directory.Exists(rollbackTarget))
                 Directory.Delete(rollbackTarget, true);

--- a/OpenTabletDriver.Desktop/Updater/WindowsUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/WindowsUpdater.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
@@ -31,8 +30,7 @@ namespace OpenTabletDriver.Desktop.Updater
         protected override string[] IncludeList { get; } = new[]
         {
             "OpenTabletDriver.UX.Wpf.exe",
-            "OpenTabletDriver.Daemon.exe",
-            "Configurations"
+            "OpenTabletDriver.Daemon.exe"
         };
 
         protected override async Task Download(Release release)

--- a/OpenTabletDriver.Desktop/Updater/WindowsUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/WindowsUpdater.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
@@ -26,6 +27,13 @@ namespace OpenTabletDriver.Desktop.Updater
                 rollBackDirectory)
         {
         }
+
+        protected override string[] IncludeList { get; } = new[]
+        {
+            "OpenTabletDriver.UX.Wpf.exe",
+            "OpenTabletDriver.Daemon.exe",
+            "Configurations"
+        };
 
         protected override async Task Download(Release release)
         {


### PR DESCRIPTION
This stops the updater from backing up files that are not related to OpenTabletDriver when updating.