### PR TITLE
AreaDisplay: Display lines on intersecting areas

### DIFF
--- a/OpenTabletDriver.UX/Controls/Editors/AreaDisplay.cs
+++ b/OpenTabletDriver.UX/Controls/Editors/AreaDisplay.cs
@@ -35,6 +35,7 @@ namespace OpenTabletDriver.UX.Controls.Editors
         private static Color ForegroundBorderColor { get; } = SystemColors.ControlText;
         private static Color BackgroundFillColor { get; } = new Color(Colors.Black, 0.05f);
         private static Color BackgroundBorderColor { get; } = new Color(Colors.Black, 0.25f);
+        private static Color IntersectColor = new Color(SystemColors.ControlText, 0.6f);
 
         protected override void OnDataContextChanged(EventArgs e)
         {
@@ -101,6 +102,32 @@ namespace OpenTabletDriver.UX.Controls.Editors
             {
                 graphics.FillRectangle(BackgroundFillColor, rect);
                 graphics.DrawRectangle(BackgroundBorderColor, rect);
+
+                // Draw borders on intersecting areas
+                foreach (var otherRect in backgrounds.Where(x => x != rect))
+                {
+                    if (rect == otherRect) continue;
+
+                    var match = false;
+                    var startPoint = new PointF(0,0);
+                    var endPoint = new PointF(0,0);
+
+                    if (rect.Right == otherRect.Left) // right<->left intersection
+                    {
+                        match = true;
+                        startPoint = new PointF(rect.Right, Math.Max(rect.TopRight.Y, otherRect.TopLeft.Y));
+                        endPoint = new PointF(rect.Right, Math.Min(rect.BottomRight.Y, otherRect.BottomLeft.Y));
+                    }
+                    else if (rect.Bottom == otherRect.Top) // top<->bottom intersection
+                    {
+                        match = true;
+                        startPoint = new PointF(Math.Max(rect.BottomLeft.X, otherRect.TopLeft.X), rect.Bottom);
+                        endPoint = new PointF(Math.Min(rect.BottomRight.X, otherRect.TopRight.X), rect.Bottom);
+                    }
+
+                    if (match)
+                        graphics.DrawLine(IntersectColor, startPoint, endPoint);
+                }
             }
 
             // Draw foreground area


### PR DESCRIPTION
This is useful for multi-monitor configurations as it allows users to more distinctly see whether they're on the middle of 2 areas or not.

It is potentially very slow code (would be appropriate to say this is going from O(n) to O(n^2)?), so as an alternative we can just change the existing `AreaBoundsBorderColor` to something more eye catching.

Alternatively I have ideas to optimize the code if we're interested in this behavior, but I just wanted to showcase the idea before sinking too much time into optimization.

![image](https://user-images.githubusercontent.com/421345/166565056-bc2bd459-a1a8-4313-bb08-8f5a3e19906e.png)
