### PR TITLE
Daemon: Log 'enabled' only when there are tablets

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -186,7 +186,8 @@ namespace OpenTabletDriver.Daemon
                 }
             }
 
-            Log.Write("Settings", "Driver is enabled.");
+            if (Driver.InputDevices.Count > 0)
+                Log.Write("Settings", "Driver is enabled.");
 
             SetToolSettings();
 


### PR DESCRIPTION
## Changes

Couldn't think of something meaningful to log in its place, it feels okay to not log it altogether.

## Issues

- Closes #2144 
