### PR TITLE
Libinput quirks generator

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -28,7 +28,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
 
         public unsafe EvdevVirtualTablet(IVirtualScreen virtualScreen)
         {
-            Device = new EvdevDevice("OpenTabletDriver Virtual Artist Tablet");
+            Device = new EvdevDevice(TABLET_NAME);
 
             Device.EnableProperty(InputProperty.INPUT_PROP_DIRECT);
             Device.EnableProperty(InputProperty.INPUT_PROP_POINTER);
@@ -93,7 +93,8 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
             }
         }
 
-        private const int MAX_PRESSURE = ushort.MaxValue;
+        public const int MAX_PRESSURE = ushort.MaxValue;
+        public const string TABLET_NAME = "OpenTabletDriver Virtual Artist Tablet";
 
         public void SetPosition(Vector2 pos)
         {

--- a/OpenTabletDriver.Tools.LibinputQuirks/OpenTabletDriver.Tools.LibinputQuirks.csproj
+++ b/OpenTabletDriver.Tools.LibinputQuirks/OpenTabletDriver.Tools.LibinputQuirks.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(FrameworkLatest)</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>otd-quirks</ToolCommandName>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+      <ProjectReference Include="..\OpenTabletDriver.Desktop\OpenTabletDriver.Desktop.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/OpenTabletDriver.Tools.LibinputQuirks/Program.cs
+++ b/OpenTabletDriver.Tools.LibinputQuirks/Program.cs
@@ -38,6 +38,8 @@ namespace OpenTabletDriver.Tools.LibinputQuirks
 
         static async Task WriteQuirksAsync(TabletAttributes attr, FileInfo output, bool verbose)
         {
+            if (attr.TipUpPressurePermille.HasValue ^ attr.TipDownPressurePermille.HasValue)
+                Console.WriteLine("WARNING: Both Tip-down and Tip-up must be specified! Ignoring pressures.");
 
             if (attr.TipUpPressurePermille.HasValue
                     && attr.TipDownPressurePermille.HasValue

--- a/OpenTabletDriver.Tools.LibinputQuirks/Program.cs
+++ b/OpenTabletDriver.Tools.LibinputQuirks/Program.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.CommandLine.Invocation;
+using System.IO;
+using System.Threading.Tasks;
+using OpenTabletDriver.Desktop.Interop.Input.Absolute;
+
+namespace OpenTabletDriver.Tools.LibinputQuirks
+{
+    class Program
+    {
+        static readonly bool DEFAULT_SMOOTHING = false;
+        static readonly uint DEFAULT_TIPDOWN_PRESSURE_PERMILLE = 10;
+        static readonly uint DEFAULT_TIPUP_PRESSURE_PERMILLE = 9;
+        static readonly string LIBINPUT_HEADER = "[OpenTabletDriver]";
+        static readonly string CONFIG_KEY_NAME_STRING = "MatchName";
+        static readonly string CONFIG_KEY_TABLET_SMOOTHING = "AttrTabletSmoothing";
+        static readonly string CONFIG_KEY_PRESSURE_RANGE = "AttrPressureRange";
+
+        static void Main(string[] args)
+        {
+            var root = new RootCommand("OpenTabletDriver libinput quirks generator")
+            {
+                new Option<uint>(new[] { "--tip-down-pressure-permille", "-pd" }, () => DEFAULT_TIPDOWN_PRESSURE_PERMILLE, "Pressure threshold for tip down in permille (1/1000)"),
+                new Option<uint>(new[] { "--tip-up-pressure-permille", "-pu" }, () => DEFAULT_TIPUP_PRESSURE_PERMILLE, "Pressure threshold for tip up in permille (1/1000)"),
+                new Option<bool>(new[] { "--smoothing", "-s" }, () => DEFAULT_SMOOTHING, "Allow libinput tablet smoothing"),
+                new Option(new[] { "--no-pressure", "-np" }, $"Do not include '{CONFIG_KEY_PRESSURE_RANGE}'"),
+                new Argument<FileInfo>("output", "Resulting .quirks file"),
+                new Option(new[] { "--verbose", "-v" }, "Verbose output")
+            };
+
+            root.Handler = CommandHandler.Create<uint, uint, bool, bool, FileInfo, bool>(WriteQuirksAsync);
+            root.Invoke(args);
+        }
+
+        static async Task WriteQuirksAsync(uint tipDownPressurePermille, uint tipUpPressurePermille, bool smoothing, bool skipPressure, FileInfo output, bool verbose)
+        {
+            if (tipUpPressurePermille >= tipDownPressurePermille) throw new ArgumentOutOfRangeException("Tip-up pressure must be less than tip-down pressure");
+
+            bool unclean = false;
+
+            var path = output.FullName.Contains(Directory.GetCurrentDirectory()) ? output.Name : output.FullName;
+            Console.WriteLine($"Writing quirks to '{path}'");
+
+            var filenameContainsQuirks = !output.Name.EndsWith(".quirks");
+            if (filenameContainsQuirks)
+                Console.WriteLine("WARNING: File name does not end with '.quirks'. Your file will not be parsed by libinput!");
+            unclean |= filenameContainsQuirks;
+
+            if (output.Exists)
+                output.Delete();
+            if (!output.Directory.Exists)
+                output.Directory.Create();
+
+            using (var sw = output.AppendText())
+            {
+                if (verbose) Console.WriteLine("Adding header");
+                await sw.WriteLineAsync(LIBINPUT_HEADER);
+                foreach (var line in CreateQuirks(smoothing, skipPressure, tipDownPressurePermille, tipUpPressurePermille))
+                {
+                    if (verbose) Console.WriteLine($"Adding {line.Substring(0,line.IndexOf("="))}");
+                    await sw.WriteLineAsync(line);
+                }
+            }
+            if (unclean) Console.WriteLine("WARNING: The generator encountered warnings and your file may not work correctly");
+        }
+
+        static IEnumerable<string> CreateQuirks(bool smoothing, bool skipPressure, uint tipDownPressurePermille, uint tipUpPressurePermille)
+        {
+            yield return GenerateKeyValue(CONFIG_KEY_NAME_STRING, EvdevVirtualTablet.TABLET_NAME);
+            yield return GenerateKeyValue(CONFIG_KEY_TABLET_SMOOTHING, Convert.ToInt32(smoothing).ToString());
+
+            if (!skipPressure)
+            {
+                yield return GenerateKeyValue(CONFIG_KEY_PRESSURE_RANGE,
+                        GeneratePressureRange(
+                            PressureConvertPermilleToUnits(tipDownPressurePermille),
+                            PressureConvertPermilleToUnits(tipUpPressurePermille)
+                        ));
+            }
+        }
+
+        static string GenerateKeyValue(string left, string right) => left + "=" + right;
+
+        static string GeneratePressureRange(uint tipDownPressure, uint tipUpPressure) => tipDownPressure + ":" + tipUpPressure;
+
+        static uint PressureConvertPermilleToUnits(uint permille) => (uint)(EvdevVirtualTablet.MAX_PRESSURE * ((double)permille / 1000));
+    }
+}

--- a/OpenTabletDriver.Tools.LibinputQuirks/Program.cs
+++ b/OpenTabletDriver.Tools.LibinputQuirks/Program.cs
@@ -67,22 +67,22 @@ namespace OpenTabletDriver.Tools.LibinputQuirks
 
         static IEnumerable<string> CreateQuirks(bool smoothing, bool skipPressure, uint tipDownPressurePermille, uint tipUpPressurePermille)
         {
-            yield return GenerateKeyValue(CONFIG_KEY_NAME_STRING, EvdevVirtualTablet.TABLET_NAME);
-            yield return GenerateKeyValue(CONFIG_KEY_TABLET_SMOOTHING, Convert.ToInt32(smoothing).ToString());
+            yield return FormatKeyValue(CONFIG_KEY_NAME_STRING, EvdevVirtualTablet.TABLET_NAME);
+            yield return FormatKeyValue(CONFIG_KEY_TABLET_SMOOTHING, Convert.ToInt32(smoothing).ToString());
 
             if (!skipPressure)
             {
-                yield return GenerateKeyValue(CONFIG_KEY_PRESSURE_RANGE,
-                        GeneratePressureRange(
+                yield return FormatKeyValue(CONFIG_KEY_PRESSURE_RANGE,
+                        FormatPressureRange(
                             PressureConvertPermilleToUnits(tipDownPressurePermille),
                             PressureConvertPermilleToUnits(tipUpPressurePermille)
                         ));
             }
         }
 
-        static string GenerateKeyValue(string left, string right) => left + "=" + right;
+        static string FormatKeyValue(string left, string right) => left + "=" + right;
 
-        static string GeneratePressureRange(uint tipDownPressure, uint tipUpPressure) => tipDownPressure + ":" + tipUpPressure;
+        static string FormatPressureRange(uint tipDownPressure, uint tipUpPressure) => tipDownPressure + ":" + tipUpPressure;
 
         static uint PressureConvertPermilleToUnits(uint permille) => (uint)(EvdevVirtualTablet.MAX_PRESSURE * ((double)permille / 1000));
     }

--- a/OpenTabletDriver.Tools.LibinputQuirks/Program.cs
+++ b/OpenTabletDriver.Tools.LibinputQuirks/Program.cs
@@ -39,15 +39,14 @@ namespace OpenTabletDriver.Tools.LibinputQuirks
         {
             if (tipUpPressurePermille >= tipDownPressurePermille) throw new ArgumentOutOfRangeException("Tip-up pressure must be less than tip-down pressure");
 
-            bool unclean = false;
-
+            var filenameDoesntContainQuirks = !output.Name.EndsWith(".quirks");
+            if (filenameDoesntContainQuirks)
+            {
+                Console.WriteLine("INFO: File name does not end with '.quirks' - this has been added!");
+                output = new FileInfo(output.FullName + ".quirks");
+            }
             var path = output.FullName.Contains(Directory.GetCurrentDirectory()) ? output.Name : output.FullName;
             Console.WriteLine($"Writing quirks to '{path}'");
-
-            var filenameContainsQuirks = !output.Name.EndsWith(".quirks");
-            if (filenameContainsQuirks)
-                Console.WriteLine("WARNING: File name does not end with '.quirks'. Your file will not be parsed by libinput!");
-            unclean |= filenameContainsQuirks;
 
             if (output.Exists)
                 output.Delete();
@@ -64,7 +63,6 @@ namespace OpenTabletDriver.Tools.LibinputQuirks
                     await sw.WriteLineAsync(line);
                 }
             }
-            if (unclean) Console.WriteLine("WARNING: The generator encountered warnings and your file may not work correctly");
         }
 
         static IEnumerable<string> CreateQuirks(bool smoothing, bool skipPressure, uint tipDownPressurePermille, uint tipUpPressurePermille)

--- a/OpenTabletDriver.Tools.LibinputQuirks/TabletAttributes.cs
+++ b/OpenTabletDriver.Tools.LibinputQuirks/TabletAttributes.cs
@@ -1,0 +1,28 @@
+namespace OpenTabletDriver.Tools.LibinputQuirks
+{
+    class TabletAttributes
+    {
+        // libinput quirks docs:
+        // https://wayland.freedesktop.org/libinput/doc/latest/device-quirks.html
+
+        // Toggle whether smoothing should be enabled or not.
+        // This is enabled by default in libinput, but disabled by default for us.
+        public bool EnableSmoothing;
+
+        // The threshold for which the tip activates "tip-down" event.
+        // Equivalent to the 'N' variable of 'AttrPressureRange=N:M' in the quirks file
+        public uint? TipDownPressurePermille;
+
+        // The threshold for which the tip activates "tip-up" event.
+        // A tip-up event can only happen after a tip-down event.
+        // Equivalent to the 'M' variable of 'AttrPressureRange=N:M' in the quirks file
+        public uint? TipUpPressurePermille;
+
+        public TabletAttributes(uint? tipDownPressurePermille, uint? tipUpPressurePermille, bool enableSmoothing)
+        {
+            TipDownPressurePermille = tipDownPressurePermille;
+            TipUpPressurePermille = tipUpPressurePermille;
+            EnableSmoothing = enableSmoothing;
+        }
+    }
+}


### PR DESCRIPTION
This is going to be useful (and hopefully mandatory) for packagers to ship (and adjust) a libinput quirks file. 

This fixes #1514, fixes #1680 and fixes #2895.

I've left the option in should an expert user decide to keep it

Unrelated to the PR but we should probably check for the presence of this file, or probe quirk behavior for virtual tablet endpoint on daemon start so that we can ensure behavior is as expected.

If anyone is aware of setting these quirks _in code_ instead of in packaging this would be greatly appreciated, as it'd ensure that we can get a consistent experience across all distros without having to worry about packaging.

Packagers/maintainers are advised to put this quirks file as `/usr/share/libinput/30-vendor-opentabletdriver.quirks` to match existing libinput naming convention.

Run example:

```
$ dotnet run -- testfile.quirks
Writing quirks to 'testfile.quirks'
$ cat testfile.quirks 
[OpenTabletDriver]
MatchName=OpenTabletDriver Virtual Artist Tablet
AttrTabletSmoothing=0
```

There is also support for setting pressure ranges (libinput quirk `AttrPressureRange`) but defaulting to any value at the moment seems unreasonable, so we should just let libinput handle button debouncing (the default).

- [x] merge prevention checkbox because there are reviews i need to address
- [ ] check whether it's necessary to update `README.md`, and if it is, do so
- [ ] update packaging script to include this