### PR TITLE
Add identifier for CTH-661

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-661.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-661.json
@@ -45,6 +45,19 @@
       "OutputInitReport": null,
       "DeviceStrings": {},
       "InitializationStrings": []
+    },
+    {
+      "VendorID": 1386,
+      "ProductID": 216,
+      "InputReportLength": 9,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
+      "FeatureInitReport": [
+        "AgI="
+      ],
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
     }
   ],
   "AuxilaryDeviceIdentifiers": [],


### PR DESCRIPTION
Verification: https://discord.com/channels/615607687467761684/615611007951306863/979856404196241412

Weird problem with the debugger causing it to crash when opened so the position value couldn't be verified, but due to the fact that corners can be reached on the screen and the user has said that changing the area and trying it still keeps accuracy that they are the same.

<sup><sup>also merge #2247 first i don't think phoenix has the brain to figure out merge conflicts in the slightest</sup></sup>