### PR TITLE
Fix typo in CT640 (again)

### DIFF
--- a/TABLETS.md
+++ b/TABLETS.md
@@ -83,7 +83,7 @@
 | XP-Pen Artist 12              |     Supported     |
 | XP-Pen Artist 22HD            |     Supported     | Windows: Requires Zadig's WinUSB on interface 0
 | XP-Pen CT430                  |     Supported     |
-| XP-Pen CT460                  |     Supported     |
+| XP-Pen CT640                  |     Supported     |
 | XP-Pen Deco Fun L (CT1060)    |     Supported     |
 | XP-Pen Deco 01                |     Supported     |
 | XP-Pen Deco mini4             |     Supported     |


### PR DESCRIPTION
Should i also maybe match the formatting in the CT1060? Either mention the "Deco Fun" bit on each or remove it from the file?