### PR TITLE
fix CTL-6100 config

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-6100.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-6100.json
@@ -1,5 +1,5 @@
 {
-	"Name": "Wacom CTL-6100WL",
+	"Name": "Wacom CTL-6100",
 	"Specifications": {
 		"Digitizer": {
 			"Width": 216.0,


### PR DESCRIPTION
Snowlire accidentally didn't change the name of the config internally when splitting the config.