### PR TITLE
Fix labeler event fail

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,14 +2,14 @@ name: "Issue Labeler"
 on:
   issues:
     types: [opened]
-  pull_requests:
+  pull_request:
     types: [opened]
 
 jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: github/issue-labeler@v2.0
+    - uses: github/issue-labeler@v2.5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler.yml


### PR DESCRIPTION
uses a version that has pull request support and fixes the event name because the docs are wrong.