### PR TITLE
Remove aux endpoint from CTH-661

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-661.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-661.json
@@ -47,18 +47,6 @@
       "InitializationStrings": []
     }
   ],
-  "AuxilaryDeviceIdentifiers": [
-    {
-      "VendorID": 1386,
-      "ProductID": 211,
-      "InputReportLength": 20,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": []
-    }
-  ],
+  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {}
 }


### PR DESCRIPTION
There isn't a parser that can handle aux for this tablet, so the endpoint has been removed on the 461 but not the 661, this pr syncs them.

https://discord.com/channels/615607687467761684/724106667964366968/966373226190098434

https://discord.com/channels/615607687467761684/724106667964366968/966375872233885746