### PR TITLE
Add support for gesture touchpads

### DIFF
--- a/OpenTabletDriver.Console/ProgramCommands.cs
+++ b/OpenTabletDriver.Console/ProgramCommands.cs
@@ -131,6 +131,17 @@ namespace OpenTabletDriver.Console
             });
         }
 
+        [Command("set-gesturetouch-binding", "Sets the gesture touchpad bindings")]
+        public async Task SetGestureTouchpadBinding(string tablet, string name, int index)
+        {
+            await ModifyProfile(tablet, async p =>
+            {
+                var binding = await _driverDaemon.GetDefaults(name);
+                
+                p.BindingSettings.TouchGestures[index] = binding;
+            });
+        }
+
         [Command("set-output-mode", "Sets the active output mode with its defaults")]
         public async Task SetOutputMode(string tablet, string mode)
         {

--- a/OpenTabletDriver.Desktop/Binding/BindingHandler.cs
+++ b/OpenTabletDriver.Desktop/Binding/BindingHandler.cs
@@ -36,6 +36,7 @@ namespace OpenTabletDriver.Desktop.Binding
 
             PenButtons = CreateBindingStates(settings.PenButtons, device, mouseButtonHandler);
             AuxButtons = CreateBindingStates(settings.AuxButtons, device, mouseButtonHandler);
+            TouchGestures = CreateBindingStates(settings.TouchGestures, device, mouseButtonHandler);
             MouseButtons = CreateBindingStates(settings.MouseButtons, device, mouseButtonHandler);
 
             MouseScrollDown = CreateBindingState<BindingState>(settings.MouseScrollDown, device, mouseButtonHandler);
@@ -47,6 +48,7 @@ namespace OpenTabletDriver.Desktop.Binding
 
         private Dictionary<int, BindingState?> PenButtons { get; }
         private Dictionary<int, BindingState?> AuxButtons { get; }
+        private Dictionary<int, BindingState?> TouchGestures { get; }
         private Dictionary<int, BindingState?> MouseButtons { get; }
 
         private BindingState? MouseScrollDown { get; }
@@ -66,6 +68,8 @@ namespace OpenTabletDriver.Desktop.Binding
                 HandleTabletReport(device.Configuration.Specifications.Pen!, tabletReport);
             if (report is IAuxReport auxReport)
                 HandleAuxiliaryReport(auxReport);
+            if (report is IGestureTouchReport gestureTouchReport)
+                HandleGestureTouchReport(gestureTouchReport);
             if (report is IMouseReport mouseReport)
                 HandleMouseReport(mouseReport);
         }
@@ -84,6 +88,11 @@ namespace OpenTabletDriver.Desktop.Binding
         private void HandleAuxiliaryReport(IAuxReport report)
         {
             HandleBindingCollection(report, AuxButtons, report.AuxButtons);
+        }
+
+        private void HandleGestureTouchReport(IGestureTouchReport report)
+        {
+            HandleBindingCollection(report, TouchGestures, report.TouchGestures);
         }
 
         private void HandleMouseReport(IMouseReport report)

--- a/OpenTabletDriver.Desktop/Profiles/BindingSettings.cs
+++ b/OpenTabletDriver.Desktop/Profiles/BindingSettings.cs
@@ -13,7 +13,8 @@ namespace OpenTabletDriver.Desktop.Profiles
         private PluginSettings? _tipButton, _eraserButton, _mouseScrollUp, _mouseScrollDown;
         private PluginSettingsCollection _penButtons = new PluginSettingsCollection(),
             _auxButtons = new PluginSettingsCollection(),
-            _mouseButtons = new PluginSettingsCollection();
+            _mouseButtons = new PluginSettingsCollection(),
+            _touchGestures = new PluginSettingsCollection();
 
         [DisplayName("Tip Activation Threshold"), JsonProperty("TipActivationThreshold")]
         public float TipActivationThreshold
@@ -57,6 +58,13 @@ namespace OpenTabletDriver.Desktop.Profiles
             get => _auxButtons;
         }
 
+        [DisplayName("Touch Gestures"), JsonProperty("TouchGestures")]
+        public PluginSettingsCollection TouchGestures
+        {
+            set => RaiseAndSetIfChanged(ref _touchGestures!, value);
+            get => _touchGestures;
+        }
+
         [DisplayName("Mouse Button"), JsonProperty("MouseButtons")]
         public PluginSettingsCollection MouseButtons
         {
@@ -91,7 +99,8 @@ namespace OpenTabletDriver.Desktop.Profiles
                 ),
                 PenButtons = new PluginSettingsCollection(),
                 AuxButtons = new PluginSettingsCollection(),
-                MouseButtons = new PluginSettingsCollection()
+                MouseButtons = new PluginSettingsCollection(),
+                TouchGestures = new PluginSettingsCollection()
             };
             bindingSettings.MatchSpecifications(tabletSpecifications);
             return bindingSettings;
@@ -102,10 +111,11 @@ namespace OpenTabletDriver.Desktop.Profiles
             var penButtonCount = tabletSpecifications.Pen?.ButtonCount ?? 0;
             var auxButtonCount = tabletSpecifications.AuxiliaryButtons?.ButtonCount ?? 0;
             var mouseButtonCount = tabletSpecifications.MouseButtons?.ButtonCount ?? 0;
-
+            var touchGestureCount = tabletSpecifications.GestureTouchpad?.GestureCount ?? 0;
             PenButtons = PenButtons.SetLength(penButtonCount);
             AuxButtons = AuxButtons.SetLength(auxButtonCount);
             MouseButtons = MouseButtons.SetLength(mouseButtonCount);
+            TouchGestures = TouchGestures.SetLength(touchGestureCount);
         }
     }
 }

--- a/OpenTabletDriver.Desktop/RPC/ReportFormatter.cs
+++ b/OpenTabletDriver.Desktop/RPC/ReportFormatter.cs
@@ -39,6 +39,8 @@ namespace OpenTabletDriver.Desktop.RPC
                 sb.AppendLines(GetStringFormat(tabletReport));
             if (report is IAuxReport auxReport)
                 sb.AppendLines(GetStringFormat(auxReport));
+            if (report is IGestureTouchReport gestureTouchReport)
+                sb.AppendLines(GetStringFormat(gestureTouchReport));
             if (report is IEraserReport eraserReport)
                 sb.AppendLines(GetStringFormat(eraserReport));
             if (report is IProximityReport proximityReport)
@@ -71,6 +73,11 @@ namespace OpenTabletDriver.Desktop.RPC
         private static IEnumerable<string> GetStringFormat(IAuxReport auxReport)
         {
             yield return $"AuxButtons:[{string.Join(" ", auxReport.AuxButtons)}]";
+        }
+
+        private static IEnumerable<string> GetStringFormat(IGestureTouchReport gestureTouchReport)
+        {
+            yield return $"TouchGestures:[{string.Join(" ", gestureTouchReport.TouchGestures)}]";
         }
 
         private static IEnumerable<string> GetStringFormat(IEraserReport eraserReport)

--- a/OpenTabletDriver.UX/Controls/GestureTouchpadPanel.cs
+++ b/OpenTabletDriver.UX/Controls/GestureTouchpadPanel.cs
@@ -1,0 +1,37 @@
+using Eto.Forms;
+using OpenTabletDriver.Desktop.Profiles;
+using OpenTabletDriver.UX.Components;
+
+namespace OpenTabletDriver.UX.Controls
+{
+    public class GestureTouchpadPanel : BindingPanel
+    {
+        public GestureTouchpadPanel(IControlBuilder controlBuilder, App app) : base(controlBuilder)
+        {
+            var buttons = new StackLayout
+            {
+                HorizontalContentAlignment = HorizontalAlignment.Stretch,
+                Spacing = 5
+            };
+
+            DataContextChanged += delegate
+            {
+                buttons.Items.Clear();
+
+                if (DataContext is not Profile profile)
+                    return;
+
+                var tablet = app.Tablets.First(t => t.Name == profile.Tablet);
+                var buttonCount = tablet.Specifications.GestureTouchpad?.GestureCount ?? 0;
+
+                foreach (var button in ButtonsFor(c => c.BindingSettings.TouchGestures, buttonCount))
+                    buttons.Items.Add(button);
+            };
+
+            Content = new Scrollable
+            {
+                Content = buttons
+            };
+        }
+    }
+}

--- a/OpenTabletDriver.UX/Controls/ProfilePanel.cs
+++ b/OpenTabletDriver.UX/Controls/ProfilePanel.cs
@@ -20,6 +20,7 @@ namespace OpenTabletDriver.UX.Controls
             var filtersPage = CreatePage<FiltersPanel>("Filters");
             var penPage = CreatePage<PenPanel>("Pen");
             var auxPage = CreatePage<AuxPanel>("Auxiliary");
+            var gestureTouchpadPage = CreatePage<GestureTouchpadPanel>("Gesture Touchpad");
             var mousePage = CreatePage<MousePanel>("Mouse");
             var toolsPage = CreatePage<ToolsPanel>("Tools");
             var logPage = CreatePage<LogViewer>("Log");
@@ -74,6 +75,9 @@ namespace OpenTabletDriver.UX.Controls
 
                     if (specifications.AuxiliaryButtons != null)
                         pages.Add(auxPage);
+
+                    if (specifications.GestureTouchpad != null)
+                        pages.Add(gestureTouchpadPage);
 
                     if (specifications.MouseButtons != null)
                         pages.Add(mousePage);

--- a/OpenTabletDriver/Tablet/GestureTouchpadSpecifications.cs
+++ b/OpenTabletDriver/Tablet/GestureTouchpadSpecifications.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel;
+using JetBrains.Annotations;
+namespace OpenTabletDriver.Tablet
+{
+    /// <summary>
+    /// Device specifications for gesture touchpads.
+    /// </summary>
+    [PublicAPI]
+    public class GestureTouchpadSpecifications
+    {
+        /// <summary>
+        /// The amount of gestures.
+        /// </summary>
+        public uint GestureCount { set; get; }
+    }
+}

--- a/OpenTabletDriver/Tablet/IGestureTouchReport.cs
+++ b/OpenTabletDriver/Tablet/IGestureTouchReport.cs
@@ -1,0 +1,12 @@
+using JetBrains.Annotations;
+namespace OpenTabletDriver.Tablet
+{
+    /// <summary>
+    /// An report designating the gesture touchpad state.
+    /// </summary>
+    [PublicAPI]
+    public interface IGestureTouchReport : IDeviceReport
+    {
+        bool[] TouchGestures { set; get; }
+    }
+}

--- a/OpenTabletDriver/Tablet/TabletSpecifications.cs
+++ b/OpenTabletDriver/Tablet/TabletSpecifications.cs
@@ -35,5 +35,10 @@ namespace OpenTabletDriver.Tablet
         /// Specifications for the touch digitizer.
         /// </summary>
         public DigitizerSpecifications? Touch { set; get; }
+
+        /// <summary>
+        /// Specifications for the touchpad gestures.
+        /// </summary>
+        public GestureTouchpadSpecifications? GestureTouchpad { set; get; }
     }
 }


### PR DESCRIPTION
Veikk tablets with gesture touchpads can now be fully supported.
(These are not sending coordinate reports - only repeated reports on swipe with direction information)