### PR TITLE
Fix crash when mutiple tablets are disconnected simultaneously.

### DIFF
--- a/OpenTabletDriver/IDriver.cs
+++ b/OpenTabletDriver/IDriver.cs
@@ -12,7 +12,7 @@ namespace OpenTabletDriver
     public interface IDriver
     {
         event EventHandler<IEnumerable<InputDevice>>? InputDevicesChanged;
-        InputDeviceCollection InputDevices { get; }
+        IReadOnlyList<InputDevice> InputDevices { get; }
         IReportParser<IDeviceReport> GetReportParser(DeviceIdentifier identifier);
         void Detect();
     }


### PR DESCRIPTION
When tablets are disconnected using USB switch, InputDevices.Remove is invoked from DeviceReader thread, which causes race condition.