### PR TITLE
Add support for DTK-1300 aka Cintiq 13HD

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-1300.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-1300.json
@@ -1,0 +1,38 @@
+{
+  "Name": "Wacom Cintiq 13HD (DTK-1300)",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 299.0,
+      "Height": 171.0,
+      "MaxX": 59800.0,
+      "MaxY": 34200.0
+    },
+    "Pen": {
+      "MaxPressure": 2048,
+      "Buttons": {
+        "ButtonCount": 2
+      }
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 8
+    },
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 1386,
+      "ProductID": 772,
+      "InputReportLength": 10,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
+      "FeatureInitReport": [
+        "AgI="
+      ],
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }
+  ],
+  "Attributes": {}
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -150,6 +150,7 @@
 | Wacom CTE-650                 |  Missing Features | Wheel is not yet supported.
 | Wacom CTH-461                 |  Missing Features | Tablet buttons and touch are not yet supported.
 | Wacom CTL-6100WL              |  Missing Features | Wireless is not yet supported.
+| Wacom DTK-1300                |  Missing Features | Wheel center button is not yet supported.
 | Wacom MTE-450                 |  Missing Features | Wheel is not yet supported.
 | Wacom PTH-450                 |  Missing Features | Wheel is not yet supported.
 | Wacom PTH-451                 |  Missing Features | Wheel is not yet supported.

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -150,7 +150,7 @@
 | Wacom CTE-650                 |  Missing Features | Wheel is not yet supported.
 | Wacom CTH-461                 |  Missing Features | Tablet buttons and touch are not yet supported.
 | Wacom CTL-6100WL              |  Missing Features | Wireless is not yet supported.
-| Wacom DTK-1300                |  Missing Features | Wheel center button is not yet supported.
+| Wacom DTK-1300                |  Missing Features | Center button is not yet supported.
 | Wacom MTE-450                 |  Missing Features | Wheel is not yet supported.
 | Wacom PTH-450                 |  Missing Features | Wheel is not yet supported.
 | Wacom PTH-451                 |  Missing Features | Wheel is not yet supported.


### PR DESCRIPTION
Digitizer works fine with IntuosV1ReportParser, only missing functionality is the 9th button (which is also non functional on Intuos4/5 tablets)