### PR TITLE
DriverDaemon: Call SetSettings on wake from sleep

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -67,6 +67,7 @@ namespace OpenTabletDriver.Daemon
             {
                 Log.Write(nameof(SleepDetectionThread), "Sleep detected...", LogLevel.Debug);
                 await DetectTablets();
+                await SetSettings(Settings);
             });
 
             SleepDetection.Start();

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -65,7 +65,7 @@ namespace OpenTabletDriver.Daemon
 #if !DEBUG
             SleepDetection = new(async () =>
             {
-                Log.Write(nameof(SleepDetectionThread), "Sleep detected...", LogLevel.Debug);
+                Log.Write(nameof(SleepDetectionThread), "Sleep detected...", LogLevel.Info);
                 await DetectTablets();
                 await SetSettings(Settings);
             });


### PR DESCRIPTION
This might fix the issue with tablets not being detected after sleep. Needs to be tested.

## Changes

- Call `SetSettings` after detecting tablets when waking from sleep.
- Change sleep detection log level to `Info`, as `Debug` is particularly odd now that sleep detection is kept out of debug builds.

## Issues

- Closes #1870
- Closes #2044 

---

Edit: Seems to work: https://github.com/OpenTabletDriver/OpenTabletDriver/issues/1870#issuecomment-1028945702