### PR TITLE
Move non-english readmes into docs folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # OpenTabletDriver
 
-English | [한국어](README_KO.md) | [Español](README_ES.md) | [Русский](README_RU.md) | [简体中文](README_CN.md) | [Français](README_FR.md) | [Deutsch](README_DE.md)
+English | [한국어](docs/README_KO.md) | [Español](docs/README_ES.md) | [Русский](docs/README_RU.md) | [简体中文](docs/README_CN.md) | [Français](docs/README_FR.md) | [Deutsch](docs/README_DE.md)
 
 OpenTabletDriver is an open source, cross platform, user mode tablet driver. The goal of OpenTabletDriver is to be cross platform as possible with the highest compatibility in an easily configurable graphical user interface.
 

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -2,7 +2,7 @@
 
 # OpenTabletDriver
 
-[English](README.md) | [한국어](README_KO.md) | [Español](README_ES.md) | [Русский](README_RU.md) | 简体中文 | [Français](README_FR.md) | [Deutsch](README_DE.md)
+[English](../README.md) | [한국어](README_KO.md) | [Español](README_ES.md) | [Русский](README_RU.md) | 简体中文 | [Français](README_FR.md) | [Deutsch](README_DE.md)
 
 OpenTabletDriver是一个开源的，跨平台的数位板驱动。其目标是在拥有直观的可自定义的界面的同时能跨平台并兼容尽可能多的设备。
 

--- a/docs/README_DE.md
+++ b/docs/README_DE.md
@@ -2,7 +2,7 @@
 
 # OpenTabletDriver
 
-[English](README.md) | [한국어](README_KO.md) | [Español](README_ES.md) | [Русский](README_RU.md) | [简体中文](README_CN.md) | [Français](README_FR.md) | Deutsch
+[English](../README.md) | [한국어](README_KO.md) | [Español](README_ES.md) | [Русский](README_RU.md) | [简体中文](README_CN.md) | [Français](README_FR.md) | Deutsch
 
 OpenTabletDriver ist ein Open-Source, platformübergreifender, Benutzermodus Tablet Treiber. Das Ziel von OpenTabletDriver ist es so Cross-Platform wie möglich zu sein mit der höchsten Kompatibilität und mit einer einfach zu konfigurierenden grafischen Benutzeroberfläche.
 
@@ -52,16 +52,16 @@ Benötigte Packages (manche Packages können bei Ihrer Distribution vorinstallie
 - GTK+3
 
 
-Um auf Linux zu kompilieren, führen Sie 'build.sh' aus. Es werden die gleichen 
+Um auf Linux zu kompilieren, führen Sie 'build.sh' aus. Es werden die gleichen
 'dotnet publish' Befehle ausgefürt, die auch für das AUR-Package verwendet werden.
 Die ausführbaren Dateien werden dann in dem 'OpenTabletDriver/bin' Ordner erstellt.
 
-Um auf Linux für ARM zu kompilieren, führen Sie 'build.sh' aus und geben 
+Um auf Linux für ARM zu kompilieren, führen Sie 'build.sh' aus und geben
 die richtige Version als Argument an. Z.B. für ARM64 ist das 'linux-arm64'.
 
-Hinweis: Falls Sie OpenTabletDriver zum ersten Mal kompilieren, führen Sie das 
-enthaltene generate-rules.sh Skript aus. Damit werden einige udev Regeln in 
-OpenTabletDriver/bin generiert (99-opentabletdriver.rules). 
+Hinweis: Falls Sie OpenTabletDriver zum ersten Mal kompilieren, führen Sie das
+enthaltene generate-rules.sh Skript aus. Damit werden einige udev Regeln in
+OpenTabletDriver/bin generiert (99-opentabletdriver.rules).
 Diese Datei sollte dann in `/etc/udev/rules.d/` verschoben werden:
 
 ```
@@ -107,28 +107,28 @@ Keine weiteren Abhängigkeiten.
 # Zu OpenTabletDriver beitragen
 
 Wenn Sie zu OpenTabletDriver beitragen wollen, besuchen Sie den [issue
-tracker](https://github.com/OpenTabletDriver/OpenTabletDriver/issues). Wenn Sie 
+tracker](https://github.com/OpenTabletDriver/OpenTabletDriver/issues). Wenn Sie
 ein Pull-Request erstellen wollen, folgen Sie den Richtlinien unter [Beitragsrichtlinien](https://github.com/OpenTabletDriver/OpenTabletDriver/blob/master/CONTRIBUTING.md).
 
 Wenn Sie Probleme oder Vorschläge haben, [Erstellen Sie ein issue
 ticket](https://github.com/OpenTabletDriver/OpenTabletDriver/issues/new/choose)
-und füllen Sie die Vorlage mit relevanten Informationen aus. Bug-Reports sowie 
-neue Tablets zum unterstützen sind wilkommen. In den meisten 
+und füllen Sie die Vorlage mit relevanten Informationen aus. Bug-Reports sowie
+neue Tablets zum unterstützen sind wilkommen. In den meisten
 Fällen ist es relativ einfach, neue Tablets zu unterstützen.
 
 ### Neue Tablets unterstützen
 
-Wenn sie wollen, dass wir ein neues Tablet unterstützen, erstellen Sie eine neue issue auf GitHub 
-oder treten Sie unserem [Discord Server](https://discord.gg/9bcMaPkVAR) bei und fragen Sie nach Hilfe. 
+Wenn sie wollen, dass wir ein neues Tablet unterstützen, erstellen Sie eine neue issue auf GitHub
+oder treten Sie unserem [Discord Server](https://discord.gg/9bcMaPkVAR) bei und fragen Sie nach Hilfe.
 *Wir bevorzugen es generell, Unterstützng neuer Tablets wegen der einfacheren Kommunikation auf Discord durchzuführen*.
 
-Sie werden einige Dinge tun müssen, wie das Aufnehmen von gesendeten Tabetdaten mithilfe 
-des eingebauten Tablet-Debuggers, testen von Funktionen des Tablets 
-(Zusatztasten, Stifttasten, Stiftdruck, etc.) mit verschiedenen Konfigurationsdateien, 
+Sie werden einige Dinge tun müssen, wie das Aufnehmen von gesendeten Tabetdaten mithilfe
+des eingebauten Tablet-Debuggers, testen von Funktionen des Tablets
+(Zusatztasten, Stifttasten, Stiftdruck, etc.) mit verschiedenen Konfigurationsdateien,
 die wir Ihnen senden.
 
 Sie können auch gerne ein Pull-Request erstellen und Überstützung selbst hinzufügen,
 wenn Sie ein gutes Verständnis der benötigten Grundlagen haben.
 
-Normalerweise ist dieser Prozess ziemlich einfach, besonders wenn es 
+Normalerweise ist dieser Prozess ziemlich einfach, besonders wenn es
 sich um ein Tablet eines bereits unterstützten Herstellers handelt.

--- a/docs/README_ES.md
+++ b/docs/README_ES.md
@@ -2,7 +2,7 @@
 
 # OpenTabletDriver
 
-[English](README.md) | [한국어](README_KO.md) | Español | [Русский](README_RU.md) | [简体中文](README_CN.md) | [Français](README_FR.md) | [Deutsch](README_DE.md)
+[English](../README.md) | [한국어](README_KO.md) | Español | [Русский](README_RU.md) | [简体中文](README_CN.md) | [Français](README_FR.md) | [Deutsch](README_DE.md)
 
 OpenTabletDriver es un driver de tabletas multiplataforma, open-source y en modo de usuario. El objetivo de OpenTabletDriver es ser lo más multiplataforma posible con la mayor compatibilidad en una interfaz de usuario fácil de configurar.
 

--- a/docs/README_FR.md
+++ b/docs/README_FR.md
@@ -2,7 +2,7 @@
 
 # OpenTabletDriver
 
-[English](README.md) | [한국어](README_KO.md) | [Español](README_ES.md) | [Русский](README_RU.md) | [简体中文](README_CN.md) | Français | [Deutsch](README_DE.md)
+[English](../README.md) | [한국어](README_KO.md) | [Español](README_ES.md) | [Русский](README_RU.md) | [简体中文](README_CN.md) | Français | [Deutsch](README_DE.md)
 
 OpenTabletDriver est un driver de tablette en mode utilisateur, open source et multiplateforme. Le but d'OpenTabletDriver est d'être compatible avec le plus de plateforme possibles, et ce grâce à une interface graphique utilisateur facilement configurable.
 

--- a/docs/README_KO.md
+++ b/docs/README_KO.md
@@ -2,7 +2,7 @@
 
 # OpenTabletDriver
 
-[English](README.md) | 한국어 | [Español](README_ES.md) | [Русский](README_RU.md) | [简体中文](README_CN.md) | [Français](README_FR.md) | [Deutsch](README_DE.md)
+[English](../README.md) | 한국어 | [Español](README_ES.md) | [Русский](README_RU.md) | [简体中文](README_CN.md) | [Français](README_FR.md) | [Deutsch](README_DE.md)
 
 OpenTabletDriver는 관리자 권한 없이 여러 플랫폼에서 작동하는 오픈 소스 타블렛 드라이버입니다. OpenTabletDriver는 쉽게 사용 가능한 유저 인터페이스를 제공함과 동시에 가능한 한 여러 플랫폼에서 무리 없이 작동하도록 하는 것을 목표로 하고 있습니다.
 

--- a/docs/README_RU.md
+++ b/docs/README_RU.md
@@ -2,7 +2,7 @@
 
 # OpenTabletDriver
 
-[English](README.md) | [한국어](README_KO.md) | [Español](README_ES.md) | Русский | [简体中文](README_CN.md) | [Français](README_FR.md) | [Deutsch](README_DE.md)
+[English](../README.md) | [한국어](README_KO.md) | [Español](README_ES.md) | Русский | [简体中文](README_CN.md) | [Français](README_FR.md) | [Deutsch](README_DE.md)
 
 OpenTabletDriver — кроссплатформенный драйвер с открытым исходным кодом для графических планшетов. Целью проекта является поддержка максимального числа устройств и платформ, а также создание простого и удобного интерфейса для настройки драйвера.
 


### PR DESCRIPTION
De-clutter project root, make more use of the docs/ subfolder created initially for the manpage.