### PR TITLE
Add identifier for Deco 01 V2

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01 V2 (variant 2).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01 V2 (variant 2).json
@@ -34,6 +34,22 @@
         "4": "UG902_BPG1002"
       },
       "InitializationStrings": []
+    },
+    {
+      "VendorID": 10429,
+      "ProductID": 2309,
+      "InputReportLength": 12,
+      "OutputReportLength": 10,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": [
+        "ArAE"
+      ],
+      "DeviceStrings": {
+        "4": "UG901_BPU1002",
+        "5": "2020-10-23_Release3"
+      },
+      "InitializationStrings": []
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01 V2.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {
-        "4": "UG901_BPU1002"
+        "4": "UG901_BPU1002",
+        "5": "^(?!2020-10-23_Release3$).*$"
       },
       "InitializationStrings": []
     },


### PR DESCRIPTION
My Deco 01 V2 can only use the upper left 1/4. So it should use variant 2 configuration.
The difference between them seems to be device string at the index 5.

device strings:
```
1=UGTABLET
2=10 inch PenTablet
3=000000
4=UG901_BPU1002
5=2020-10-23_Release3
```