### PR TITLE
Explicitly use libX11.so.6 and libXRandr.so.2

### DIFF
--- a/OpenTabletDriver.Native/Linux/Xorg/XLib.cs
+++ b/OpenTabletDriver.Native/Linux/Xorg/XLib.cs
@@ -10,7 +10,7 @@ namespace OpenTabletDriver.Native.Linux.Xorg
 
     public class XLib
     {
-        private const string libX11 = "libX11";
+        private const string libX11 = "libX11.so.6";
         private static object Lock = new object();
 
         [DllImport(libX11, EntryPoint = "XOpenDisplay")]

--- a/OpenTabletDriver.Native/Linux/Xorg/XRandr.cs
+++ b/OpenTabletDriver.Native/Linux/Xorg/XRandr.cs
@@ -8,7 +8,7 @@ namespace OpenTabletDriver.Native.Linux.Xorg
 
     public static class XRandr
     {
-        private const string libXRandr = "libXrandr";
+        private const string libXRandr = "libXrandr.so.2";
 
         [DllImport(libXRandr, EntryPoint = "XRRGetMonitors")]
         public unsafe extern static XRRMonitorInfo* XRRGetMonitors(Display dpy, Window window, bool get_active, out int nmonitors);


### PR DESCRIPTION
This fixes issues that pops up on recent distros like Fedora.

Resolves #2180