### PR TITLE
add support for the 3rd button of Wacom Pro Pen 3D used by PTH-X60 tablets

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2Report.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2Report.cs
@@ -23,11 +23,13 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
             Pressure = Unsafe.ReadUnaligned<ushort>(ref report[8]);
 
             var penByte = report[1];
+            var Button3 = penByte.IsBitSet(1) && penByte.IsBitSet(2);
             Eraser = penByte.IsBitSet(4);
             PenButtons = new bool[]
             {
-                penByte.IsBitSet(1),
-                penByte.IsBitSet(2)
+                penByte.IsBitSet(1) && (!Button3),
+                penByte.IsBitSet(2) && (!Button3),
+                Button3
             };
             NearProximity = report[1].IsBitSet(5);
             HoverDistance = report[16];


### PR DESCRIPTION
Issue https://github.com/OpenTabletDriver/OpenTabletDriver/issues/1257

PTH-460, PTH-660, PTH-860 can be used with Pro Pen 3D that has 3 buttons and no eraser.

As [raw data tested](https://github.com/OpenTabletDriver/OpenTabletDriver/pull/1275#issuecomment-984168512)
> Wacom decide to represent the 3rd button as both the 1st and the 2nd button in the raw data