### PR TITLE
Linux Artist Mode: Allow usage of mouse buttons with Artist Mode

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -147,5 +147,13 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
         {
             Device.Sync();
         }
+
+        protected override EventCode? GetCode(MouseButton button) => button switch
+        {
+            MouseButton.Left => EventCode.BTN_TOUCH,
+            MouseButton.Middle => EventCode.BTN_STYLUS2,
+            MouseButton.Right => EventCode.BTN_STYLUS,
+            _ => null
+        };
     }
 }


### PR DESCRIPTION
This should probably be defined better for the user, ie:
LMB is actually pen down
RMB is actually barrel button 1
MMB is actually barrel button 2

- [ ] Checkbox to indicate discussion before merging

This supersedes d131beb84b93e0bf97744cf262b69bea45887f56 from #1984

(please test, the changes were simply rebased to the current codebase)