### PR TITLE
Linux Artist Mode: Expose ABS_DISTANCE to userspace

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -45,6 +45,13 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
             input_absinfo* pressurePtr = &pressure;
             Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_PRESSURE, (IntPtr)pressurePtr);
 
+            var distance = new input_absinfo
+            {
+                maximum = 100
+            };
+            input_absinfo* distancePtr = &distance;
+            Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_DISTANCE, (IntPtr)distancePtr);
+
             var xTilt = new input_absinfo
             {
                 minimum = -64,


### PR DESCRIPTION
This was unintentionally not enabled despite us emitting `ABS_DISTANCE` events

We're using a max value of 100 for now as that is unlikely to be out of bounds for any currently supported tablet

This supersedes dd358b477a95fc13feb2945f2027afa0286d5411 from #1984

(please test, the changes were simply rebased to the current codebase)