### PR TITLE
Split CTL-6100 and CTL-6100WL config

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-6100.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-6100.json
@@ -1,0 +1,40 @@
+{
+	"Name": "Wacom CTL-6100WL",
+	"Specifications": {
+		"Digitizer": {
+			"Width": 216.0,
+			"Height": 135.0,
+			"MaxX": 21600.0,
+			"MaxY": 13500.0
+		},
+		"Pen": {
+			"MaxPressure": 4095,
+			"Buttons": {
+				"ButtonCount": 2
+			}
+		},
+		"AuxiliaryButtons": {
+			"ButtonCount": 4
+		},
+		"MouseButtons": null,
+		"Touch": null
+	},
+	"DigitizerIdentifiers": [
+		{
+			"VendorID": 1386,
+			"ProductID": 885,
+			"InputReportLength": 192,
+			"OutputReportLength": null,
+			"ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser",
+			"FeatureInitReport": [
+				"AgI="
+			],
+			"OutputInitReport": null,
+			"DeviceStrings": {},
+			"InitializationStrings": []
+		}
+	],
+	"AuxilaryDeviceIdentifiers": [],
+	"Attributes": {}
+}
+  

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-6100WL.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-6100WL.json
@@ -32,19 +32,6 @@
       "OutputInitReport": null,
       "DeviceStrings": {},
       "InitializationStrings": []
-    },
-    {
-      "VendorID": 1386,
-      "ProductID": 885,
-      "InputReportLength": 192,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser",
-      "FeatureInitReport": [
-        "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": []
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -63,6 +63,7 @@
 | Wacom CTL-672                 |     Supported     |
 | Wacom CTL-680                 |     Supported     |
 | Wacom CTL-690                 |     Supported     |
+| Wacom CTL-6100                |     Supported     |
 | Wacom DTC-133                 |     Supported     |
 | Wacom ET-0405-U               |     Supported     |
 | Wacom ET-0405A-U              |     Supported     |
@@ -71,7 +72,7 @@
 | Wacom GD-0608-U               |     Supported     |
 | Wacom XD-0608-U               |     Supported     |
 | XenceLabs Pen Tablet Medium   |     Supported     |
-| XP-Pen Artist 12              |     Supported     | 
+| XP-Pen Artist 12              |     Supported     |
 | XP-Pen Artist 22HD            |     Supported     | Windows: Requires Zadig's WinUSB on interface 0
 | XP-Pen CT430                  |     Supported     |
 | XP-Pen CT460                  |     Supported     |


### PR DESCRIPTION
Wacom estore doesn't show a non-bluetooth version, but according to [The USB ID repository](https://usb-ids.gowdy.us/read/UD/056a), ProductID 885 (0x0375) belongs to the non-bluetooth version.
However I can find sellers having it in stock: [Hungarian seller](https://oaziscomputer.hu/termek/21889/wacom-intuos-m-usb-ctl-6100k-b), [Bangladeshi seller](https://www.startech.com.bd/wacom-ctl-6100-k0-cx-intuos-graphic-tablet), [Aliexpress seller](https://www.aliexpress.com/item/1005001693368299.html).