### PR TITLE
Correctly parse hover distance for intuos4

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1TabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1TabletReport.cs
@@ -28,7 +28,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1
                 penByte.IsBitSet(2)
             };
             NearProximity = report[1].IsBitSet(6);
-            HoverDistance = (uint)report[9] >> 2;
+            HoverDistance = (uint)report[9];
         }
 
         public byte[] Raw { set; get; }


### PR DESCRIPTION
Correctly parse hover distance for intuos4
Right now it caps at "62"