### PR TITLE
Migrate to .NET 7.0

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0'
+          dotnet-version: '7.0'
           include-prerelease: True
 
       - name: Linux Publish
@@ -54,7 +54,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0'
+          dotnet-version: '7.0'
           include-prerelease: True
 
       - name: MacOS Publish
@@ -82,7 +82,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0'
+          dotnet-version: '7.0'
           include-prerelease: True
 
       - name: Windows Publish
@@ -113,7 +113,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0'
+          dotnet-version: '7.0'
           include-prerelease: True
 
       - name: Lint Changed Files
@@ -131,7 +131,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0'
+          dotnet-version: '7.0'
           include-prerelease: True
 
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0'
+          dotnet-version: '7.0'
           include-prerelease: True
       - name: Debian Build
         run: ./Debian/package
@@ -96,7 +96,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0'
+          dotnet-version: '7.0'
           include-prerelease: True
       - name: Package
         run: ./Windows/package.ps1

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # IDE
 .vs/
-.vscode/
+.vscode/**
+!.vscode/launch.json
+!.vscode/tasks.json
 .idea/
 
 # Build Artifacts

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,54 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Daemon",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "Build Daemon",
+            "program": "${workspaceFolder}/OpenTabletDriver.Daemon/bin/Debug/net7.0/OpenTabletDriver.Daemon.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/OpenTabletDriver.Daemon",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "UX (Wpf)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "Build UX (Wpf)",
+            "program": "${workspaceFolder}/OpenTabletDriver.UX.Wpf/bin/Debug/net7.0/OpenTabletDriver.UX.Wpf.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/OpenTabletDriver.UX.Wpf",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "UX (Gtk)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "Build UX (Gtk)",
+            "program": "${workspaceFolder}/OpenTabletDriver.UX.Gtk/bin/Debug/net7.0/OpenTabletDriver.UX.Gtk.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/OpenTabletDriver.UX.Gtk",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "UX (MacOS)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "Build UX (MacOS)",
+            "program": "${workspaceFolder}/OpenTabletDriver.UX.MacOS/bin/Debug/net7.0/OpenTabletDriver.UX.MacOS.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/OpenTabletDriver.UX.MacOS",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,49 +6,33 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "Build Daemon",
+            "cwd": "${workspaceFolder}/OpenTabletDriver.Daemon/bin/Debug/net7.0",
             "program": "${workspaceFolder}/OpenTabletDriver.Daemon/bin/Debug/net7.0/OpenTabletDriver.Daemon.dll",
             "args": [],
-            "cwd": "${workspaceFolder}/OpenTabletDriver.Daemon",
             "console": "internalConsole",
             "stopAtEntry": false
         },
         {
-            "name": "UX (Wpf)",
+            "name": "UX",
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "Build UX (Wpf)",
-            "program": "${workspaceFolder}/OpenTabletDriver.UX.Wpf/bin/Debug/net7.0/OpenTabletDriver.UX.Wpf.dll",
+            "preLaunchTask": "Build UX",
+            "program": "",
             "args": [],
-            "cwd": "${workspaceFolder}/OpenTabletDriver.UX.Wpf",
             "console": "internalConsole",
-            "stopAtEntry": false
-        },
-        {
-            "name": "UX (Gtk)",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "Build UX (Gtk)",
-            "program": "${workspaceFolder}/OpenTabletDriver.UX.Gtk/bin/Debug/net7.0/OpenTabletDriver.UX.Gtk.dll",
-            "args": [],
-            "cwd": "${workspaceFolder}/OpenTabletDriver.UX.Gtk",
-            "console": "internalConsole",
-            "stopAtEntry": false
-        },
-        {
-            "name": "UX (MacOS)",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "Build UX (MacOS)",
-            "program": "${workspaceFolder}/OpenTabletDriver.UX.MacOS/bin/Debug/net7.0/OpenTabletDriver.UX.MacOS.dll",
-            "args": [],
-            "cwd": "${workspaceFolder}/OpenTabletDriver.UX.MacOS",
-            "console": "internalConsole",
-            "stopAtEntry": false
-        },
-        {
-            "name": ".NET Core Attach",
-            "type": "coreclr",
-            "request": "attach"
+            "stopAtEntry": false,
+            "windows": {
+                "cwd": "${workspaceFolder}/OpenTabletDriver.UX.Wpf/bin/Debug/net7.0-windows",
+                "program": "${workspaceFolder}/OpenTabletDriver.UX.Wpf/bin/Debug/net7.0-windows/OpenTabletDriver.UX.Wpf.dll",
+            },
+            "linux": {
+                "cwd": "${workspaceFolder}/OpenTabletDriver.UX.Gtk/bin/Debug/net7.0/",
+                "program": "${workspaceFolder}/OpenTabletDriver.UX.Gtk/bin/Debug/net7.0/OpenTabletDriver.UX.Gtk.dll",
+            },
+            "osx": {
+                "cwd": "${workspaceFolder}/OpenTabletDriver.UX.MacOS/bin/Debug/net7.0/OpenTabletDriver.UX.MacOS.app/Contents/MacOS/",
+                "program": "${workspaceFolder}/OpenTabletDriver.UX.MacOS/bin/Debug/net7.0/OpenTabletDriver.UX.MacOS.app/Contents/MacOS/OpenTabletDriver.UX.MacOS.dll",
+            }
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,53 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build Daemon",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/OpenTabletDriver.Daemon/OpenTabletDriver.Daemon.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Build UX (Wpf)",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/OpenTabletDriver.UX.Wpf/OpenTabletDriver.UX.Wpf.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Build UX (Gtk)",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/OpenTabletDriver.UX.Gtk/OpenTabletDriver.UX.Gtk.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Build UX (MacOS)",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/OpenTabletDriver.UX.MacOS/OpenTabletDriver.UX.MacOS.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,8 +3,9 @@
     "tasks": [
         {
             "label": "Build Daemon",
-            "command": "dotnet",
             "type": "process",
+            "isBuildCommand": true,
+            "command": "dotnet",
             "args": [
                 "build",
                 "${workspaceFolder}/OpenTabletDriver.Daemon/OpenTabletDriver.Daemon.csproj",
@@ -14,40 +15,36 @@
             "problemMatcher": "$msCompile"
         },
         {
-            "label": "Build UX (Wpf)",
-            "command": "dotnet",
+            "label": "Build UX",
             "type": "process",
-            "args": [
-                "build",
-                "${workspaceFolder}/OpenTabletDriver.UX.Wpf/OpenTabletDriver.UX.Wpf.csproj",
-                "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
-            ],
-            "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "Build UX (Gtk)",
+            "isBuildCommand": true,
             "command": "dotnet",
-            "type": "process",
-            "args": [
-                "build",
-                "${workspaceFolder}/OpenTabletDriver.UX.Gtk/OpenTabletDriver.UX.Gtk.csproj",
-                "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
-            ],
-            "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "Build UX (MacOS)",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "build",
-                "${workspaceFolder}/OpenTabletDriver.UX.MacOS/OpenTabletDriver.UX.MacOS.csproj",
-                "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
-            ],
-            "problemMatcher": "$msCompile"
-        },
+            "args": [],
+            "problemMatcher": "$msCompile",
+            "windows": {
+                "args": [
+                    "build",
+                    "${workspaceFolder}/OpenTabletDriver.UX.Wpf/OpenTabletDriver.UX.Wpf.csproj",
+                    "/property:GenerateFullPaths=true",
+                    "/consoleloggerparameters:NoSummary"
+                ]
+            },
+            "linux": {
+                "args": [
+                    "build",
+                    "${workspaceFolder}/OpenTabletDriver.UX.Gtk/OpenTabletDriver.UX.Gtk.csproj",
+                    "/property:GenerateFullPaths=true",
+                    "/consoleloggerparameters:NoSummary"
+                ]
+            },
+            "osx": {
+                "args": [
+                    "build",
+                    "${workspaceFolder}/OpenTabletDriver.UX.MacOS/OpenTabletDriver.UX.MacOS.csproj",
+                    "/property:GenerateFullPaths=true",
+                    "/consoleloggerparameters:NoSummary"
+                ]
+            }
+        }
     ]
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,8 @@
 <Project>
   <PropertyGroup>
     <VersionBase>0.7.0.0</VersionBase>
-    <FrameworkBase>net6.0</FrameworkBase>
+    <FrameworkLTS>net6.0</FrameworkLTS>
+    <FrameworkLatest>net7.0</FrameworkLatest>
     <LangVersion>preview</LangVersion>
     <VersionPrefix>$(VersionBase)</VersionPrefix>
   </PropertyGroup>

--- a/OpenTabletDriver.Benchmarks/OpenTabletDriver.Benchmarks.csproj
+++ b/OpenTabletDriver.Benchmarks/OpenTabletDriver.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup Label="Project Properties">
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(FrameworkBase)</TargetFramework>
+    <TargetFramework>$(FrameworkLatest)</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/OpenTabletDriver.Configurations/OpenTabletDriver.Configurations.csproj
+++ b/OpenTabletDriver.Configurations/OpenTabletDriver.Configurations.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Project Properties">
-    <TargetFrameworks>net5.0;$(FrameworkBase)</TargetFrameworks>
+    <TargetFrameworks>$(FrameworkLTS);$(FrameworkLatest)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>VSTHRD100; VSTHRD101; VSTHRD110; VSTHRD200</NoWarn>
     <Nullable>enable</Nullable>

--- a/OpenTabletDriver.Console/OpenTabletDriver.Console.csproj
+++ b/OpenTabletDriver.Console/OpenTabletDriver.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup Label="Project Properties">
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(FrameworkBase)</TargetFramework>
+    <TargetFramework>$(FrameworkLatest)</TargetFramework>
     <NoWarn>VSTHRD100; VSTHRD101; VSTHRD110; VSTHRD200</NoWarn>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/OpenTabletDriver.Daemon/OpenTabletDriver.Daemon.csproj
+++ b/OpenTabletDriver.Daemon/OpenTabletDriver.Daemon.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup Label="Project Properties">
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(FrameworkBase)</TargetFramework>
+    <TargetFramework>$(FrameworkLatest)</TargetFramework>
     <NoWarn>VSTHRD100; VSTHRD101; VSTHRD110; VSTHRD200</NoWarn>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/OpenTabletDriver.Desktop/OpenTabletDriver.Desktop.csproj
+++ b/OpenTabletDriver.Desktop/OpenTabletDriver.Desktop.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Project Properties">
-    <TargetFramework>$(FrameworkBase)</TargetFramework>
+    <TargetFramework>$(FrameworkLatest)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>VSTHRD100; VSTHRD101; VSTHRD110; VSTHRD200</NoWarn>
     <Nullable>enable</Nullable>

--- a/OpenTabletDriver.Native/OpenTabletDriver.Native.csproj
+++ b/OpenTabletDriver.Native/OpenTabletDriver.Native.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Project Properties">
-    <TargetFrameworks>net5.0;$(FrameworkBase)</TargetFrameworks>
+    <TargetFrameworks>$(FrameworkLTS);$(FrameworkLatest)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/OpenTabletDriver.Tests/OpenTabletDriver.Tests.csproj
+++ b/OpenTabletDriver.Tests/OpenTabletDriver.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Project Properties">
-    <TargetFramework>$(FrameworkBase)</TargetFramework>
+    <TargetFramework>$(FrameworkLatest)</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/OpenTabletDriver.Tools.udev/OpenTabletDriver.Tools.udev.csproj
+++ b/OpenTabletDriver.Tools.udev/OpenTabletDriver.Tools.udev.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(FrameworkBase)</TargetFramework>
+    <TargetFramework>$(FrameworkLatest)</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/OpenTabletDriver.UX.Gtk/OpenTabletDriver.UX.Gtk.csproj
+++ b/OpenTabletDriver.UX.Gtk/OpenTabletDriver.UX.Gtk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup Label="Project Properties">
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(FrameworkBase)</TargetFramework>
+    <TargetFramework>$(FrameworkLatest)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/OpenTabletDriver.UX.MacOS/OpenTabletDriver.UX.MacOS.csproj
+++ b/OpenTabletDriver.UX.MacOS/OpenTabletDriver.UX.MacOS.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup Label="Project Properties">
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(FrameworkBase)</TargetFramework>
+    <TargetFramework>$(FrameworkLatest)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RuntimeIdentifiers>osx-x64;osx-arm64</RuntimeIdentifiers>

--- a/OpenTabletDriver.UX.Wpf/OpenTabletDriver.UX.Wpf.csproj
+++ b/OpenTabletDriver.UX.Wpf/OpenTabletDriver.UX.Wpf.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup Label="Project Properties">
     <OutputType>WinExe</OutputType>
-    <TargetFramework>$(FrameworkBase)-windows</TargetFramework>
+    <TargetFramework>$(FrameworkLatest)-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <ApplicationIcon>../OpenTabletDriver.UX/Assets/otd.ico</ApplicationIcon>

--- a/OpenTabletDriver.UX/OpenTabletDriver.UX.csproj
+++ b/OpenTabletDriver.UX/OpenTabletDriver.UX.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Project Properties">
-    <TargetFramework>$(FrameworkBase)</TargetFramework>
+    <TargetFramework>$(FrameworkLatest)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/OpenTabletDriver/OpenTabletDriver.csproj
+++ b/OpenTabletDriver/OpenTabletDriver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Project Properties">
-    <TargetFrameworks>net5.0;$(FrameworkBase)</TargetFrameworks>
+    <TargetFrameworks>$(FrameworkLTS);$(FrameworkLatest)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>VSTHRD100; VSTHRD101; VSTHRD110; VSTHRD200</NoWarn>
     <Nullable>enable</Nullable>

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ shift
 
 config=(--configuration='Release')
 
-options=(${config} --framework='net6.0' --self-contained='false' --verbosity=quiet --output='./bin' \
+options=(${config} --framework='net7.0' --self-contained='false' --verbosity=quiet --output='./bin' \
     /p:SuppressNETCoreSdkPreviewMessage=true /p:PublishTrimmed=false --runtime=$runtime -p:SourceRevisionId=$(git rev-parse --short HEAD))
 
 # change dir to script root, in case people run the script outside of the folder

--- a/generate-rules.sh
+++ b/generate-rules.sh
@@ -4,7 +4,7 @@ SRC_ROOT=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 [ ! -d "${SRC_ROOT}" ] && exit 100;
 
 PROJECT="${SRC_ROOT}/OpenTabletDriver.Tools.udev"
-FRAMEWORK="net6.0"
+FRAMEWORK="net7.0"
 
 TABLET_CONFIGURATIONS="${SRC_ROOT}/OpenTabletDriver.Configurations/Configurations"
 RULES_FILE="${SRC_ROOT}/bin/99-opentabletdriver.rules"


### PR DESCRIPTION
- Centralized framework version to `Directory.Build.props` (we now explicitly support only two flavors of .NET, "Latest" and "LTS").
- Also added some default `.vscode/[tasks/launch].json`.