### PR TITLE
Add absolute wheel (ring) support

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-851.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-851.json
@@ -17,7 +17,8 @@
       "ButtonCount": 8
     },
     "MouseButtons": null,
-    "Touch": null
+    "Touch": null,
+    "MaxWheelPosition": 71
   },
   "DigitizerIdentifiers": [
     {

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1AuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1AuxReport.cs
@@ -2,7 +2,7 @@ using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1
 {
-    public struct IntuosV1AuxReport : IAuxReport
+    public struct IntuosV1AuxReport : IAuxReport, IWheelReport
     {
         public IntuosV1AuxReport(byte[] report)
         {
@@ -20,9 +20,14 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1
                 auxByte.IsBitSet(6),
                 auxByte.IsBitSet(7),
             };
+
+            WheelActive = report[2].IsBitSet(7);
+            WheelPosition = report[2].IsBitSet(7) ? (uint)(report[2] - 0x80) : 0;
         }
 
         public byte[] Raw { set; get; }
         public bool[] AuxButtons { set; get; }
+        public bool WheelActive { set; get; }
+        public uint WheelPosition { set; get; }
     }
 }

--- a/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
@@ -135,6 +135,9 @@ namespace OpenTabletDriver.Plugin.Output
             return report;
         }
 
+        private const uint MAX_ABS_WHEEL = 360; // number of points per full wheel rotation
+        private uint _wheel_multiplier = 0;
+
         protected override void OnOutput(IDeviceReport report)
         {
             if (report is IEraserReport eraserReport && Pointer is IEraserHandler eraserHandler)
@@ -151,6 +154,21 @@ namespace OpenTabletDriver.Plugin.Output
                     proximityHandler.SetProximity(proximityReport.NearProximity);
                 if (Pointer is IHoverDistanceHandler hoverDistanceHandler)
                     hoverDistanceHandler.SetHoverDistance(proximityReport.HoverDistance);
+            }
+            if (report is IWheelReport wheelReport && Pointer is IWheelHandler wheelHandler)
+            {
+                if (_wheel_multiplier == 0)
+                {
+                    if (Tablet.Properties.Specifications.MaxWheelPosition == 0)
+                        _wheel_multiplier = 1;
+                    else
+                        _wheel_multiplier = MAX_ABS_WHEEL / (Tablet.Properties.Specifications.MaxWheelPosition + 1);
+                }
+
+                if (wheelReport.WheelActive)
+                    wheelHandler.SetWheel(wheelReport.WheelPosition * _wheel_multiplier);
+                else
+                    wheelHandler.UnsetWheel();
             }
             if (Pointer is ISynchronousPointer synchronousPointer)
             {

--- a/OpenTabletDriver.Plugin/Platform/Pointer/IWheelHandler.cs
+++ b/OpenTabletDriver.Plugin/Platform/Pointer/IWheelHandler.cs
@@ -1,0 +1,18 @@
+using System.Numerics;
+
+namespace OpenTabletDriver.Plugin.Platform.Pointer
+{
+    public interface IWheelHandler
+    {
+        /// <summary>
+        /// Reports the absolute wheel position in degrees to the OS stack
+        /// </summary>
+        /// <param name="degrees">The amount of degrees the wheel is positioned to (0-359)</param>
+        void SetWheel(uint degrees);
+
+        /// <summary>
+        /// Reports that the wheel is no longer being used
+        /// </summary>
+        void UnsetWheel();
+    }
+}

--- a/OpenTabletDriver.Plugin/Tablet/IWheelReport.cs
+++ b/OpenTabletDriver.Plugin/Tablet/IWheelReport.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace OpenTabletDriver.Plugin.Tablet
+{
+    public interface IWheelReport : IDeviceReport
+    {
+        bool WheelActive { set; get; }
+        uint WheelPosition { set; get; }
+    }
+}

--- a/OpenTabletDriver.Plugin/Tablet/TabletSpecifications.cs
+++ b/OpenTabletDriver.Plugin/Tablet/TabletSpecifications.cs
@@ -26,5 +26,10 @@ namespace OpenTabletDriver.Plugin.Tablet
         /// Specifications for the touch digitizer.
         /// </summary>
         public DigitizerSpecifications Touch { set; get; }
+
+        /// <summary>
+        /// The maximum absolute wheel position the tablet can report, if any
+        /// </summary>
+        public uint MaxWheelPosition { set; get; }
     }
 }

--- a/OpenTabletDriver.UX/Tools/ReportFormatter.cs
+++ b/OpenTabletDriver.UX/Tools/ReportFormatter.cs
@@ -37,6 +37,8 @@ namespace OpenTabletDriver.UX.Tools
                 sb.AppendLines(GetStringFormat(toolReport));
             if (report is OutOfRangeReport oorReport)
                 sb.AppendLines(GetStringFormat(oorReport));
+            if (report is IWheelReport wheelReport)
+                sb.AppendLines(GetStringFormat(wheelReport));
 
             return sb.ToString();
         }
@@ -97,6 +99,13 @@ namespace OpenTabletDriver.UX.Tools
         private static IEnumerable<string> GetStringFormat(OutOfRangeReport oorReport)
         {
             yield return $"Pen is out of Range";
+        }
+
+        private static IEnumerable<string> GetStringFormat(IWheelReport wheelReport)
+        {
+            yield return $"Wheel active: {wheelReport.WheelActive}";
+            if (wheelReport.WheelActive)
+                yield return $"Wheel Position: {wheelReport.WheelPosition}";
         }
 
         private static void AppendLines(this StringBuilder sb, IEnumerable<string> lines)


### PR DESCRIPTION
Partial fix for #1367 - code needs a bit of cleanup (magic numbers into vars) and we likely need some UX configurables.

The idea is absolute wheels should just work:tm: without having to set anything, but UX additions are welcome of course. You can PR to my branch of course.

As the code is right now, it's not doing what I want.
I _think_ libinput is handling the events differently because the OTD device is considered a pen and not a pad. We might have to split events into 2 devices here, one for the pen itself and one for the pad if fixing libinput tags (via quirks?) doesn't fix it

Leaving as draft as I'm not entirely satisfied with it yet, but people can take a look and tell me if there's anything glaringly wrong. I have no plans of personally including relative wheel support, though once again you can PR to my branch.