### PR TITLE
EvdevVirtualTablet: Support forward/backwards mouse buttons

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -70,7 +70,9 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
                 EventCode.BTN_TOOL_PEN,
                 EventCode.BTN_TOOL_RUBBER,
                 EventCode.BTN_STYLUS2,
-                EventCode.BTN_STYLUS3
+                EventCode.BTN_STYLUS3,
+                EventCode.BTN_SIDE,
+                EventCode.BTN_EXTRA
             );
 
             var result = Device.Initialize();
@@ -145,7 +147,5 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
         {
             Device.Sync();
         }
-
-        protected override EventCode? GetCode(MouseButton button) => null;
     }
 }


### PR DESCRIPTION
Pre-PR:
Pen bindings using mouse button Forwards/Backwards did nothing

Post-PR:
Mouse button bindings with Forward/Backwards now does something

Notes:
I've removed the `GetCode(MouseButton button) => null` override entirely as the binding of the other 3 mouse buttons should be harmless, as they're not defined in evdev as being events that can happen from that endpoint, and in my testing they are filtered out as expected. This means that mouse{1..3} behavior is effectively not different from pre-PR.