### PR TITLE
add support for a variant of the Gaomon S56K

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/S56K.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/S56K.json
@@ -47,6 +47,21 @@
       "InitializationStrings": [
         200
       ]
+    },
+    {
+      "VendorID": 9580,
+      "ProductID": 110,
+      "InputReportLength": 16,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "201": "HUION_T156_\\d{6}$"
+      },
+      "InitializationStrings": [
+        200
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -7,7 +7,7 @@
 | Gaomon PD1560                 |     Supported     |
 | Gaomon PD1561                 |     Supported     |
 | Gaomon PD2200                 |     Supported     |
-| Gaomon S56K                   |     Supported     |
+| Gaomon S56K                   |     Supported     | Windows: Some variations may require Zadig's WinUSB to be installed on interface 0 or 1
 | Gaomon S620                   |     Supported     |
 | Gaomon S630                   |     Supported     | Windows: Requires Zadig's WinUSB to be installed on interface 0
 | Gaomon S830                   |     Supported     | User may need to re-plug their tablet multiple time for it to be detected


### PR DESCRIPTION
Verification: https://discord.com/channels/615607687467761684/615611007951306863/1007629239547351040

This variant requires winusb on interface 1.