### PR TITLE
add tilt support for Gaomon 1060 Pro

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/1060 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/1060 Pro.json
@@ -25,7 +25,7 @@
       "ProductID": 109,
       "InputReportLength": 12,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {
@@ -40,11 +40,26 @@
       "ProductID": 100,
       "InputReportLength": 12,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {
         "201": "OEM02_T174_\\d{6}$"
+      },
+      "InitializationStrings": [
+        200
+      ]
+    },
+    {
+      "VendorID": 9580,
+      "ProductID": 100,
+      "InputReportLength": 12,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "201": "GM001_T213_\\d{6}$"
       },
       "InitializationStrings": [
         200


### PR DESCRIPTION
i have tested tilt support for Gaomon 1060 Pro:

the tilt support has written on [official website](https://www.gaomon.cn/Pen_Tablet/1060PRO.html)
![图片](https://user-images.githubusercontent.com/55868015/173214936-c1b2e2ca-f9d6-4828-8a0b-2e86f3d08c0a.png)


minimum 0deg - the pen is vertical on tablet
![图片](https://user-images.githubusercontent.com/55868015/173214164-19e327e4-1b1e-4f61-9b0b-2388e29b5b8e.png)
maximum 60deg - right tilt the pen
![图片](https://user-images.githubusercontent.com/55868015/173214214-23529768-0fc9-4a1e-aa2d-3917f63f5c12.png)
forward tilt the pen
![图片](https://user-images.githubusercontent.com/55868015/173214268-d1ded1f2-6e8f-45c1-825e-900dd95b679f.png)

and add a new device identifier (discussed on #2305)