### PR TITLE
Fix typo in Gaomon M1220

### DIFF
--- a/TABLETS.md
+++ b/TABLETS.md
@@ -92,7 +92,7 @@
 | Gaomon M106K Pro              |  Missing Features | Tilt is unsupported.
 | Gaomon M10K                   |  Missing Features | Wheel is unsupported.
 | Gaomon M10K Pro               |  Missing Features | Tilt and wheel are unsupported.
-| Gaomon M1120                  |  Missing Features | Tilt and wheel are unsupported.
+| Gaomon M1220                  |  Missing Features | Tilt and wheel are unsupported.
 | Huion GC610                   |  Missing Features | Touchpad is unsupported.
 | Huion GT-221 Pro              |  Missing Features | Touch bar is unsupported.
 | Huion H1060P                  |  Missing Features | Tilt is unsupported.


### PR DESCRIPTION
This seems to be a typo, there is no Gaomon M1120, but there is a config to the M1220 but no tablets entry to this, but the opposite for the M1120, so i've corrected the TABLETS.md file.