### PR TITLE
Panic if display env vars are missing

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/DesktopLinuxServiceCollection.cs
+++ b/OpenTabletDriver.Desktop/Interop/DesktopLinuxServiceCollection.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTabletDriver.Desktop.Diagnostics;
@@ -42,8 +43,7 @@ namespace OpenTabletDriver.Desktop.Interop
             if (HasEnvironmentVariable("DISPLAY"))
                 return Singleton<IVirtualScreen, XScreen>();
 
-            Log.Write("Display", "Neither Wayland nor X11 were detected, defaulting to X11.", LogLevel.Warning);
-            return Singleton<IVirtualScreen, XScreen>();
+            throw new InvalidOperationException("Neither Wayland nor X11 environment variables were set");
         }
 
         private static bool HasEnvironmentVariable(string variable)


### PR DESCRIPTION
Trying to open an X11 display with no DISPLAY variable set will likely just cause another exception, as seen in OpenTabletDriver#2331

This behavior should ensure OTD doesn't try to start without a sane environment. Users affected by this change should fix their environment.

Fixes #2331

*note: I removed the Log call since that log output ended up not being present when testing - might work with a flush though*