### PR TITLE
CTL-472: Remove Auxiliary device identifier

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-472.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-472.json
@@ -43,18 +43,6 @@
       "InitializationStrings": []
     }
   ],
-  "AuxiliaryDeviceIdentifiers": [
-    {
-      "VendorID": 1386,
-      "ProductID": 890,
-      "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": []
-    }
-  ],
+  "AuxiliaryDeviceIdentifiers": [],
   "Attributes": {}
 }


### PR DESCRIPTION
Device has no auxiliary keys, so no reason to have it there

Fixes OpenTabletDriver/OpenTabletDriver#1170