### PR TITLE
Add identifier to XP-PEN Deco mini7

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco mini7.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco mini7.json
@@ -58,6 +58,19 @@
       ],
       "DeviceStrings": {},
       "InitializationStrings": []
+    },
+    {
+      "VendorID": 10429,
+      "ProductID": 2344,
+      "InputReportLength": 12,
+      "OutputReportLength": 32,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": [
+        "ArAE"
+      ],
+      "DeviceStrings": {},
+      "InitializationStrings": []
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -84,6 +84,7 @@
 | XP-Pen Deco Fun L (CT1060)    |     Supported     |
 | XP-Pen Deco 01                |     Supported     |
 | XP-Pen Deco mini4             |     Supported     |
+| XP-Pen Deco mini7             |     Supported     |
 | XP-Pen Star 03                |     Supported     |
 | XP-Pen Star 05 V3             |     Supported     |
 | XP-Pen Star G430              |     Supported     | Windows: Zadig's WinUSB on interface 1 required for older variations
@@ -160,7 +161,6 @@
 | XP-Pen Deco 01 V2 (variant 2) |  Missing Features | Tilt is unsupported
 | XP-Pen Deco 02                |  Missing Features | Wheel is unsupported.
 | XP-Pen Deco 03                |  Missing Features | Wheel is unsupported.
-| XP-Pen Deco mini7             |  Missing Features |
 | XP-Pen Deco Pro Medium        |  Missing Features | Tilt and wheel are unsupported.
 | XP-Pen Deco Pro Small         |  Missing Features | Tilt and wheel are unsupported.
 | XP-Pen Innovator 16           |  Missing Features | Wheel is unsupported.


### PR DESCRIPTION
Verification: https://canary.discord.com/channels/615607687467761684/615611007951306863/952017593772961972

This pull request adds another identifier, this one adds support for wireless.

Could all the identifiers be merged into 12, null instead of listing each one like 12 12, 12 10, 12 21 and 12 32?

Also corrected incorrect TABLETS.md entry listing missing features without saying what, however the tablet is fully supported as shown above in the verification.