### PR TITLE
Add support for Wacom Bamboo Pad USB CTH-301 tablets

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-301.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-301.json
@@ -1,0 +1,39 @@
+{
+  "Name": "Wacom CTH-301",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 107.0,
+      "Height": 67.0,
+      "MaxX": 10690.0,
+      "MaxY": 6680.0
+    },
+    "Pen": {
+      "MaxPressure": 511,
+      "Buttons": {
+        "ButtonCount": 1
+      }
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 2
+    },
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 1386,
+      "ProductID": 792,
+      "InputReportLength": 64,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.BambooPad.BambooPadReportParser",
+      "FeatureInitReport": [
+        "AgI="
+      ],
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }
+  ],
+  "AuxiliaryDeviceIdentifiers": [],
+  "Attributes": {}
+}

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/BambooPad/BambooPadAuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/BambooPad/BambooPadAuxReport.cs
@@ -1,0 +1,23 @@
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Wacom.BambooPad
+{
+    public struct BambooPadAuxReport : IAuxReport
+    {
+        public BambooPadAuxReport(byte[] report)
+        {
+            Raw = report;
+
+            AuxButtons = new bool[]
+            {
+                report[23] == 1,
+                report[23] == 2
+            };
+        }
+
+        public byte[] Raw { set; get; }
+        public bool[] AuxButtons { set; get; }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/BambooPad/BambooPadReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/BambooPad/BambooPadReportParser.cs
@@ -1,0 +1,26 @@
+using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Wacom.BambooPad
+{
+    public class BambooPadReportParser : IReportParser<IDeviceReport>
+    {
+        public virtual IDeviceReport Parse(byte[] report)
+        {
+            return report[0] switch
+            {
+                0x10 => GetToolReport(report),
+                _ => new DeviceReport(report)
+            };
+        }
+
+        private IDeviceReport GetToolReport(byte[] report)
+        {
+            if (report[1] == 0x01)
+                return new BambooPadTabletReport(report);
+            if (report[1] == 0x06)
+                return new BambooPadAuxReport(report);
+
+            return new DeviceReport(report);
+        }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/BambooPad/BambooPadTabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/BambooPad/BambooPadTabletReport.cs
@@ -1,0 +1,35 @@
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Wacom.BambooPad
+{
+    public struct BambooPadTabletReport : ITabletReport, IEraserReport
+    {
+        public BambooPadTabletReport(byte[] report)
+        {
+            Raw = report;
+
+            Position = new Vector2
+            {
+                X = Unsafe.ReadUnaligned<ushort>(ref report[3]),
+                Y = Unsafe.ReadUnaligned<ushort>(ref report[5])
+            };
+
+            Pressure = Unsafe.ReadUnaligned<ushort>(ref report[7]);
+
+            PenButtons = new bool[]
+            {
+                report[2].IsBitSet(1)
+            };
+
+            Eraser = report[2].IsBitSet(3);
+        }
+
+        public byte[] Raw { set; get; }
+        public Vector2 Position { set; get; }
+        public uint Pressure { set; get; }
+        public bool[] PenButtons { set; get; }
+        public bool Eraser { set; get; }
+    }
+}


### PR DESCRIPTION
This thing is different from any other wacom tablets, so new parser is needed. Pen, eraser, pen and aux button works. No touch support yet.