### PR TITLE
Add xp pen g430 initstring

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G430.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G430.json
@@ -44,7 +44,9 @@
       "DeviceStrings": {
         "2": "TABLET G3 4x3"
       },
-      "InitializationStrings": []
+      "InitializationStrings": [
+        "100"
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [],


### PR DESCRIPTION
Verification: https://discord.com/channels/615607687467761684/615611007951306863/964270329935585280

This variant uses winusb on interface 1 just like the previous similar variant. So no changes need to be made to tablets.md.

There shouldn't be any conflicts with requesting string 100 even if other variations don't need it.