### PR TITLE
Fix pen mapping to mouse button does not work on Linux

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -72,7 +72,12 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
                 EventCode.BTN_STYLUS2,
                 EventCode.BTN_STYLUS3,
                 EventCode.BTN_SIDE,
-                EventCode.BTN_EXTRA
+                EventCode.BTN_EXTRA,
+                EventCode.BTN_LEFT,
+                EventCode.BTN_MIDDLE,
+                EventCode.BTN_RIGHT,
+                EventCode.BTN_FORWARD,
+                EventCode.BTN_BACK
             );
 
             var result = Device.Initialize();


### PR DESCRIPTION
Previously if I set the pen binding 1 or 2 to a mouse button (e.g mouse right button or middle button), clicking the pen button does not trigger a ButtonPress event in artist mode.

It seems just because those events are not enabled

![image](https://user-images.githubusercontent.com/9698542/202837827-e5c0e628-ef3b-47de-a5ee-02464305e7d9.png)

Tested on Ubuntu 22.04 with Gnome on X11.

Unknown issues: wayland session still does not work and I don't know why but at least we are getting somewhere.