### PR TITLE
Move packaging files to the main repository and add a basic Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ BenchmarkDotNet.Artifacts/
 # Nix
 .envrc
 shell.nix
+
+# Linux packagaing
+!Common/Linux/bin
+

--- a/Common/Linux/bin/opentabletdriver
+++ b/Common/Linux/bin/opentabletdriver
@@ -1,0 +1,10 @@
+#!/bin/bash
+systemctl --user --quiet is-active opentabletdriver
+daemonactive=$?
+
+if [ $daemonactive != 0 ]
+then
+  systemctl --user start opentabletdriver
+fi
+
+/usr/share/OpenTabletDriver/OpenTabletDriver.UX.Gtk "$@"

--- a/Common/Linux/bin/otd
+++ b/Common/Linux/bin/otd
@@ -1,0 +1,10 @@
+#!/bin/bash
+systemctl --user --quiet is-active opentabletdriver
+daemonactive=$?
+
+if [ $daemonactive != 0 ]
+then
+  systemctl --user start opentabletdriver
+fi
+
+/usr/share/OpenTabletDriver/OpenTabletDriver.Console "$@"

--- a/Common/Linux/lib/modprobe.d/99-opentabletdriver.conf
+++ b/Common/Linux/lib/modprobe.d/99-opentabletdriver.conf
@@ -1,0 +1,2 @@
+blacklist hid_uclogic
+blacklist wacom

--- a/Common/Linux/lib/systemd/user/opentabletdriver.service
+++ b/Common/Linux/lib/systemd/user/opentabletdriver.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=OpenTabletDriver Daemon
+
+[Service]
+ExecStart=/usr/share/OpenTabletDriver/OpenTabletDriver.Daemon -c /usr/share/OpenTabletDriver/Configurations
+Restart=always
+RestartSec=30
+
+[Install]
+WantedBy=default.target

--- a/Common/Linux/share/applications/OpenTabletDriver.desktop
+++ b/Common/Linux/share/applications/OpenTabletDriver.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Version=0.0.0
+Name=OpenTabletDriver
+Exec=/usr/bin/opentabletdriver
+Icon=/usr/share/pixmaps/otd.png
+Terminal=false
+Type=Application
+StartupNotify=true
+Categories=Settings;

--- a/Common/Linux/share/doc/OpenTabletDriver/copyright
+++ b/Common/Linux/share/doc/OpenTabletDriver/copyright
@@ -1,0 +1,29 @@
+Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: OpenTabletDriver
+Source: https://github.com/InfinityGhost/OpenTabletDriver
+
+Files: *
+Copyright: Copyright 2019-2020 InfinityGhost <infinityghostgit@gmail.com>
+License: LGPL-3+
+
+Files: debian/*
+Copyright: Copyright 2019-2020 InfinityGhost <infinityghostgit@gmail.com>
+License: LGPL-3+
+
+License: LGPL-3+
+ This package is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+
+This package is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+ License along with this package; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+On Debian systems, the complete text of the GNU Lesser General
+ Public License can be found in `/usr/share/common-licenses/LGPL-3'.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+#!/usr/bin/make -f
+SHELL=/bin/bash
+
+ifdef DESTDIR
+	PREFIX = $(DESTDIR)/usr
+else
+	PREFIX = /usr
+endif
+
+PKG_VERSION = $(shell [[ $$(cat Directory.Build.props) =~ \<VersionBase\>(.+?)\<\/VersionBase\> ]] && echo $${BASH_REMATCH[1]})
+VERSION_REGEX = ^Version=.\+$$
+VERSION_REPLACE_REGEX = Version=$(PKG_VERSION)
+
+all: build
+
+build:
+	./build.sh
+
+install:
+	mkdir -p $(PREFIX)/share/OpenTabletDriver
+	cp -r bin/* $(PREFIX)/share/OpenTabletDriver
+	find $(PREFIX)/share/OpenTabletDriver -name "*.pdb" -type f -exec rm {} ';'
+	
+	cp -r Common/Linux/* $(PREFIX)
+	
+	mkdir -p $(PREFIX)/share/man/man8
+	gzip -c docs/manpages/opentabletdriver.8 > $(PREFIX)/share/man/man8/opentabletdriver.8.gz
+
+	mkdir -p $(PREFIX)/share/pixmaps
+	cp -v OpenTabletDriver.UX/Assets/* $(PREFIX)/share/pixmaps
+
+	mkdir -p $(PREFIX)/lib/udev/rules.d
+	./generate-rules.sh -v OpenTabletDriver.Configurations/Configurations $(PREFIX)/lib/udev/rules.d/99-opentabletdriver.rules
+
+	sed -i "s/$(VERSION_REGEX)/$(VERSION_REPLACE_REGEX)/g" "$(PREFIX)/share/applications/OpenTabletDriver.desktop"
+	
+uninstall:
+	rm -r $(PREFIX)/share/OpenTabletDriver
+	cd Common/Linux; find . -type f -exec rm $(PREFIX)/{} ';'
+	rm $(PREFIX)/share/man/man8/opentabletdriver.8.gz
+	rm $(PREFIX)/share/pixmaps/otd.{ico,png}
+	rm $(PREFIX)/lib/udev/rules.d/99-opentabletdriver.rules
+	
+clean:
+	rm -rf bin
+	
+	
+.PHONY: all build install uninstall clean


### PR DESCRIPTION
This PR contains a basic Makefile that can be used for packaging and files that originally belong to OpenTabletDriver.Packaging project.

... I'm not sure if my Makefile is okay lol