### PR TITLE
Fix logging ui is not refreshed when LogDataStore changes.

### DIFF
--- a/OpenTabletDriver.UX/Collections/EnumerableHelpers.cs
+++ b/OpenTabletDriver.UX/Collections/EnumerableHelpers.cs
@@ -1,0 +1,80 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace OpenTabletDriver.UX.Collections
+{
+    /// <summary>
+    /// Internal helper functions for working with enumerables.
+    /// </summary>
+    internal static partial class EnumerableHelpers
+    {
+        /// <summary>Converts an enumerable to an array using the same logic as List{T}.</summary>
+        /// <param name="source">The enumerable to convert.</param>
+        /// <param name="length">The number of items stored in the resulting array, 0-indexed.</param>
+        /// <returns>
+        /// The resulting array.  The length of the array may be greater than <paramref name="length"/>,
+        /// which is the actual number of elements in the array.
+        /// </returns>
+        internal static T[] ToArray<T>(IEnumerable<T> source, out int length)
+        {
+            if (source is ICollection<T> ic)
+            {
+                int count = ic.Count;
+                if (count != 0)
+                {
+                    // Allocate an array of the desired size, then copy the elements into it. Note that this has the same
+                    // issue regarding concurrency as other existing collections like List<T>. If the collection size
+                    // concurrently changes between the array allocation and the CopyTo, we could end up either getting an
+                    // exception from overrunning the array (if the size went up) or we could end up not filling as many
+                    // items as 'count' suggests (if the size went down).  This is only an issue for concurrent collections
+                    // that implement ICollection<T>, which as of .NET 4.6 is just ConcurrentDictionary<TKey, TValue>.
+                    T[] arr = new T[count];
+                    ic.CopyTo(arr, 0);
+                    length = count;
+                    return arr;
+                }
+            }
+            else
+            {
+                using (var en = source.GetEnumerator())
+                {
+                    if (en.MoveNext())
+                    {
+                        const int DefaultCapacity = 4;
+                        T[] arr = new T[DefaultCapacity];
+                        arr[0] = en.Current;
+                        int count = 1;
+
+                        while (en.MoveNext())
+                        {
+                            if (count == arr.Length)
+                            {
+                                // This is the same growth logic as in List<T>:
+                                // If the array is currently empty, we make it a default size.  Otherwise, we attempt to
+                                // double the size of the array.  Doubling will overflow once the size of the array reaches
+                                // 2^30, since doubling to 2^31 is 1 larger than Int32.MaxValue.  In that case, we instead
+                                // constrain the length to be Array.MaxLength (this overflow check works because of the
+                                // cast to uint).
+                                int newLength = count << 1;
+                                if ((uint)newLength > Array.MaxLength)
+                                {
+                                    newLength = Array.MaxLength <= count ? count + 1 : Array.MaxLength;
+                                }
+
+                                Array.Resize(ref arr, newLength);
+                            }
+
+                            arr[count++] = en.Current;
+                        }
+
+                        length = count;
+                        return arr;
+                    }
+                }
+            }
+
+            length = 0;
+            return Array.Empty<T>();
+        }
+    }
+}

--- a/OpenTabletDriver.UX/Collections/QueueDebugView.cs
+++ b/OpenTabletDriver.UX/Collections/QueueDebugView.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace OpenTabletDriver.UX.Collections
+{
+    internal sealed class RandomAccessQueueDebugView<T>
+    {
+        private readonly RandomAccessQueue<T> _queue;
+
+        public RandomAccessQueueDebugView(RandomAccessQueue<T> queue)
+        {
+            ArgumentNullException.ThrowIfNull(queue);
+
+            _queue = queue;
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public T[] Items
+        {
+            get
+            {
+                return _queue.ToArray();
+            }
+        }
+    }
+}

--- a/OpenTabletDriver.UX/Collections/RandomAccessQueue.cs
+++ b/OpenTabletDriver.UX/Collections/RandomAccessQueue.cs
@@ -1,0 +1,512 @@
+// These code are taken from dotnet runtime, modified to support random access.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+/*=============================================================================
+**
+**
+** Purpose: A circular-array implementation of a generic queue.
+**
+**
+=============================================================================*/
+
+using System.Collections;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using OpenTabletDriver.UX.Collections;
+
+namespace OpenTabletDriver.UX.Collections
+{
+    // A simple Queue of generic objects.  Internally it is implemented as a
+    // circular buffer, so Enqueue can be O(n).  Dequeue is O(1).
+    [DebuggerTypeProxy(typeof(RandomAccessQueueDebugView<>))]
+    [DebuggerDisplay("Count = {Count}")]
+    [Serializable]
+    public partial class RandomAccessQueue<T> : IEnumerable<T>,
+        System.Collections.ICollection,
+        IReadOnlyCollection<T>
+    {
+        private T[] _array;
+        private int _head;       // The index from which to dequeue if the queue isn't empty.
+        private int _tail;       // The index at which to enqueue if the queue isn't full.
+        private int _size;       // Number of elements.
+        private int _version;
+
+        // Creates a queue with room for capacity objects. The default initial
+        // capacity and grow factor are used.
+        public RandomAccessQueue()
+        {
+            _array = Array.Empty<T>();
+        }
+
+        // Creates a queue with room for capacity objects. The default grow factor
+        // is used.
+        public RandomAccessQueue(int capacity)
+        {
+            if (capacity < 0)
+                throw new ArgumentOutOfRangeException(nameof(capacity), capacity, SR.ArgumentOutOfRange_NeedNonNegNum);
+            _array = new T[capacity];
+        }
+
+        // Fills a Queue with the elements of an ICollection.  Uses the enumerator
+        // to get each of the elements.
+        public RandomAccessQueue(IEnumerable<T> collection)
+        {
+            ArgumentNullException.ThrowIfNull(collection);
+
+            _array = EnumerableHelpers.ToArray(collection, out _size);
+            if (_size != _array.Length) _tail = _size;
+        }
+
+        public int Count
+        {
+            get { return _size; }
+        }
+
+        bool ICollection.IsSynchronized
+        {
+            get { return false; }
+        }
+
+        object ICollection.SyncRoot => this;
+
+        // Removes all Objects from the queue.
+        public void Clear()
+        {
+            if (_size != 0)
+            {
+                if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+                {
+                    if (_head < _tail)
+                    {
+                        Array.Clear(_array, _head, _size);
+                    }
+                    else
+                    {
+                        Array.Clear(_array, _head, _array.Length - _head);
+                        Array.Clear(_array, 0, _tail);
+                    }
+                }
+
+                _size = 0;
+            }
+
+            _head = 0;
+            _tail = 0;
+            _version++;
+        }
+
+        // CopyTo copies a collection into an Array, starting at a particular
+        // index into the array.
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            ArgumentNullException.ThrowIfNull(array);
+
+            if (arrayIndex < 0 || arrayIndex > array.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(arrayIndex), arrayIndex, SR.ArgumentOutOfRange_IndexMustBeLessOrEqual);
+            }
+
+            if (array.Length - arrayIndex < _size)
+            {
+                throw new ArgumentException(SR.Argument_InvalidOffLen);
+            }
+
+            int numToCopy = _size;
+            if (numToCopy == 0) return;
+
+            int firstPart = Math.Min(_array.Length - _head, numToCopy);
+            Array.Copy(_array, _head, array, arrayIndex, firstPart);
+            numToCopy -= firstPart;
+            if (numToCopy > 0)
+            {
+                Array.Copy(_array, 0, array, arrayIndex + _array.Length - _head, numToCopy);
+            }
+        }
+
+        void ICollection.CopyTo(Array array, int index)
+        {
+            ArgumentNullException.ThrowIfNull(array);
+
+            if (array.Rank != 1)
+            {
+                throw new ArgumentException(SR.Arg_RankMultiDimNotSupported, nameof(array));
+            }
+
+            if (array.GetLowerBound(0) != 0)
+            {
+                throw new ArgumentException(SR.Arg_NonZeroLowerBound, nameof(array));
+            }
+
+            int arrayLen = array.Length;
+            if (index < 0 || index > arrayLen)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_IndexMustBeLessOrEqual);
+            }
+
+            if (arrayLen - index < _size)
+            {
+                throw new ArgumentException(SR.Argument_InvalidOffLen);
+            }
+
+            int numToCopy = _size;
+            if (numToCopy == 0) return;
+
+            try
+            {
+                int firstPart = (_array.Length - _head < numToCopy) ? _array.Length - _head : numToCopy;
+                Array.Copy(_array, _head, array, index, firstPart);
+                numToCopy -= firstPart;
+
+                if (numToCopy > 0)
+                {
+                    Array.Copy(_array, 0, array, index + _array.Length - _head, numToCopy);
+                }
+            }
+            catch (ArrayTypeMismatchException)
+            {
+                throw new ArgumentException(SR.Argument_InvalidArrayType, nameof(array));
+            }
+        }
+
+        // Adds item to the tail of the queue.
+        public void Enqueue(T item)
+        {
+            if (_size == _array.Length)
+            {
+                Grow(_size + 1);
+            }
+
+            _array[_tail] = item;
+            MoveNext(ref _tail);
+            _size++;
+            _version++;
+        }
+
+        // GetEnumerator returns an IEnumerator over this Queue.  This
+        // Enumerator will support removing.
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        /// <internalonly/>
+        IEnumerator<T> IEnumerable<T>.GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        // Removes the object at the head of the queue and returns it. If the queue
+        // is empty, this method throws an
+        // InvalidOperationException.
+        public T Dequeue()
+        {
+            int head = _head;
+            T[] array = _array;
+
+            if (_size == 0)
+            {
+                ThrowForEmptyQueue();
+            }
+
+            T removed = array[head];
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            {
+                array[head] = default!;
+            }
+            MoveNext(ref _head);
+            _size--;
+            _version++;
+            return removed;
+        }
+
+        public bool TryDequeue([MaybeNullWhen(false)] out T result)
+        {
+            int head = _head;
+            T[] array = _array;
+
+            if (_size == 0)
+            {
+                result = default;
+                return false;
+            }
+
+            result = array[head];
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            {
+                array[head] = default!;
+            }
+            MoveNext(ref _head);
+            _size--;
+            _version++;
+            return true;
+        }
+
+        // Returns the object at the head of the queue. The object remains in the
+        // queue. If the queue is empty, this method throws an
+        // InvalidOperationException.
+        public T Peek()
+        {
+            if (_size == 0)
+            {
+                ThrowForEmptyQueue();
+            }
+
+            return _array[_head];
+        }
+
+        public bool TryPeek([MaybeNullWhen(false)] out T result)
+        {
+            if (_size == 0)
+            {
+                result = default;
+                return false;
+            }
+
+            result = _array[_head];
+            return true;
+        }
+
+        // Returns true if the queue contains at least one object equal to item.
+        // Equality is determined using EqualityComparer<T>.Default.Equals().
+        public bool Contains(T item)
+        {
+            if (_size == 0)
+            {
+                return false;
+            }
+
+            if (_head < _tail)
+            {
+                return Array.IndexOf(_array, item, _head, _size) >= 0;
+            }
+
+            // We've wrapped around. Check both partitions, the least recently enqueued first.
+            return
+                Array.IndexOf(_array, item, _head, _array.Length - _head) >= 0 ||
+                Array.IndexOf(_array, item, 0, _tail) >= 0;
+        }
+
+        // Iterates over the objects in the queue, returning an array of the
+        // objects in the Queue, or an empty array if the queue is empty.
+        // The order of elements in the array is first in to last in, the same
+        // order produced by successive calls to Dequeue.
+        public T[] ToArray()
+        {
+            if (_size == 0)
+            {
+                return Array.Empty<T>();
+            }
+
+            T[] arr = new T[_size];
+
+            if (_head < _tail)
+            {
+                Array.Copy(_array, _head, arr, 0, _size);
+            }
+            else
+            {
+                Array.Copy(_array, _head, arr, 0, _array.Length - _head);
+                Array.Copy(_array, 0, arr, _array.Length - _head, _tail);
+            }
+
+            return arr;
+        }
+
+        // PRIVATE Grows or shrinks the buffer to hold capacity objects. Capacity
+        // must be >= _size.
+        private void SetCapacity(int capacity)
+        {
+            T[] newarray = new T[capacity];
+            if (_size > 0)
+            {
+                if (_head < _tail)
+                {
+                    Array.Copy(_array, _head, newarray, 0, _size);
+                }
+                else
+                {
+                    Array.Copy(_array, _head, newarray, 0, _array.Length - _head);
+                    Array.Copy(_array, 0, newarray, _array.Length - _head, _tail);
+                }
+            }
+
+            _array = newarray;
+            _head = 0;
+            _tail = (_size == capacity) ? 0 : _size;
+            _version++;
+        }
+
+        // Increments the index wrapping it if necessary.
+        private void MoveNext(ref int index)
+        {
+            // It is tempting to use the remainder operator here but it is actually much slower
+            // than a simple comparison and a rarely taken branch.
+            // JIT produces better code than with ternary operator ?:
+            int tmp = index + 1;
+            if (tmp == _array.Length)
+            {
+                tmp = 0;
+            }
+            index = tmp;
+        }
+
+        private void ThrowForEmptyQueue()
+        {
+            Debug.Assert(_size == 0);
+            throw new InvalidOperationException(SR.InvalidOperation_EmptyQueue);
+        }
+
+        public void TrimExcess()
+        {
+            int threshold = (int)(_array.Length * 0.9);
+            if (_size < threshold)
+            {
+                SetCapacity(_size);
+            }
+        }
+
+        /// <summary>
+        /// Ensures that the capacity of this Queue is at least the specified <paramref name="capacity"/>.
+        /// </summary>
+        /// <param name="capacity">The minimum capacity to ensure.</param>
+        /// <returns>The new capacity of this queue.</returns>
+        public int EnsureCapacity(int capacity)
+        {
+            if (capacity < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(capacity), capacity, SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            if (_array.Length < capacity)
+            {
+                Grow(capacity);
+            }
+
+            return _array.Length;
+        }
+
+        private void Grow(int capacity)
+        {
+            Debug.Assert(_array.Length < capacity);
+
+            const int GrowFactor = 2;
+            const int MinimumGrow = 4;
+
+            int newcapacity = GrowFactor * _array.Length;
+
+            // Allow the list to grow to maximum possible capacity (~2G elements) before encountering overflow.
+            // Note that this check works even when _items.Length overflowed thanks to the (uint) cast
+            if ((uint)newcapacity > Array.MaxLength) newcapacity = Array.MaxLength;
+
+            // Ensure minimum growth is respected.
+            newcapacity = Math.Max(newcapacity, _array.Length + MinimumGrow);
+
+            // If the computed capacity is still less than specified, set to the original argument.
+            // Capacities exceeding Array.MaxLength will be surfaced as OutOfMemoryException by Array.Resize.
+            if (newcapacity < capacity) newcapacity = capacity;
+
+            SetCapacity(newcapacity);
+        }
+
+        // Implements an enumerator for a Queue.  The enumerator uses the
+        // internal version number of the list to ensure that no modifications are
+        // made to the list while an enumeration is in progress.
+        public struct Enumerator : IEnumerator<T>,
+            System.Collections.IEnumerator
+        {
+            private readonly RandomAccessQueue<T> _q;
+            private readonly int _version;
+            private int _index;   // -1 = not started, -2 = ended/disposed
+            private T? _currentElement;
+
+            internal Enumerator(RandomAccessQueue<T> q)
+            {
+                _q = q;
+                _version = q._version;
+                _index = -1;
+                _currentElement = default;
+            }
+
+            public void Dispose()
+            {
+                _index = -2;
+                _currentElement = default;
+            }
+
+            public bool MoveNext()
+            {
+                if (_version != _q._version) throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
+
+                if (_index == -2)
+                    return false;
+
+                _index++;
+
+                if (_index == _q._size)
+                {
+                    // We've run past the last element
+                    _index = -2;
+                    _currentElement = default;
+                    return false;
+                }
+
+                // Cache some fields in locals to decrease code size
+                T[] array = _q._array;
+                int capacity = array.Length;
+
+                // _index represents the 0-based index into the queue, however the queue
+                // doesn't have to start from 0 and it may not even be stored contiguously in memory.
+
+                int arrayIndex = _q._head + _index; // this is the actual index into the queue's backing array
+                if (arrayIndex >= capacity)
+                {
+                    // NOTE: Originally we were using the modulo operator here, however
+                    // on Intel processors it has a very high instruction latency which
+                    // was slowing down the loop quite a bit.
+                    // Replacing it with simple comparison/subtraction operations sped up
+                    // the average foreach loop by 2x.
+
+                    arrayIndex -= capacity; // wrap around if needed
+                }
+
+                _currentElement = array[arrayIndex];
+                return true;
+            }
+
+            public T Current
+            {
+                get
+                {
+                    if (_index < 0)
+                        ThrowEnumerationNotStartedOrEnded();
+                    return _currentElement!;
+                }
+            }
+
+            private void ThrowEnumerationNotStartedOrEnded()
+            {
+                Debug.Assert(_index == -1 || _index == -2);
+                throw new InvalidOperationException(_index == -1 ? SR.InvalidOperation_EnumNotStarted : SR.InvalidOperation_EnumEnded);
+            }
+
+            object? IEnumerator.Current
+            {
+                get { return Current; }
+            }
+
+            void IEnumerator.Reset()
+            {
+                if (_version != _q._version) throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
+                _index = -1;
+                _currentElement = default;
+            }
+        }
+    }
+}

--- a/OpenTabletDriver.UX/Collections/RandomAccessQueueExtras.cs
+++ b/OpenTabletDriver.UX/Collections/RandomAccessQueueExtras.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using Newtonsoft.Json.Linq;
+using OpenTabletDriver.UX.Collections;
+
+namespace OpenTabletDriver.UX.Collections
+{
+    public partial class RandomAccessQueue<T>
+    {
+        public T this[int index]
+        {
+            get
+            {
+                // Following trick can reduce the range check by one
+                if ((uint)index >= (uint)this._size)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_IndexMustBeLess);
+                }
+                return _array[arrayIndex(index)];
+            }
+            set
+            {
+                if ((uint)index >= (uint)_size)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_IndexMustBeLess);
+                }
+
+                _array[arrayIndex(index)] = value;
+
+            }
+        }
+
+        public int IndexOf(T item)
+        {
+            if (_size == 0)
+            {
+                return -1;
+            }
+
+            if (_head < _tail)
+            {
+                return Array.IndexOf(_array, item, _head, _size) - _head;
+            }
+
+            // We've wrapped around. Check both partitions, the least recently enqueued first.
+            int firstIndex = Array.IndexOf(_array, item, _head, _array.Length - _head);
+
+            if (firstIndex >= 0)
+            {
+                return firstIndex - _head;
+            }
+            return Array.IndexOf(_array, item, 0, _tail) + _array.Length - _head;
+        }
+
+        private int arrayIndex(int index)
+        {
+            int capacity = _array.Length;
+
+            // _index represents the 0-based index into the queue, however the queue
+            // doesn't have to start from 0 and it may not even be stored contiguously in memory.
+
+            int arrayIndex = _head + index; // this is the actual index into the queue's backing array
+            if (arrayIndex >= capacity)
+            {
+                // NOTE: Originally we were using the modulo operator here, however
+                // on Intel processors it has a very high instruction latency which
+                // was slowing down the loop quite a bit.
+                // Replacing it with simple comparison/subtraction operations sped up
+                // the average foreach loop by 2x.
+
+                arrayIndex -= capacity; // wrap around if needed
+            }
+            return arrayIndex;
+        }
+
+        internal class SR
+        {
+            internal static readonly string Arg_RankMultiDimNotSupported = "Only single dimensional arrays are supported for the requested action.";
+            internal static readonly string ArgumentOutOfRange_IndexMustBeLessOrEqual = "Index was out of range. Must be non-negative and less than or equal to the size of the collection.";
+            internal static readonly string Argument_InvalidOffLen = "Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.";
+            internal static readonly string Arg_NonZeroLowerBound = "The lower bound of target array must be zero.";
+            internal static readonly string Argument_InvalidArrayType = "Target array type is not compatible with the type of items in the collection.";
+            internal static readonly string ArgumentOutOfRange_NeedNonNegNum = "Non-negative number required.";
+            internal static readonly string InvalidOperation_EnumFailedVersion = "Collection was modified; enumeration operation may not execute.";
+            internal static readonly string InvalidOperation_EnumNotStarted = "Enumeration has not started. Call MoveNext.";
+            internal static readonly string InvalidOperation_EnumEnded = "Enumeration already finished.";
+            internal static readonly string ArgumentOutOfRange_IndexMustBeLess = "Index was out of range. Must be non-negative and less than the size of the collection.";
+            internal static readonly string InvalidOperation_EmptyQueue = "Queue empty.";
+        }
+
+    }
+}
+
+


### PR DESCRIPTION
https://github.com/OpenTabletDriver/OpenTabletDriver/blob/d50c1324488f09da5321cf560ad3f5840243c889/OpenTabletDriver.UX.MacOS/OpenTabletDriver.UX.MacOS.csproj#L16
https://github.com/OpenTabletDriver/OpenTabletDriver/blob/d50c1324488f09da5321cf560ad3f5840243c889/OpenTabletDriver.UX.Wpf/OpenTabletDriver.UX.Wpf.csproj#L19
Eto 2.6.0 or above requires datastore to implements IList\<object\> or IList indexer, 
otherwise it will won't responds to  INotifyCollectionChanged.  

As it caches a copy of IEnumerable\<object\> as IList\<object\> internally. 
https://github.com/picoe/Eto/pull/2029/files

https://github.com/OpenTabletDriver/OpenTabletDriver/blob/d50c1324488f09da5321cf560ad3f5840243c889/OpenTabletDriver.UX/Components/LogDataStore.cs#L119
Queue\<T\> does not implements IList\<T\>

This pull request implements IList for LogDataStore  and add a modification of Queue\<T\> to support random access.