### PR TITLE
CI: Move format project argument before file list

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Lint Changed Files
         run: |
           mapfile -t files < <(git diff --name-only --diff-filter=AM HEAD^ HEAD | grep '.*\.cs$')
-          if [ ${#files[@]} -ne 0 ]; then dotnet format --verify-no-changes --include "${files[@]}" OpenTabletDriver; fi
+          if [ ${#files[@]} -ne 0 ]; then dotnet format OpenTabletDriver --verify-no-changes --include "${files[@]}"; fi
 
   unittests:
     name: Unit Tests


### PR DESCRIPTION
I messed up in #2017. I hadn't tested it locally with the `include` option, which actually eats up the project argument right after. Moving it earlier fixes it locally, this should fix it for good.