### PR TITLE
Use full project argument in `dotnet run`

### DIFF
--- a/generate-rules.sh
+++ b/generate-rules.sh
@@ -17,4 +17,4 @@ else
   dotnet_args=("-v" "${TABLET_CONFIGURATIONS}" "${RULES_FILE}")
 fi
 
-dotnet run -p "${PROJECT}" -f "${FRAMEWORK}" -- ${dotnet_args[@]}
+dotnet run --project "${PROJECT}" -f "${FRAMEWORK}" -- ${dotnet_args[@]}


### PR DESCRIPTION
## Changes

- Uses `--project` in udev generation in place of `-p`.

## Issues

- Closes #2110 