### PR TITLE
Add tilt support For Huion Kamvas 13

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 13.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 13.json
@@ -25,7 +25,7 @@
       "ProductID": 109,
       "InputReportLength": 12,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -21,6 +21,7 @@
 | Huion H640P                   |     Supported     |
 | Huion H642                    |     Supported     |
 | Huion HS64                    |     Supported     |
+| Huion Kamvas 13               |     Supported     |
 | Huion Kamvas 16               |     Supported     |
 | Huion Kamvas 16 (2021)        |     Supported     |
 | Huion Kamvas 20               |     Supported     |
@@ -113,7 +114,6 @@
 | Huion HS610                   |  Missing Features | Tilt and wheel are unsupported.
 | Huion HS611                   |  Missing Features | Touch strip is unsupported.
 | Huion Kamvas 12 Pro           |  Missing Features | Touch strip is unsupported.
-| Huion Kamvas 13               |  Missing Features | Tilt is unsupported.
 | Huion Kamvas Pro 13           |  Missing Features | Tilt is unsupported.
 | Huion Kamvas Pro 16           |  Missing Features | Touch bar is unsupported.
 | Huion Kamvas Pro 20           |  Missing Features | Touch bar is unsupported.


### PR DESCRIPTION
waiting for #2104 to confirm if this works or not. It should because Huion tablets usually are the same in this case.

fixes #2104 