### PR TITLE
Add LogLevel configuration

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -34,6 +34,7 @@ namespace OpenTabletDriver.Daemon
         {
             Driver = driver;
 
+            Configuration.Load(AppInfo.Current.ConfigurationFile);
             Log.Output += (sender, message) =>
             {
                 LogMessages.Add(message);

--- a/OpenTabletDriver.Desktop/AppInfo.cs
+++ b/OpenTabletDriver.Desktop/AppInfo.cs
@@ -12,6 +12,7 @@ namespace OpenTabletDriver.Desktop
     public class AppInfo
     {
         private string configurationDirectory,
+            configurationFile,
             settingsFile,
             pluginDirectory,
             presetDirectory,
@@ -57,6 +58,12 @@ namespace OpenTabletDriver.Desktop
         {
             set => this.configurationDirectory = value;
             get => this.configurationDirectory ?? GetDefaultConfigurationDirectory();
+        }
+
+        public string ConfigurationFile
+        {
+            set => this.configurationFile = value;
+            get => this.configurationFile ?? GetDefaultConfigurationFile();
         }
 
         public string SettingsFile
@@ -127,6 +134,7 @@ namespace OpenTabletDriver.Desktop
             Path.Join(Environment.CurrentDirectory, "Configurations")
         );
 
+        private string GetDefaultConfigurationFile() => Path.Join(AppDataDirectory, "config.toml");
         private string GetDefaultSettingsFile() => Path.Join(AppDataDirectory, "settings.json");
         private string GetDefaultPluginDirectory() => Path.Join(AppDataDirectory, "Plugins");
         private string GetDefaultPresetDirectory() => Path.Join(AppDataDirectory, "Presets");

--- a/OpenTabletDriver.Desktop/Configuration.cs
+++ b/OpenTabletDriver.Desktop/Configuration.cs
@@ -1,0 +1,64 @@
+using System;
+using System.IO;
+using OpenTabletDriver.Plugin;
+using Tommy;
+
+namespace OpenTabletDriver.Desktop
+{
+    public static class Configuration
+    {
+        public static void Load(string path)
+        {
+            var file = new FileInfo(path);
+            if (!file.Exists)
+            {
+                GenerateAndApplyDefaults(path);
+                return;
+            }
+
+            using (var reader = file.OpenText())
+            {
+                TomlTable table;
+                try
+                {
+                    table = TOML.Parse(reader);
+                    ApplyConfig(table);
+                }
+                catch
+                {
+                    GenerateAndApplyDefaults(path);
+                    Log.Write("Configuration", "Failed to parse configuration file. Using defaults.", LogLevel.Warning);
+                }
+            }
+        }
+
+        private static void GenerateAndApplyDefaults(string path)
+        {
+            var logLevelStrings = string.Join(", ", Enum.GetNames<LogLevel>());
+            var config = new TomlTable
+            {
+                ["loglevel"] = new TomlString
+                {
+                    Value = LogLevel.Info.ToString(),
+                    Comment = $"The minimum level of log messages to output. Valid values are {logLevelStrings}"
+                }
+            };
+
+            using (var writer = File.CreateText(path))
+            {
+                config.WriteTo(writer);
+            }
+
+            ApplyConfig(config);
+        }
+
+        private static void ApplyConfig(TomlTable config)
+        {
+            var logLevelString = config["loglevel"].AsString;
+            if (logLevelString.HasValue && Enum.TryParse<LogLevel>(logLevelString.Value, out var logLevel))
+            {
+                Log.Verbosity = logLevel;
+            }
+        }
+    }
+}

--- a/OpenTabletDriver.Desktop/OpenTabletDriver.Desktop.csproj
+++ b/OpenTabletDriver.Desktop/OpenTabletDriver.Desktop.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="StreamJsonRpc" Version="2.6.121" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20253.1" />
+    <PackageReference Include="Tommy" Version="3.1.2" />
     <PackageReference Include="WaylandNET" Version="0.2.0" />
   </ItemGroup>
 

--- a/OpenTabletDriver.Plugin/Log.cs
+++ b/OpenTabletDriver.Plugin/Log.cs
@@ -11,11 +11,19 @@ namespace OpenTabletDriver.Plugin
         public static event EventHandler<LogMessage> Output;
 
         /// <summary>
+        /// Minimum verbosity to log.
+        /// </summary>
+        public static LogLevel Verbosity { get; set; } = LogLevel.Info;
+
+        /// <summary>
         /// Invoke sending a log message.
         /// </summary>
         /// <param name="message">The message to be passed to the <see cref="Output"/> event.</param>
         public static void Write(LogMessage message)
         {
+            if (message.Level < Verbosity)
+                return;
+
             Output?.Invoke(null, message);
         }
 

--- a/OpenTabletDriver.Tests/LoggingTest.cs
+++ b/OpenTabletDriver.Tests/LoggingTest.cs
@@ -1,0 +1,23 @@
+using System.IO;
+using OpenTabletDriver.Plugin;
+using Xunit;
+
+namespace OpenTabletDriver.Tests
+{
+    public class LoggingTest
+    {
+        [Fact]
+        public void Ignore_Write_On_Log_Level_Below_Verbosity()
+        {
+            var fired = false;
+            Log.Output += (_, _) => fired = true;
+            Log.Verbosity = LogLevel.Warning;
+
+            Log.Write("Test", "Should not fire", LogLevel.Info);
+            Assert.False(fired);
+
+            Log.Write("Test", "Should fire", LogLevel.Warning);
+            Assert.True(fired);
+        }
+    }
+}

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -331,6 +331,7 @@ namespace OpenTabletDriver.UX
 
             // Load the application information from the daemon
             AppInfo.Current = await Driver.Instance.GetApplicationInfo();
+            Configuration.Load(AppInfo.Current.ConfigurationFile);
 
             // Load any new plugins
             AppInfo.PluginManager.Load();


### PR DESCRIPTION
Default LogLevel is set to `Info`.

The configuration file is loaded only during boot sequence of daemon, and reconnection of UX (why do we still have two separate instances of everything in `OpenTabletDriver.Desktop/Plugin`).

Generated file looks like this:
```toml
# The minimum level of log messages to output. Valid values are Debug, Info, Warning, Error, Fatal
loglevel = "Info"
```

This supersedes #2176.