### PR TITLE
Disable automatic plugin installation

### DIFF
--- a/OpenTabletDriver.Desktop/Reflection/DesktopPluginManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/DesktopPluginManager.cs
@@ -52,9 +52,7 @@ namespace OpenTabletDriver.Desktop.Reflection
                 {
                     foreach (var file in PluginDirectory.GetFiles())
                     {
-                        var newPath = Path.Join(PluginDirectory.FullName, file.Name.Replace(file.Extension, string.Empty), file.Name);
-                        Directory.CreateDirectory(Directory.GetParent(newPath).FullName);
-                        file.MoveTo(newPath);
+                        Log.Write("Plugin", $"Unexpected file found: '{file.FullName}'", LogLevel.Warning);
                     }
                 }
 


### PR DESCRIPTION
Same story as #1991, but instead of dropping into plugin manager, files are dropped directly into plugin directory.