### PR TITLE
Overhaul debugger report recording UI

### DIFF
--- a/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
+++ b/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
@@ -289,13 +289,30 @@ namespace OpenTabletDriver.UX.Windows.Tablet
         private void startRecording() => Application.Instance.AsyncInvoke(() =>
         {
             startDataRecordingButton.Enabled = false;
-            stopDataRecordingButton.Enabled = true;
-            reportsRecordedGroup.Visible = true;
+            var fileDialog = new SaveFileDialog
+            {
+                Title = "Record reports to file...",
+                Directory = new Uri(Eto.EtoEnvironment.GetFolderPath(Eto.EtoSpecialFolder.Documents)),
+                Filters =
+                {
+                    new FileFilter("Tablet Report Recording (*.txt)", ".txt")
+                }
+            };
+            switch (fileDialog.ShowDialog(this))
+            {
+                case DialogResult.Ok:
+                case DialogResult.Yes:
+                    dataRecordingOutput = new StreamWriter(File.OpenWrite(fileDialog.FileName));
 
-            var outputStream = File.OpenWrite(Path.Join(AppInfo.Current.AppDataDirectory, "tablet-data.txt"));
-            dataRecordingOutput = new StreamWriter(outputStream);
+                    stopDataRecordingButton.Enabled = true;
+                    reportsRecordedGroup.Visible = true;
 
-            isRecording = true;
+                    isRecording = true;
+                    break;
+                default:
+                    startDataRecordingButton.Enabled = true;
+                    return;
+            }
         });
 
         private void stopRecording() => Application.Instance.AsyncInvoke(() =>

--- a/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
+++ b/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
@@ -165,8 +165,8 @@ namespace OpenTabletDriver.UX.Windows.Tablet
             App.Driver.TabletsChanged += HandleTabletsChanged;
             App.Driver.Instance.SetTabletDebug(true);
 
-            startDataRecordingButton.Click += (sender, e) => startRecording();
-            stopDataRecordingButton.Click += (sender, e) => stopRecording();
+            startDataRecordingButton.Click += (sender, e) => StartRecording();
+            stopDataRecordingButton.Click += (sender, e) => StopRecording();
         }
 
         protected override async void OnClosing(CancelEventArgs e)
@@ -175,7 +175,7 @@ namespace OpenTabletDriver.UX.Windows.Tablet
 
             await App.Driver.Instance.SetTabletDebug(false);
 
-            stopRecording();
+            StopRecording();
             reportsRecordedGroup.Visible = false;
         }
 
@@ -288,7 +288,7 @@ namespace OpenTabletDriver.UX.Windows.Tablet
             }
         }
 
-        private void startRecording() => Application.Instance.AsyncInvoke(() =>
+        private void StartRecording() => Application.Instance.AsyncInvoke(() =>
         {
             startDataRecordingButton.Enabled = false;
             var fileDialog = new SaveFileDialog
@@ -329,7 +329,7 @@ namespace OpenTabletDriver.UX.Windows.Tablet
             }
         });
 
-        private void stopRecording() => Application.Instance.AsyncInvoke(() =>
+        private void StopRecording() => Application.Instance.AsyncInvoke(() =>
         {
             isRecording = false;
             startDataRecordingButton.Enabled = true;


### PR DESCRIPTION
Medium PR to overhaul the UI for making recordings of tablet reports.

- Fixes #2000 
- Fixes #2006 

## Notable changes:

- Data recording is now a start/stop button system instead of a checkbox. Buttons flip "Enabled" status to clearly indicate when a recording is happening (and prevents starting/stopping recordings twice ofc)
- File to write to can be selected when start button is pressed, and file is closed when stop button is pressed, or when the debugger is closed. This allows for multiple independent recordings to different files.
- Addressing the issues in #2000, said reports recorded value is hidden until a recording is made in that debug session (re-hidden when the debugger is closed).
- Buttons have tooltips explaining what "recording" means.

## Screenshots (windows)

While not recording:

![not recording](https://user-images.githubusercontent.com/10090332/151624473-e205ce2c-8e5e-4c7d-b559-bde51d035e13.PNG)

While recording (no tablet plugged in as I didn't have it handy):

![recording](https://user-images.githubusercontent.com/10090332/151624542-596b1c7f-b8c8-45f3-9930-3810aa94bfe4.PNG)



