### PR TITLE
Fix mapping for negative offset displays

### DIFF
--- a/OpenTabletDriver.UX/Controls/Editors/AreaDisplay.cs
+++ b/OpenTabletDriver.UX/Controls/Editors/AreaDisplay.cs
@@ -96,11 +96,17 @@ namespace OpenTabletDriver.UX.Controls.Editors
             graphics.TranslateTransform(ControlOffset);
 
             // Draw background area
-            var backgrounds = Backgrounds.Select(r => r * Scale);
-            foreach (var rect in backgrounds)
+            using (graphics.SaveTransformState())
             {
-                graphics.FillRectangle(BackgroundFillColor, rect);
-                graphics.DrawRectangle(BackgroundBorderColor, rect);
+                var offset = -FullBackground.TopLeft * Scale;
+                graphics.TranslateTransform(offset);
+
+                var backgrounds = Backgrounds.Select(r => r * Scale);
+                foreach (var rect in backgrounds)
+                {
+                    graphics.FillRectangle(BackgroundFillColor, rect);
+                    graphics.DrawRectangle(BackgroundBorderColor, rect);
+                }
             }
 
             // Draw foreground area

--- a/OpenTabletDriver.UX/Controls/Editors/OutputAreaEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Editors/OutputAreaEditor.cs
@@ -112,8 +112,8 @@ namespace OpenTabletDriver.UX.Controls.Editors
                 {
                     width.Value = display.Width;
                     height.Value = display.Height;
-                    xPosition.Value = display.Position.X + display.Width / 2;
-                    yPosition.Value = display.Position.Y + display.Height / 2;
+                    xPosition.Value = display.Position.X - areaDisplay.FullBackground.X + display.Width / 2;
+                    yPosition.Value = display.Position.Y - areaDisplay.FullBackground.Y + display.Height / 2;
                 });
                 displayMenu.Items.Add(setDisplayCommand);
             }


### PR DESCRIPTION
Use the top left point of `FullBackground`, which happens to be the exact offset of the displays.
In case no display uses negative coordinates, the top left point will be (0, 0) therefore no offset applied.
- Resolves OpenTabletDriver/OpenTabletDriver#2542