### PR TITLE
EvdevVirtualTablet: Code cleanup

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -10,6 +10,16 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
 {
     public class EvdevVirtualTablet : EvdevVirtualMouse, IPressureHandler, ITiltHandler, IEraserHandler, IHoverDistanceHandler, IProximityHandler, ISynchronousPointer
     {
+        private readonly EventCode[] eventCodes =
+        {
+                EventCode.BTN_TOOL_PEN,
+                EventCode.BTN_TOOL_RUBBER,
+                EventCode.BTN_TOUCH,
+                EventCode.BTN_STYLUS,
+                EventCode.BTN_STYLUS2,
+                EventCode.BTN_STYLUS3,
+        };
+
         private const int RESOLUTION = 1000; // subpixels per screen pixel
 
         private bool _isEraser;
@@ -65,14 +75,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
 
             Device.EnableTypeCodes(
                 EventType.EV_KEY,
-                EventCode.BTN_TOUCH,
-                EventCode.BTN_STYLUS,
-                EventCode.BTN_TOOL_PEN,
-                EventCode.BTN_TOOL_RUBBER,
-                EventCode.BTN_STYLUS2,
-                EventCode.BTN_STYLUS3,
-                EventCode.BTN_SIDE,
-                EventCode.BTN_EXTRA
+                eventCodes
             );
 
             var result = Device.Initialize();
@@ -131,13 +134,9 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
         public void Reset()
         {
             // Zero out everything except position and tilt
-            Device.Write(EventType.EV_KEY, EventCode.BTN_TOOL_RUBBER, 0);
-            Device.Write(EventType.EV_KEY, EventCode.BTN_TOOL_PEN, 0);
-            Device.Write(EventType.EV_KEY, EventCode.BTN_TOUCH, 0);
+            foreach (var code in eventCodes)
+                Device.Write(EventType.EV_KEY, code, 0);
             Device.Write(EventType.EV_ABS, EventCode.ABS_PRESSURE, 0);
-            Device.Write(EventType.EV_KEY, EventCode.BTN_STYLUS, 0);
-            Device.Write(EventType.EV_KEY, EventCode.BTN_STYLUS2, 0);
-            Device.Write(EventType.EV_KEY, EventCode.BTN_STYLUS3, 0);
 
             _isEraser = false;
             _proximity = true; // we counterintuitively set this to true since its the initial state

--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -10,6 +10,8 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
 {
     public class EvdevVirtualTablet : EvdevVirtualMouse, IPressureHandler, ITiltHandler, IEraserHandler, IHoverDistanceHandler, IProximityHandler, ISynchronousPointer
     {
+        // order seems important due to reset ordering (to satisfy libinput)
+        // tools -> touch -> buttons
         private readonly EventCode[] eventCodes =
         {
                 EventCode.BTN_TOOL_PEN,

--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -12,7 +12,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
     {
         // order seems important due to reset ordering (to satisfy libinput)
         // tools -> touch -> buttons
-        private readonly EventCode[] eventCodes =
+        private static readonly EventCode[] eventCodes =
         {
                 EventCode.BTN_TOOL_PEN,
                 EventCode.BTN_TOOL_RUBBER,


### PR DESCRIPTION
Less lines = more good

The array ordering has been carefully chosen to make sure that events are reset in the following order: tools -> touch -> buttons

This supersedes ce6b876d13142d82af8ad1981499f4fe256a8efe from #1984

(please test, the changes were simply rebased to the current codebase)