### PR TITLE
Update tablet support status of multiple tablets

### DIFF
--- a/TABLETS.md
+++ b/TABLETS.md
@@ -78,6 +78,7 @@
 | Wacom GD-0405-U               |     Supported     |
 | Wacom GD-0608-U               |     Supported     |
 | Wacom XD-0608-U               |     Supported     |
+| Wacom XD-1218-U               |     Supported     |
 | XenceLabs Pen Tablet Medium   |     Supported     |
 | XP-Pen Artist 12              |     Supported     |
 | XP-Pen Artist 22HD            |     Supported     | Windows: Requires Zadig's WinUSB on interface 0
@@ -157,6 +158,7 @@
 | Wacom PTZ-630                 |  Missing Features | Tablet buttons and touch strips are unsupported.
 | Wacom PTZ-631W                |  Missing Features | Touch strips are unsupported.
 | Wacom PTZ-930                 |  Missing Features | Touch strips are unsupported.
+| Wacom PTZ-1231W               |  Missing Features | Touch strips are unsupported.
 | XP-Pen Artist 12              |  Missing Features | Touch bar is unsupported
 | XP-Pen Artist Pro 12          |  Missing Features | Tilt and wheel are unsupported.
 | XP-Pen Artist Pro 15.6        |  Missing Features | Tilt and wheel are unsupported.
@@ -177,9 +179,7 @@
 | Wacom GD-1218-U               |     Untested      |
 | Wacom PTK-450                 |     Untested      |
 | Wacom PTK-650                 |     Untested      |
-| Wacom PTZ-1231W               |     Untested      |
 | Wacom PTZ-430                 |     Untested      |
 | Wacom XD-0405-U               |     Untested      |
 | Wacom XD-0912-U               |     Untested      |
 | Wacom XD-1212-U               |     Untested      |
-| Wacom XD-1218-U               |     Untested      |


### PR DESCRIPTION
Moving these tablets from untested due to evidence that these tablets work accordingly.

XD-1218-U:
https://canary.discord.com/channels/615607687467761684/615607687467761690/951194933799293068

PTZ-1231W:
https://canary.discord.com/channels/615607687467761684/787072060563128321/956343693659500544

Its probably fine to go ahead and update each of the status for all of the XD series now, don't know if this is the best route but should be fine. If so tell me and i'll throw them all on because nothing should be wrong with them. (probably the same with most of the tablets in the untested section i just haven't looked hard enough for verification on them)