### PR TITLE
Only show TrayIcon once window init is complete

### DIFF
--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -38,6 +38,8 @@ namespace OpenTabletDriver.UX
                 Text = "Connecting to OpenTabletDriver Daemon..."
             };
 
+            trayIcon.Indicator.Show();
+
             Driver.Connected += HandleDaemonConnected;
             Driver.Disconnected += HandleDaemonDisconnected;
 

--- a/OpenTabletDriver.UX/TrayIcon.cs
+++ b/OpenTabletDriver.UX/TrayIcon.cs
@@ -25,7 +25,6 @@ namespace OpenTabletDriver.UX
                 window.Show();
                 window.BringToFront();
             };
-            Indicator.Show();
         }
 
         public TrayIndicator Indicator { get; }


### PR DESCRIPTION
Prevents crash on activation of TrayIcon before window is capable of being shown. TrayIcon is hidden until the window is finished initializing, (and thus _can_ be shown when the icon is clicked).

Fixes #1915 