### PR TITLE
Add IProximityReport to BambooTabletReport

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Bamboo/BambooTabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Bamboo/BambooTabletReport.cs
@@ -34,7 +34,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo
             };
 
             NearProximity = report[1].IsBitSet(7);
-            HoverDistance = (uint)report[1];
+            HoverDistance = (uint)report[1] >> 4;
         }
 
         public byte[] Raw { set; get; }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Bamboo/BambooTabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Bamboo/BambooTabletReport.cs
@@ -35,7 +35,6 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo
 
             NearProximity = report[1].IsBitSet(7);
             HoverDistance = (uint)report[1];
-
         }
 
         public byte[] Raw { set; get; }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Bamboo/BambooTabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Bamboo/BambooTabletReport.cs
@@ -4,7 +4,7 @@ using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo
 {
-    public struct BambooTabletReport : ITabletReport, IAuxReport, IEraserReport
+    public struct BambooTabletReport : ITabletReport, IAuxReport, IEraserReport, IProximityReport
     {
         public BambooTabletReport(byte[] report)
         {
@@ -32,6 +32,10 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo
                 report[7].IsBitSet(5),
                 report[7].IsBitSet(6),
             };
+
+            NearProximity = report[1].IsBitSet(7);
+            HoverDistance = (uint)report[1];
+
         }
 
         public byte[] Raw { set; get; }
@@ -40,5 +44,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo
         public bool[] PenButtons { set; get; }
         public bool[] AuxButtons { set; get; }
         public bool Eraser { set; get; }
+        public bool NearProximity { set; get; }
+        public uint HoverDistance { set; get; }
     }
 }


### PR DESCRIPTION
The tablets using BambooReportParser contain data for NearProximity so that should be parsed.

They do not contain normal precise hover distance data but it is required for IProximityReport to use HoverDistance. Using byte 1 for this isn't perfect but the data from it is reasonable to use in place of more precise hover distance data.