### PR TITLE
Add support for Gaomon S830

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/S830.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/S830.json
@@ -1,0 +1,43 @@
+{
+  "Name": "Gaomon S830",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 182.3,
+      "Height": 107.7,
+      "MaxX": 34460.0,
+      "MaxY": 21540.0
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "Buttons": {
+        "ButtonCount": 2
+      }
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 4
+    },
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 9580,
+      "ProductID": 109,
+      "InputReportLength": 12,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "2": "Gaomon Tablet_ S830"
+      },
+      "InitializationStrings": [
+        200
+      ]
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -9,6 +9,7 @@
 | Gaomon S56K                   |     Supported     |
 | Gaomon S620                   |     Supported     |
 | Gaomon S630                   |     Supported     | Windows: Requires Zadig's WinUSB to be installed on interface 0
+| Gaomon S830                   |     Supported     | User may need to re-plug their tablet multiple time for it to be detected
 | Genius G-Pen 560              |     Supported     | Soft-buttons are bindable as aux buttons
 | Genius i405x                  |     Supported     | Windows: Require Zadig's WinUSB
 | Genius i608x                  |     Supported     | Windows: Require Zadig's WinUSB


### PR DESCRIPTION
making a new pull for #1781

Invoking detection constantly is the only way that we can get detection because the strings randomise. The gaomon driver also does what is required here. (I think so the conversation was somewhere and I can't find it)