### PR TITLE
Restore linux native timers

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/DesktopInterop.cs
+++ b/OpenTabletDriver.Desktop/Interop/DesktopInterop.cs
@@ -72,6 +72,7 @@ namespace OpenTabletDriver.Desktop.Interop
         public static ITimer Timer => CurrentPlatform switch
         {
             PluginPlatform.Windows => new WindowsTimer(),
+            PluginPlatform.Linux   => new LinuxTimer(),
             _ => new FallbackTimer()
         };
 


### PR DESCRIPTION
With the merging of https://github.com/dotnet/runtime/pull/65406 and dotnet 6.0.4 releasing, the memory leak with native timers has been fixed, and now we can use them again.

Is this the line that was removed, and would this work just throwing it back in now lol?