### PR TITLE
Fix incorrectly parsed ack report in Veikk S640

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/S640.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/S640.json
@@ -23,7 +23,7 @@
       "ProductID": 1,
       "InputReportLength": 9,
       "OutputReportLength": 9,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.SkipByteTabletReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkV2ReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE"

--- a/OpenTabletDriver.Configurations/Parsers/Veikk/VeikkV2ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Veikk/VeikkV2ReportParser.cs
@@ -1,0 +1,17 @@
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Veikk
+{
+    public class VeikkV2ReportParser : IReportParser<IDeviceReport>
+    {
+        public IDeviceReport Parse(byte[] report)
+        {
+            return (report[1], report[2]) switch
+            {
+                (0x41, byte x) when (x & 0xF0) == 0xA0 => new TabletReport(report[1..]),
+                (0x41, 0xC0) => new OutOfRangeReport(report),
+                _ => new DeviceReport(report)
+            };
+        }
+    }
+}


### PR DESCRIPTION
Other Veikk tablets that use SkipByteReportParser should be tested if they also use the same format as this.

Fixes #2472 

###### should also cherry-pick this to master at some point in the future.