### PR TITLE
Linux Artist Mode: Don't submit BTN_TOUCH based off pressure 

### DIFF
--- a/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModeButtonBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModeButtonBinding.cs
@@ -25,7 +25,8 @@ namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
         public static string[] ValidButtons { get; } = {
             "Pen Button 1",
             "Pen Button 2",
-            "Pen Button 3"
+            "Pen Button 3",
+            "Pen Tip"
         };
 
         [Setting("Button"), MemberValidated(nameof(ValidButtons))]
@@ -48,6 +49,7 @@ namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
                 "Pen Button 1" => EventCode.BTN_STYLUS,
                 "Pen Button 2" => EventCode.BTN_STYLUS2,
                 "Pen Button 3" => EventCode.BTN_STYLUS3,
+                "Pen Tip" => EventCode.BTN_TOUCH,
                 _ => throw new InvalidOperationException($"Invalid Button '{Button}'")
             };
 

--- a/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModeButtonBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModeButtonBinding.cs
@@ -23,10 +23,10 @@ namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
         }
 
         public static string[] ValidButtons { get; } = {
+            "Pen Tip",
             "Pen Button 1",
             "Pen Button 2",
-            "Pen Button 3",
-            "Pen Tip"
+            "Pen Button 3"
         };
 
         [Setting("Button"), MemberValidated(nameof(ValidButtons))]
@@ -46,10 +46,10 @@ namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
         {
             var eventCode = Button switch
             {
+                "Pen Tip" => EventCode.BTN_TOUCH,
                 "Pen Button 1" => EventCode.BTN_STYLUS,
                 "Pen Button 2" => EventCode.BTN_STYLUS2,
                 "Pen Button 3" => EventCode.BTN_STYLUS3,
-                "Pen Tip" => EventCode.BTN_TOUCH,
                 _ => throw new InvalidOperationException($"Invalid Button '{Button}'")
             };
 

--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -98,7 +98,6 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
 
         public void SetPressure(float percentage)
         {
-            Device.Write(EventType.EV_KEY, EventCode.BTN_TOUCH, percentage > 0 ? 1 : 0);
             Device.Write(EventType.EV_ABS, EventCode.ABS_PRESSURE, (int)(MAX_PRESSURE * percentage));
         }
 


### PR DESCRIPTION
The original intention of the code was under the assumption that the threshold slider rewrites pressure.

Since we do not rewrite pressure at the moment, it seems to behave libinput spec if we instead only send `BTN_TOUCH` when the tip is actually touching the tablet.

This supersedes 15b8341a2bd19f9193288d60ef986d70824a1148 and daf0fdce831e755beeb17aafb851fa84fc0769ed from #1984

(please test, the changes were simply rebased to the current codebase)