### PR TITLE
Deco 02 Area Size Correction

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 02.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 02.json
@@ -2,8 +2,8 @@
   "Name": "XP-Pen Deco 02",
   "Specifications": {
     "Digitizer": {
-      "Width": 223.52,
-      "Height": 139.7,
+      "Width": 254.0,
+      "Height": 142.9,
       "MaxX": 22352,
       "MaxY": 13970
     },


### PR DESCRIPTION
Based on both [vendor info](https://www.ugee.com.cn/goods/84.html) and my own measurement, the area is 254mm x 142.9mm. (or 142.875mm)

(Deco 02 seems have different LPI/LPmm on x-axis and y-axis)

p.s.: XP-Pen Deco 02 is the same hardware as UGEE RB170
