### PR TITLE
Prevent infinite exceptions from UX when daemon disconnected

### DIFF
--- a/OpenTabletDriver.Desktop/RPC/RpcClient.cs
+++ b/OpenTabletDriver.Desktop/RPC/RpcClient.cs
@@ -14,6 +14,7 @@ namespace OpenTabletDriver.Desktop.RPC
         private IList<Action<T>> reconnectHooks = new List<Action<T>>();
 
         public T Instance { private set; get; }
+        public bool IsConnected { get => rpc != null && !rpc.IsDisposed; }
 
         public event EventHandler Connected;
         public event EventHandler Disconnected;

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -326,7 +326,7 @@ namespace OpenTabletDriver.UX
         private void HandleDaemonConnected(object sender, EventArgs e) => Application.Instance.AsyncInvoke(async () =>
         {
             // Hook events after the instance is (re)instantiated
-            Log.Output += async (sender, message) => await Driver.Instance.WriteMessage(message);
+            Log.Output += async (sender, message) => { if (Driver.IsConnected) await Driver.Instance?.WriteMessage(message); };
             Driver.TabletsChanged += (sender, tablet) => SetTitle(tablet);
 
             // Load the application information from the daemon


### PR DESCRIPTION
## Changes

- Check if RPC client is connected to the daemon before trying to send it a log message to print.
It makes sense to check only the daemon output handler rather than the `ShowUnhandledException` method as `Log.Output` may have sensible handlers that should run even if daemon is dead.

## Issues

- Closes #2028 
