### PR TITLE
Add support for H690

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/H690.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H690.json
@@ -14,8 +14,8 @@
       }
     },
     "AuxiliaryButtons": {
-		"ButtonCount": 3
-		},
+      "ButtonCount": 3
+    },
     "MouseButtons": null,
     "Touch": null
   },
@@ -24,6 +24,22 @@
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 8,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "6": "HuionH690"
+      },
+      "InitializationStrings": [
+        100,
+        123
+      ]
+    },
+    {
+      "VendorID": 9580,
+      "ProductID": 110,
+      "InputReportLength": 16,
       "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
       "FeatureInitReport": null,

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H690.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H690.json
@@ -1,0 +1,44 @@
+{
+  "Name": "Huion H690",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 228.6,
+      "Height": 142.875,
+      "MaxX": 36000.0,
+      "MaxY": 22500.0
+    },
+    "Pen": {
+      "MaxPressure": 2047,
+      "Buttons": {
+        "ButtonCount": 2
+      }
+    },
+    "AuxiliaryButtons": {
+		"ButtonCount": 3
+		},
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 9580,
+      "ProductID": 110,
+      "InputReportLength": 8,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "6": "HuionH690"
+      },
+      "InitializationStrings": [
+        100,
+        123
+      ]
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -23,7 +23,7 @@
 | Huion H610X                   |     Supported     |
 | Huion H640P                   |     Supported     |
 | Huion H642                    |     Supported     |
-| Huion H690                    |     Supported     |
+| Huion H690                    |     Supported     | Windows: Requires Zadig's WinUSB to be installed on interface 0
 | Huion H950P                   |     Supported     |
 | Huion H1060P                  |     Supported     |
 | Huion HS64                    |     Supported     |

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -23,6 +23,7 @@
 | Huion H610X                   |     Supported     |
 | Huion H640P                   |     Supported     |
 | Huion H642                    |     Supported     |
+| Huion H690                    |     Supported     |
 | Huion H950P                   |     Supported     |
 | Huion H1060P                  |     Supported     |
 | Huion HS64                    |     Supported     |


### PR DESCRIPTION
Works on Linux perfectly. 
Works on Windows on interface 0 with the usual quirks. No issues apart from the ones generally caused by OTD.
Not tested on Mac.