### PR TITLE
add the 3rd pen button for PTH-X60 tablets (configs)

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-460.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-460.json
@@ -9,7 +9,7 @@
     },
     "Pen": {
       "MaxPressure": 8191,
-      "ButtonCount": 2
+      "ButtonCount": 3
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-660.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-660.json
@@ -9,7 +9,7 @@
     },
     "Pen": {
       "MaxPressure": 8191,
-      "ButtonCount": 2
+      "ButtonCount": 3
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-860.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-860.json
@@ -9,7 +9,7 @@
     },
     "Pen": {
       "MaxPressure": 8191,
-      "ButtonCount": 2
+      "ButtonCount": 3
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8


### PR DESCRIPTION
The config part of PR https://github.com/OpenTabletDriver/OpenTabletDriver/pull/2539

Change pen button count to 3 for PTH-460, PTH-660, PTH-860

Issue https://github.com/OpenTabletDriver/OpenTabletDriver/issues/1257