### PR TITLE
Remove Octokit dependency on updater interfaces

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Diagnostics;
-using Octokit;
 using OpenTabletDriver.Desktop;
 using OpenTabletDriver.Desktop.Binding;
 using OpenTabletDriver.Desktop.Contracts;
@@ -463,9 +462,9 @@ namespace OpenTabletDriver.Daemon
             return Updater?.CheckForUpdates() ?? Task.FromResult(false);
         }
 
-        public async Task<Release> GetUpdateInfo()
+        public async Task<UpdateInfo?> GetUpdateInfo()
         {
-            return await Updater.GetRelease()!;
+            return await Updater.GetInfo();
         }
 
         public Task InstallUpdate()

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -462,9 +462,9 @@ namespace OpenTabletDriver.Daemon
             return Updater?.CheckForUpdates() ?? Task.FromResult(false);
         }
 
-        public async Task<UpdateInfo?> GetUpdateInfo()
+        public Task<UpdateInfo?> GetUpdateInfo()
         {
-            return await Updater.GetInfo();
+            return Updater.GetInfo();
         }
 
         public Task InstallUpdate()

--- a/OpenTabletDriver.Desktop/Contracts/IDriverDaemon.cs
+++ b/OpenTabletDriver.Desktop/Contracts/IDriverDaemon.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Octokit;
 using OpenTabletDriver.Desktop.Reflection.Metadata;
 using OpenTabletDriver.Desktop.RPC;
+using OpenTabletDriver.Desktop.Updater;
 using OpenTabletDriver.Plugin.Devices;
 using OpenTabletDriver.Plugin.Logging;
 using OpenTabletDriver.Plugin.Tablet;
@@ -40,7 +40,7 @@ namespace OpenTabletDriver.Desktop.Contracts
         Task<IEnumerable<LogMessage>> GetCurrentLog();
 
         Task<bool> HasUpdate();
-        Task<Release> GetUpdateInfo();
+        Task<UpdateInfo> GetUpdateInfo();
         Task InstallUpdate();
     }
 }

--- a/OpenTabletDriver.Desktop/Updater/GithubUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/GithubUpdater.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading.Tasks;
+using Octokit;
+
+#nullable enable
+
+namespace OpenTabletDriver.Desktop.Updater
+{
+    public abstract class GithubUpdater : Updater<GithubRelease>
+    {
+        private readonly GitHubClient github = new(new ProductHeaderValue("OpenTabletDriver"));
+
+        protected GithubUpdater(Version? currentVersion, string binaryDir, string appDataDir, string rollbackDir)
+            : base(currentVersion, binaryDir, appDataDir, rollbackDir)
+        {
+        }
+
+        protected override async Task<GithubRelease> GetUpdate()
+        {
+            var release = await github.Repository.Release.GetLatest("OpenTabletDriver", "OpenTabletDriver");
+            var version = new Version(release!.TagName[1..]); // remove `v` from `vW.X.Y.Z
+            return new GithubRelease(release, version);
+        }
+    }
+
+    public record GithubRelease(Release Release, Version Version) : UpdateInfo(Version);
+}

--- a/OpenTabletDriver.Desktop/Updater/IUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/IUpdater.cs
@@ -1,12 +1,13 @@
 using System.Threading.Tasks;
-using Octokit;
+
+#nullable enable
 
 namespace OpenTabletDriver.Desktop.Updater
 {
     public interface IUpdater
     {
         Task<bool> CheckForUpdates();
-        Task<Release> GetRelease();
+        Task<UpdateInfo?> GetInfo();
         Task InstallUpdate();
     }
 }

--- a/OpenTabletDriver.Desktop/Updater/UpdateInfo.cs
+++ b/OpenTabletDriver.Desktop/Updater/UpdateInfo.cs
@@ -1,0 +1,8 @@
+using System;
+
+#nullable enable
+
+namespace OpenTabletDriver.Desktop.Updater
+{
+    public record UpdateInfo(Version Version);
+}

--- a/OpenTabletDriver.Desktop/Updater/WindowsUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/WindowsUpdater.cs
@@ -3,23 +3,22 @@ using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Octokit;
 
 #nullable enable
 
 namespace OpenTabletDriver.Desktop.Updater
 {
-    public class WindowsUpdater : Updater
+    public class WindowsUpdater : GithubUpdater
     {
         public WindowsUpdater()
-           : this(AssemblyVersion,
+           : this(null,
                AppDomain.CurrentDomain.BaseDirectory,
                AppInfo.Current.AppDataDirectory,
                AppInfo.Current.BackupDirectory)
         {
         }
 
-        public WindowsUpdater(Version currentVersion, string binDirectory, string appDataDirectory, string rollBackDirectory)
+        public WindowsUpdater(Version? currentVersion, string binDirectory, string appDataDirectory, string rollBackDirectory)
             : base(currentVersion,
                 binDirectory,
                 appDataDirectory,
@@ -33,8 +32,9 @@ namespace OpenTabletDriver.Desktop.Updater
             "OpenTabletDriver.Daemon.exe"
         };
 
-        protected override async Task Download(Release release)
+        protected override async Task Download(GithubRelease ghRelease)
         {
+            var release = ghRelease.Release;
             var asset = release.Assets.First(r => r.Name.Contains("win-x64"));
 
             using (var client = new HttpClient())

--- a/OpenTabletDriver.UX/Windows/Updater/UpdaterWindow.cs
+++ b/OpenTabletDriver.UX/Windows/Updater/UpdaterWindow.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Threading.Tasks;
 using Eto.Drawing;
 using Eto.Forms;
-using OpenTabletDriver.Desktop.Interop;
 using OpenTabletDriver.Interop;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.UX.Controls;
@@ -49,7 +48,7 @@ namespace OpenTabletDriver.UX.Windows.Updater
                         new PaddingSpacerItem(),
                         new Bitmap(App.Logo.WithSize(256, 256)),
                         "An update is available to install",
-                        release.TagName,
+                        $"v{release.Version}",
                         new Button(Update)
                         {
                             Text = "Install"


### PR DESCRIPTION
And refactor out Github networking code to separate class.

This allows for mocking the version returned by update checks, and avoid issues when other branches became out-of-sync, causing false-positive test failures.