### PR TITLE
IntuosV1TabletReport: Match upstream distance

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1TabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1TabletReport.cs
@@ -28,7 +28,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1
                 penByte.IsBitSet(2)
             };
             NearProximity = report[1].IsBitSet(6);
-            HoverDistance = (uint)report[9] >> 2;
+            HoverDistance = (uint)report[9] >> 3;
         }
 
         public byte[] Raw { set; get; }


### PR DESCRIPTION
Measuring the stock Wacom driver for my GD-0608 reveals that our distance was twice as high as it should've been

This change makes it report the same distance as the upstream Wacom driver