### PR TITLE
Fixed aux buttons for Veikk A30 V2

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A30 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A30 V2.json
@@ -28,7 +28,9 @@
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": [
-        "CQEE"
+        "CQEE",
+        "CQIC",
+        "CQMC"
       ],
       "DeviceStrings": {},
       "InitializationStrings": []

--- a/OpenTabletDriver.Configurations/Parsers/Veikk/VeikkAuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Veikk/VeikkAuxReport.cs
@@ -1,0 +1,22 @@
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Veikk
+{
+    public struct VeikkAuxReport : IAuxReport
+    {
+        public VeikkAuxReport(byte[] report)
+        {
+            Raw = report;
+            AuxButtons = new bool[]
+            {
+                report[4].IsBitSet(0) && report[3].IsBitSet(0), // First
+                report[4].IsBitSet(1) && report[3].IsBitSet(0), // Second
+                report[4].IsBitSet(2) && report[3].IsBitSet(0), // Third
+                report[4].IsBitSet(3) && report[3].IsBitSet(0), // Fourth
+            };
+        }
+
+        public byte[] Raw { get; set; }
+        public bool[] AuxButtons { get; set; }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Veikk/VeikkReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Veikk/VeikkReportParser.cs
@@ -6,8 +6,13 @@ namespace OpenTabletDriver.Configurations.Parsers.Veikk
     {
         public IDeviceReport Parse(byte[] report)
         {
+            if (report[1] == 0x43) // Touchpad report - not yet supported, so ignored
+                return new DeviceReport(report);
+
             if (report[2].IsBitSet(5))
                 return new VeikkTabletReport(report);
+            else if (report[2] == 1)
+                return new VeikkAuxReport(report);
 
             return new DeviceReport(report);
         }


### PR DESCRIPTION
@jamesbt365 said in this PR https://github.com/OpenTabletDriver/OpenTabletDriver/pull/2216 that the aux buttons might not be working due to the OEM drivers still being installed, but that's not the case (they are also broken on a fresh windows 10 install). 

I reverse-engineered the OEM driver and it turns out the tablet needs 3 initial reports (one for the digitizer, one for the aux buttons, one for the touchpad). I've added a parser that can parse the aux button reports. I don't know if that solution works for other Veikk tablets as well, it might fix #1854.