### PR TITLE
Add support for Genius i405x

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Genius/i405x.json
+++ b/OpenTabletDriver.Configurations/Configurations/Genius/i405x.json
@@ -1,0 +1,39 @@
+{
+  "Name": "Genius i405x",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 140.5,
+      "Height": 102.4,
+      "MaxX": 14050.0,
+      "MaxY": 10240.0
+    },
+    "Pen": {
+      "MaxPressure": 1023,
+      "Buttons": {
+        "ButtonCount": 2
+      }
+    },
+    "AuxiliaryButtons": null,
+    "MouseButtons": {
+      "ButtonCount": 3
+    },
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 1112,
+      "ProductID": 20496,
+      "InputReportLength": 8,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Genius.GeniusReportParser",
+      "FeatureInitReport": [
+        "BRIQERIAAAA="
+      ],
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {}
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -10,7 +10,8 @@
 | Gaomon S620                   |     Supported     |
 | Gaomon S630                   |     Supported     | Windows: Requires Zadig's WinUSB to be installed on interface 0
 | Genius G-Pen 560              |     Supported     | Soft-buttons are bindable as aux buttons
-| Genius i608x                  |     Supported     | Require Zadig's WinUSB
+| Genius i405x                  |     Supported     | Windows: Require Zadig's WinUSB
+| Genius i608x                  |     Supported     | Windows: Require Zadig's WinUSB
 | Huion 1060 Plus               |     Supported     |
 | Huion 420                     |     Supported     | Windows: Requires Zadig's WinUSB to be installed on interface 0
 | Huion GT-220 V2               |     Supported     |


### PR DESCRIPTION
This seemed to never be added once it was completed? 

Tablet only has one interface

https://discord.com/channels/615607687467761684/927267867089592340/927302489928241203
https://discord.com/channels/615607687467761684/789348845372178482/973620584212758608

Linux diag for modern evidence.
[2.txt](https://github.com/OpenTabletDriver/OpenTabletDriver/files/8663301/2.txt)

