### PR TITLE
Relative mode reset fix

### DIFF
--- a/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
@@ -14,6 +14,7 @@ namespace OpenTabletDriver.Plugin.Output
     public abstract class RelativeOutputMode : OutputMode
     {
         private Vector2? lastPos;
+        private Boolean resetNext = false;
         private HPETDeltaStopwatch stopwatch = new HPETDeltaStopwatch(true);
         private bool skipReport;
 
@@ -78,10 +79,11 @@ namespace OpenTabletDriver.Plugin.Output
             var deltaTime = stopwatch.Restart();
 
             var pos = Vector2.Transform(report.Position, this.TransformationMatrix);
-            var delta = pos - this.lastPos;
+            var delta = this.resetNext ? Vector2.Zero : pos - this.lastPos;
 
             this.lastPos = pos;
-            report.Position = deltaTime < ResetTime ? delta.GetValueOrDefault() : Vector2.Zero;
+            report.Position = delta.GetValueOrDefault();
+            this.resetNext = deltaTime > ResetTime;
 
             if (skipReport)
             {

--- a/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
@@ -14,7 +14,7 @@ namespace OpenTabletDriver.Plugin.Output
     public abstract class RelativeOutputMode : OutputMode
     {
         private Vector2? lastPos;
-        private Boolean resetNext = false;
+        private bool resetNext = false;
         private HPETDeltaStopwatch stopwatch = new HPETDeltaStopwatch(true);
         private bool skipReport;
 


### PR DESCRIPTION
The current relative mode positioning does not reset as intended. When lifting a pen from a tablet and placing it down again, the cursor moves instead of remaining in the same location, as shown below.
https://user-images.githubusercontent.com/57815456/152726588-c85d3781-6cbc-414f-bbb7-f1a63a8e1149.mp4

I believe the issue is that while pos is set to the zero vector, the lastPos attribute does not change when the position is supposed to be reset. This leads to delta being the new pen position instead of being zero. My change adds a new attribute, resetNext, which indicates whether next Transform call should have no movement. This results in the intended behaviour, shown below.
https://user-images.githubusercontent.com/57815456/152727704-d1e27d96-9c6f-4b42-b449-ec3fefbf206b.mp4

