### PR TITLE
Add more user guidance to build.sh and generate-rules.sh

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -7,7 +7,7 @@ $nl = [Environment]::NewLine;
 
 $Config = "Release";
 
-$Options = @("--configuration", "$Config", "--self-contained=false", "--output=./bin", "/p:PublishSingleFile=true", "/p:DebugType=embedded",`
+$Options = @("--configuration", "$Config", "--verbosity=quiet", "--self-contained=false", "--output=./bin", "/p:PublishSingleFile=true", "/p:DebugType=embedded",`
     "/p:SuppressNETCoreSdkPreviewMessage=true", "/p:PublishTrimmed=false", "--runtime=$NetRuntime", "-p:SourceRevisionId=$(git rev-parse --short HEAD)");
 
 # Change dir to script root, in case people run the script outside of the folder.

--- a/build.sh
+++ b/build.sh
@@ -42,8 +42,8 @@ dotnet publish OpenTabletDriver.UX.Gtk ${options[@]} $@ || exit 3
 
 echo "Build finished successfully. Binaries created in ./bin"
 
-if [ ! -f /etc/udev/rules.d/99-opentabletdriver.rules ]; then
-    echo "\nUdev rules don't seem to be installed in /etc/udev/rules.d."
+if [ ! -f /etc/udev/rules.d/99-opentabletdriver.rules ] && [ ! -f /usr/lib/udev/rules.d/99-opentabletdriver.rules ]; then
+    echo "\nUdev rules don't seem to be installed in /etc/udev/rules.d or /usr/lib/udev/rules.d."
     echo "If your distribution installs them elsewhere, ignore this message."
     echo "If not, generate them by running generate-rules.sh, then follow the prompts."
 fi

--- a/build.sh
+++ b/build.sh
@@ -40,4 +40,10 @@ dotnet publish OpenTabletDriver.Console ${options[@]} $@ || exit 2
 echo -e "\nBuilding GTK UX...\n"
 dotnet publish OpenTabletDriver.UX.Gtk ${options[@]} $@ || exit 3
 
-echo "Build finished. Binaries created in ./bin"
+echo "Build finished successfully. Binaries created in ./bin"
+
+if [ ! -f /etc/udev/rules.d/99-opentabletdriver.rules ]; then
+    echo "\nUdev rules don't seem to be installed in /etc/udev/rules.d."
+    echo "If your distribution installs them elsewhere, ignore this message."
+    echo "If not, generate them by running generate-rules.sh, then follow the prompts."
+fi

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ shift
 
 config=(--configuration='Release')
 
-options=(${config} --framework='net6.0' --self-contained='false' -v=q --output='./bin' \
+options=(${config} --framework='net6.0' --self-contained='false' --verbosity=quiet --output='./bin' \
     /p:SuppressNETCoreSdkPreviewMessage=true /p:PublishTrimmed=false --runtime=$runtime -p:SourceRevisionId=$(git rev-parse --short HEAD))
 
 # change dir to script root, in case people run the script outside of the folder

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ shift
 
 config=(--configuration='Release')
 
-options=(${config} --framework='net6.0' --self-contained='false' --output='./bin' \
+options=(${config} --framework='net6.0' --self-contained='false' -v=q --output='./bin' \
     /p:SuppressNETCoreSdkPreviewMessage=true /p:PublishTrimmed=false --runtime=$runtime -p:SourceRevisionId=$(git rev-parse --short HEAD))
 
 # change dir to script root, in case people run the script outside of the folder

--- a/build.sh
+++ b/build.sh
@@ -42,7 +42,7 @@ dotnet publish OpenTabletDriver.UX.Gtk ${options[@]} $@ || exit 3
 
 echo "Build finished successfully. Binaries created in ./bin"
 
-if [ ! -f /etc/udev/rules.d/99-opentabletdriver.rules ] && [ ! -f /usr/lib/udev/rules.d/99-opentabletdriver.rules ]; then
+if [ ! -f /etc/udev/rules.d/??-opentabletdriver.rules ] && [ ! -f /usr/lib/udev/rules.d/??-opentabletdriver.rules ]; then
     echo "\nUdev rules don't seem to be installed in /etc/udev/rules.d or /usr/lib/udev/rules.d."
     echo "If your distribution installs them elsewhere, ignore this message."
     echo "If not, generate them by running generate-rules.sh, then follow the prompts."

--- a/generate-rules.sh
+++ b/generate-rules.sh
@@ -17,4 +17,10 @@ else
   dotnet_args=("-v" "${TABLET_CONFIGURATIONS}" "${RULES_FILE}")
 fi
 
+echo "Generating udev rules..."
+
 dotnet run --project "${PROJECT}" -f "${FRAMEWORK}" -- ${dotnet_args[@]}
+
+echo "\nRule file generated. Please move the generated rule file './bin/99-opentabletdriver.rules' to /etc/udev/rules.d, then run"
+echo "sudo udevadm control --reload-rules"
+echo "or simply reboot your PC."


### PR DESCRIPTION


Small PR that adds some more guidance to people using build.sh and generate-rules.sh to build and run OTD from source. Notably,

- Build.sh now checks for udev rules in the typical `/etc/udev/rules.d/` directory, and if not found, warns the user that they need to also run generate-rules.sh.
- Generate-rules.sh now explains what to do with the generated rules file.
- (added this in as a bonus) build.sh now spams less text while building, via providing the --verbosity=quiet tag. `dotnet publish` will still output errors (if any) just fine, but it won't spam individual files being built. 

The only thing unaddressed is running the binaries themselves, but I don't think that this is necessary - the script explains where the binaries are created by build.sh, and they're named obviously. You run `OpenTabletDriver.Daemon` for the daemon, etc. 

If the user wants automated running of OTD (and isn't planning on installing a package to have the service), they should set that up via their DE's startup system, potentially creating .desktop files pointing at the created binaries. Alternatively we could provide some pre-made .desktop files for the user to edit and move where they're supposed to go for their DE.

If they want to start OTD for dev work, a simple `./bin/OpenTabletDriver.Daemon` from the root folder works. No need for a dedicated run script.