### PR TITLE
Change parser for Wacom CTE-450/650

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-450.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-450.json
@@ -25,7 +25,7 @@
       "ProductID": 23,
       "InputReportLength": 9,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
       "FeatureInitReport": [
         "AgI="
       ],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-650.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-650.json
@@ -25,7 +25,7 @@
       "ProductID": 24,
       "InputReportLength": 9,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
       "FeatureInitReport": [
         "AgI="
       ],


### PR DESCRIPTION
The CTE-450/650 configurations use a parser which does not work for those particular tablets.
The Intuos report parser does not work for the Bamboo tablets and is the change of this pull request.

- [x] I have personally tested this modification to work on my own CTE-450
- [x] Received verification that the modification works on the CTE-650 *[see here for more details](https://discord.com/channels/615607687467761684/932116307674021919)*
