### PR TITLE
Disable drag n drop for .dll files

### DIFF
--- a/OpenTabletDriver.UX/Windows/Plugins/PluginDropPanel.cs
+++ b/OpenTabletDriver.UX/Windows/Plugins/PluginDropPanel.cs
@@ -73,12 +73,7 @@ namespace OpenTabletDriver.UX.Windows.Plugins
                             if (uri.IsFile && File.Exists(uri.LocalPath))
                             {
                                 var fileInfo = new FileInfo(uri.LocalPath);
-                                return fileInfo.Extension switch
-                                {
-                                    ".zip" => true,
-                                    ".dll" => true,
-                                    _ => false
-                                };
+                                return fileInfo.Extension == ".zip";
                             }
                             return false;
                         });


### PR DESCRIPTION
Should help with reducing chances of users mistakenly dragging individual `.dll` files of a single plugin to plugin manager, which causes issue with type loading due to missing dependency.