### PR TITLE
Add Intuos4 middle button to AuxButtons

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos4/Intuos4AuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos4/Intuos4AuxReport.cs
@@ -8,16 +8,22 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos4
         {
             Raw = report;
 
+            var touchWheelButtonByte = report[2];
+            var buttonsByte = report[3];
+
             AuxButtons = new bool[]
             {
-                (report[3] & (1 << 0)) != 0,
-                (report[3] & (1 << 1)) != 0,
-                (report[3] & (1 << 2)) != 0,
-                (report[3] & (1 << 3)) != 0,
-                (report[3] & (1 << 4)) != 0,
-                (report[3] & (1 << 5)) != 0,
-                (report[3] & (1 << 6)) != 0,
-                (report[3] & (1 << 7)) != 0
+                buttonsByte.IsBitSet(0),
+                buttonsByte.IsBitSet(1),
+                buttonsByte.IsBitSet(2),
+                buttonsByte.IsBitSet(3),
+
+                touchWheelButtonByte.IsBitSet(0),
+
+                buttonsByte.IsBitSet(4),
+                buttonsByte.IsBitSet(5),
+                buttonsByte.IsBitSet(6),
+                buttonsByte.IsBitSet(7),
             };
         }
 


### PR DESCRIPTION
During testing of a newly acquired PTK-1240, I've noticed that the button in the middle of the touch wheel wasn't handled.

Because the button was added in the middle of the array, this PR **will break** existing bindings for the four buttons at the bottom.
