### PR TITLE
Swap ProductID and VendorID

### DIFF
--- a/OpenTabletDriver.Desktop/Json/Converters/Implementations/SerializableDeviceEndpoint.cs
+++ b/OpenTabletDriver.Desktop/Json/Converters/Implementations/SerializableDeviceEndpoint.cs
@@ -4,8 +4,8 @@ namespace OpenTabletDriver.Desktop.Json.Converters.Implementations
 {
     internal sealed class SerializableDeviceEndpoint : Serializable, IDeviceEndpoint
     {
-        public int ProductID { set; get; }
         public int VendorID { set; get; }
+        public int ProductID { set; get; }
         public int InputReportLength { set; get; }
         public int OutputReportLength { set; get; }
         public int FeatureReportLength { set; get; }


### PR DESCRIPTION
0.6:
```json
    {
      "DevicePath": "/sys/devices/pci0000:00/0000:00:08.1/0000:04:00.3/usb1/1-2/1-2.1/1-2.1:1.0/0003:056A:037B.0004/hidraw/hidraw3",
      "Manufacturer": "Wacom Co.,Ltd.",
      "ProductName": "CTL-672",
      "SerialNumber": "0ME00M1089305",
      "FriendlyName": "CTL-672",
      "VendorID": 1386,
      "ProductID": 891,
      "InputReportLength": 10,
      "OutputReportLength": 0,
      "FeatureReportLength": 266,
      "CanOpen": true
    },
```
current:
```json
{
    "ProductID": 891,
    "VendorID": 1386,
    "InputReportLength": 10,
    "OutputReportLength": 0,
    "FeatureReportLength": 266,
    "Manufacturer": "Wacom Co.,Ltd.",
    "ProductName": "CTL-672",
    "FriendlyName": "CTL-672",
    "SerialNumber": "0ME00M1089305",
    "DevicePath": "/sys/devices/pci0000:00/0000:00:08.1/0000:04:00.3/usb1/1-2/1-2.1/1-2.1:1.0/0003:056A:037B.0004/hidraw/hidraw3",
    "CanOpen": true
  },
```
adjusted:
```json

{
    "VendorID": 1386,
    "ProductID": 891,
    "InputReportLength": 10,
    "OutputReportLength": 0,
    "FeatureReportLength": 266,
    "Manufacturer": "Wacom Co.,Ltd.",
    "ProductName": "CTL-672",
    "FriendlyName": "CTL-672",
    "SerialNumber": "0ME00M1089305",
    "DevicePath": "/sys/devices/pci0000:00/0000:00:08.1/0000:04:00.3/usb1/1-2/1-2.1/1-2.1:1.0/0003:056A:037B.0004/hidraw/hidraw3",
    "CanOpen": true
  },
```

(this really annoyed me)