### PR TITLE
A15 moment

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A15 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A15 V2.json
@@ -1,0 +1,43 @@
+{
+    "Name": "VEIKK A15 V2",
+    "Specifications": {
+      "Digitizer": {
+        "Width": 254.0,
+        "Height": 152.4,
+        "MaxX": 50800.0,
+        "MaxY": 31750.0
+      },
+      "Pen": {
+        "MaxPressure": 8191,
+        "Buttons": {
+          "ButtonCount": 2
+        }
+      },
+      "AuxiliaryButtons": {
+        "ButtonCount": 12
+      },
+      "MouseButtons": null,
+      "Touch": null
+    },
+    "DigitizerIdentifiers": [
+      {
+        "VendorID": 12267,
+        "ProductID": 4,
+        "InputReportLength": 13,
+        "OutputReportLength": 9,
+        "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkReportParser",
+        "FeatureInitReport": null,
+        "OutputInitReport": [
+            "CQEE",
+            "CQIC",
+            "CQMC"
+        ],
+        "DeviceStrings": {},
+        "InitializationStrings": []
+      }
+    ],
+    "AuxilaryDeviceIdentifiers": [],
+    "Attributes": {
+      "libinputoverride": "1"
+    }
+  }

--- a/OpenTabletDriver.Configurations/Parsers/Veikk/VeikkAuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Veikk/VeikkAuxReport.cs
@@ -17,6 +17,10 @@ namespace OpenTabletDriver.Configurations.Parsers.Veikk
                 report[4].IsBitSet(5) && report[3].IsBitSet(0),
                 report[4].IsBitSet(6) && report[3].IsBitSet(0),
                 report[4].IsBitSet(7) && report[3].IsBitSet(0),
+                report[5].IsBitSet(0) && report[3].IsBitSet(0),
+                report[5].IsBitSet(1) && report[3].IsBitSet(0),
+                report[5].IsBitSet(2) && report[3].IsBitSet(0),
+                report[5].IsBitSet(3) && report[3].IsBitSet(0),
             };
         }
 

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -57,6 +57,7 @@
 | UGTABLET M708                 |     Supported     | Windows: Some variations may require Zadig's WinUSB to be installed on interface 0
 | UGTABLET M708 V2              |     Supported     |
 | VEIKK A15                     |     Supported     |
+| VEIKK A15 V2                  |     Supported     |
 | VEIKK S640                    |     Supported     |
 | VEIKK S640 V2                 |     Supported     |
 | VEIKK VK1060                  |     Supported     |


### PR DESCRIPTION
Verification: https://discord.com/channels/615607687467761684/615611007951306863/1015361583444131934
https://discord.com/channels/615607687467761684/615611007951306863/1015369710801535137

Don't think this technically counts as a V2, but has a different lpi on the Y axis compared to the other configuration so it had to be split.

Added to the tablets.md anyway but will remove if it doesn't count.

Extra inits required for aux.