### PR TITLE
Cache configurations to ImmutableArray

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,10 @@
             "preLaunchTask": "Build Daemon",
             "cwd": "${workspaceFolder}/OpenTabletDriver.Daemon/bin/Debug/net7.0",
             "program": "${workspaceFolder}/OpenTabletDriver.Daemon/bin/Debug/net7.0/OpenTabletDriver.Daemon.dll",
-            "args": [],
+            "args": [
+              "--config",
+              "${workspaceFolder}/bin/Configurations"
+            ],
             "console": "internalConsole",
             "stopAtEntry": false
         },

--- a/OpenTabletDriver.Analyzers.Tests/TabletConfigurationGeneratorTests.cs
+++ b/OpenTabletDriver.Analyzers.Tests/TabletConfigurationGeneratorTests.cs
@@ -14,28 +14,37 @@ namespace OpenTabletDriver.Analyzers.Tests
         public Task Test(string tabletName)
         {
             GetResources(tabletName,
+                out var sources,
                 out var tabletJsonFiles,
                 out var generatedSources,
                 out var analyzerConfigOptions);
 
-            return TabletConfigurationVerifier.Verify(tabletJsonFiles, generatedSources, analyzerConfigOptions);
+            return TabletConfigurationVerifier.Verify(sources, tabletJsonFiles, generatedSources, analyzerConfigOptions);
         }
 
         [Fact]
         public Task TestAllConfigurations()
         {
+            GetResources("SingleEndpointTablet", out var sources, out _, out _, out _);
+
             var tabletJsonFiles = GetAllConfigurations();
             static string analyzerConfigOptionsFactory(string _) => "build_metadata.AdditionalFiles.TabletConfiguration = true";
 
-            return TabletConfigurationVerifier.Verify(tabletJsonFiles, analyzerConfigOptionsFactory);
+            return TabletConfigurationVerifier.Verify(sources, tabletJsonFiles, analyzerConfigOptionsFactory);
         }
 
         private static void GetResources(string resourceName,
+            out (string file, string content)[] sources,
             out (string file, string content)[] tabletJsonFiles,
             out (string file, string content)[] generatedFiles,
             out (string file, string content)[] analyzerConfigOptions)
         {
             var testResources = TestResourceHelper.GetGroupedTestResourcesContent(resourceName);
+
+            sources = testResources
+                .Single(g => g.Key == "Sources")
+                .Where(f => f.file.EndsWith(".cs"))
+                .ToArray();
 
             tabletJsonFiles = testResources
                 .Single(g => g.Key == "Configurations")

--- a/OpenTabletDriver.Analyzers.Tests/TestResources/MultiEndpointTablet/Generated/DeviceConfigurationProvider.g.cs
+++ b/OpenTabletDriver.Analyzers.Tests/TestResources/MultiEndpointTablet/Generated/DeviceConfigurationProvider.g.cs
@@ -4,7 +4,7 @@ namespace OpenTabletDriver.Configurations
 {
     partial class DeviceConfigurationProvider : global::OpenTabletDriver.Components.IDeviceConfigurationProvider
     {
-        public global::System.Collections.Generic.IEnumerable<global::OpenTabletDriver.Tablet.TabletConfiguration> TabletConfigurations { get; } = new[]
+        public global::System.Collections.Immutable.ImmutableArray<global::OpenTabletDriver.Tablet.TabletConfiguration> TabletConfigurations { get; } = global::System.Collections.Immutable.ImmutableArray.Create(new[]
         {
             new global::OpenTabletDriver.Tablet.TabletConfiguration()
             {
@@ -80,6 +80,6 @@ namespace OpenTabletDriver.Configurations
                 },
                 Attributes = new global::System.Collections.Generic.Dictionary<string, string>()
             }
-        };
+        });
     }
 }

--- a/OpenTabletDriver.Analyzers.Tests/TestResources/MultiEndpointTablet/Sources/DeviceConfigurationProvider.cs
+++ b/OpenTabletDriver.Analyzers.Tests/TestResources/MultiEndpointTablet/Sources/DeviceConfigurationProvider.cs
@@ -1,18 +1,13 @@
 using System;
 using System.Collections.Immutable;
-using JetBrains.Annotations;
 using OpenTabletDriver.Components;
 using OpenTabletDriver.Tablet;
 
 namespace OpenTabletDriver.Configurations
 {
-    [PublicAPI]
     public partial class DeviceConfigurationProvider : IDeviceConfigurationProvider
     {
         public bool RaisesTabletConfigurationsChanged => false;
-
-#pragma warning disable CS0067 // The event 'DeviceConfigurationProvider.TabletConfigurationsChanged' is never used
         public event Action<ImmutableArray<TabletConfiguration>>? TabletConfigurationsChanged;
-#pragma warning restore CS0067
     }
 }

--- a/OpenTabletDriver.Analyzers.Tests/TestResources/SingleEndpointTablet/Generated/DeviceConfigurationProvider.g.cs
+++ b/OpenTabletDriver.Analyzers.Tests/TestResources/SingleEndpointTablet/Generated/DeviceConfigurationProvider.g.cs
@@ -4,7 +4,7 @@ namespace OpenTabletDriver.Configurations
 {
     partial class DeviceConfigurationProvider : global::OpenTabletDriver.Components.IDeviceConfigurationProvider
     {
-        public global::System.Collections.Generic.IEnumerable<global::OpenTabletDriver.Tablet.TabletConfiguration> TabletConfigurations { get; } = new[]
+        public global::System.Collections.Immutable.ImmutableArray<global::OpenTabletDriver.Tablet.TabletConfiguration> TabletConfigurations { get; } = global::System.Collections.Immutable.ImmutableArray.Create(new[]
         {
             new global::OpenTabletDriver.Tablet.TabletConfiguration()
             {
@@ -84,6 +84,6 @@ namespace OpenTabletDriver.Configurations
                     ["libinputoverride"] = "1"
                 }
             }
-        };
+        });
     }
 }

--- a/OpenTabletDriver.Analyzers.Tests/TestResources/SingleEndpointTablet/Sources/DeviceConfigurationProvider.cs
+++ b/OpenTabletDriver.Analyzers.Tests/TestResources/SingleEndpointTablet/Sources/DeviceConfigurationProvider.cs
@@ -1,18 +1,13 @@
 using System;
 using System.Collections.Immutable;
-using JetBrains.Annotations;
 using OpenTabletDriver.Components;
 using OpenTabletDriver.Tablet;
 
 namespace OpenTabletDriver.Configurations
 {
-    [PublicAPI]
     public partial class DeviceConfigurationProvider : IDeviceConfigurationProvider
     {
         public bool RaisesTabletConfigurationsChanged => false;
-
-#pragma warning disable CS0067 // The event 'DeviceConfigurationProvider.TabletConfigurationsChanged' is never used
         public event Action<ImmutableArray<TabletConfiguration>>? TabletConfigurationsChanged;
-#pragma warning restore CS0067
     }
 }

--- a/OpenTabletDriver.Analyzers.Tests/Verifiers/TabletConfigurationVerifier.cs
+++ b/OpenTabletDriver.Analyzers.Tests/Verifiers/TabletConfigurationVerifier.cs
@@ -10,12 +10,14 @@ namespace OpenTabletDriver.Analyzers.Tests.Verifiers
     public static class TabletConfigurationVerifier
     {
         public static Task Verify(
+            (string file, string content)[] sources,
             (string file, string content)[] tabletJsonFiles,
             (string file, string content)[] generatedSources,
             (string file, string content)[] analyzerConfigOptions)
         {
             return new IncrementalGeneratorVerifier<TabletConfigurationGenerator>()
             {
+                Sources = sources.ToList(),
                 AdditionalTexts = tabletJsonFiles.ToList(),
                 AnalyzerConfigOptions = analyzerConfigOptions.ToList(),
                 GeneratedSources = generatedSources.ToList(),
@@ -24,11 +26,13 @@ namespace OpenTabletDriver.Analyzers.Tests.Verifiers
         }
 
         public static Task Verify(
+            (string file, string content)[] sources,
             (string file, string content)[] tabletJsonFiles,
             Func<string, string?> analyzerConfigOptionsFactory)
         {
             return new IncrementalGeneratorVerifier<TabletConfigurationGenerator>()
             {
+                Sources = sources.ToList(),
                 AdditionalTexts = tabletJsonFiles.ToList(),
                 AnalyzerConfigOptionsFactory = analyzerConfigOptionsFactory,
                 ShouldVerifyGeneratedSources = false,
@@ -43,6 +47,7 @@ namespace OpenTabletDriver.Analyzers.Tests.Verifiers
                 MetadataReference.CreateFromFile(Assembly.Load("netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51").Location),
                 MetadataReference.CreateFromFile(Assembly.Load("System.Collections, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a").Location),
                 MetadataReference.CreateFromFile(Assembly.Load("System.Runtime, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a").Location),
+                MetadataReference.CreateFromFile(Assembly.Load("System.Collections.Immutable, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a").Location),
                 MetadataReference.CreateFromFile(typeof(TabletConfigurationVerifier).Assembly.Location),
                 MetadataReference.CreateFromFile(typeof(TabletConfigurationGenerator).Assembly.Location),
                 MetadataReference.CreateFromFile(typeof(IEnumerable<>).Assembly.Location)

--- a/OpenTabletDriver.Analyzers/Emitters/DeviceConfigurationProviderEmitter.cs
+++ b/OpenTabletDriver.Analyzers/Emitters/DeviceConfigurationProviderEmitter.cs
@@ -50,10 +50,10 @@ namespace OpenTabletDriver.Analyzers.Emitters
                                     SyntaxFactory.SingletonList<MemberDeclarationSyntax>(
                                         SyntaxFactory.PropertyDeclaration(
                                             SyntaxFactory.GenericName(
-                                                SyntaxFactory.Identifier($"global::System.Collections.Generic.IEnumerable"))
+                                                SyntaxFactory.Identifier($"global::System.Collections.Immutable.ImmutableArray"))
                                             .WithTypeArgumentList(
                                                 SyntaxFactory.TypeArgumentList(
-                                                    SyntaxFactory.SingletonSeparatedList<TypeSyntax>(
+                                                    SyntaxFactory.SingletonSeparatedList(
                                                         SyntaxFactory.ParseTypeName(TabletConfigurationEmitter.CLASS_NAME)))),
                                             SyntaxFactory.Identifier("TabletConfigurations"))
                                         .WithModifiers(
@@ -68,11 +68,20 @@ namespace OpenTabletDriver.Analyzers.Emitters
                                                         SyntaxFactory.Token(SyntaxKind.SemicolonToken)))))
                                         .WithInitializer(
                                             SyntaxFactory.EqualsValueClause(
-                                                SyntaxFactory.ImplicitArrayCreationExpression(
-                                                    SyntaxFactory.InitializerExpression(
-                                                        SyntaxKind.ArrayInitializerExpression,
-                                                        SyntaxFactory.SeparatedList<ExpressionSyntax>(
-                                                            _tabletConfigurations.Select(t => new TabletConfigurationEmitter(t).Emit()))))))
+                                                SyntaxFactory.InvocationExpression(
+                                                    SyntaxFactory.MemberAccessExpression(
+                                                        SyntaxKind.SimpleMemberAccessExpression,
+                                                        SyntaxFactory.IdentifierName($"global::System.Collections.Immutable.ImmutableArray"),
+                                                        SyntaxFactory.IdentifierName("Create")))
+                                                .WithArgumentList(
+                                                    SyntaxFactory.ArgumentList(
+                                                        SyntaxFactory.SingletonSeparatedList(
+                                                            SyntaxFactory.Argument(
+                                                                SyntaxFactory.ImplicitArrayCreationExpression(
+                                                                    SyntaxFactory.InitializerExpression(
+                                                                        SyntaxKind.ArrayInitializerExpression,
+                                                                        SyntaxFactory.SeparatedList<ExpressionSyntax>(
+                                                                            _tabletConfigurations.Select(t => new TabletConfigurationEmitter(t).Emit()))))))))))
                                         .WithSemicolonToken(
                                             SyntaxFactory.Token(SyntaxKind.SemicolonToken))))))))
                 .NormalizeWhitespace(eol: "\n");

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -87,6 +87,7 @@ namespace OpenTabletDriver.Daemon
                 Message?.Invoke(sender, message);
             };
 
+            Log.Write("Detect", $"Configuration overrides exist: '{_appInfo.ConfigurationDirectory}'", LogLevel.Debug);
             InitializePlatform();
             _driver.InputDevicesChanged += (sender, e) => TabletsChanged?.Invoke(sender, e.Select(c => c.Configuration));
             _deviceHub.DevicesChanged += (_, e) =>

--- a/OpenTabletDriver.Desktop/DesktopDeviceConfigurationProvider.cs
+++ b/OpenTabletDriver.Desktop/DesktopDeviceConfigurationProvider.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using OpenTabletDriver.Components;
 using OpenTabletDriver.Configurations;
 using OpenTabletDriver.Desktop.Interop.AppInfo;
@@ -11,44 +14,87 @@ namespace OpenTabletDriver.Desktop
 {
     public class DesktopDeviceConfigurationProvider : IDeviceConfigurationProvider
     {
+        private const int THRESHOLD_MS = 250;
         private readonly DeviceConfigurationProvider _inAssemblyConfigurationProvider = new();
         private readonly IAppInfo _appInfo;
+        private readonly FileSystemWatcher? _watcher;
+
+        private CancellationTokenSource? _cts;
+        private ImmutableArray<TabletConfiguration> _tabletConfigurations;
 
         public DesktopDeviceConfigurationProvider(IAppInfo appInfo)
         {
             _appInfo = appInfo;
+
+            _tabletConfigurations = GetTabletConfigurations();
+
+            if (!Directory.Exists(_appInfo.ConfigurationDirectory))
+                return;
+
+            _watcher = new FileSystemWatcher(_appInfo.ConfigurationDirectory)
+            {
+                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName,
+                Filter = "*.json",
+                IncludeSubdirectories = true,
+                EnableRaisingEvents = true
+            };
+
+            _watcher.Changed += debouncedUpdateConfigurations;
+            _watcher.Renamed += debouncedUpdateConfigurations;
+            _watcher.Created += debouncedUpdateConfigurations;
+            _watcher.Deleted += debouncedUpdateConfigurations;
+
+            // wait THRESHOLD_MS before updating configurations
+            // if another change occurs within THRESHOLD_MS, cancel this update
+            void debouncedUpdateConfigurations(object sender, FileSystemEventArgs e)
+            {
+                _cts?.Cancel();
+                _cts = new CancellationTokenSource();
+                var ct = _cts.Token;
+
+                Task.Run(async () =>
+                {
+                    await Task.Delay(THRESHOLD_MS, ct);
+                    Log.Debug("Detect", "Refreshing configurations...");
+                    _tabletConfigurations = GetTabletConfigurations();
+                    TabletConfigurationsChanged?.Invoke(_tabletConfigurations);
+                }, ct);
+            }
         }
 
-        public IEnumerable<TabletConfiguration> TabletConfigurations => GetTabletConfigurations();
+        public bool RaisesTabletConfigurationsChanged => true;
+        public ImmutableArray<TabletConfiguration> TabletConfigurations => _tabletConfigurations;
+        public event Action<ImmutableArray<TabletConfiguration>>? TabletConfigurationsChanged;
 
-        private IEnumerable<TabletConfiguration> GetTabletConfigurations()
+        private ImmutableArray<TabletConfiguration> GetTabletConfigurations()
         {
-            IEnumerable<(ConfigurationSource, TabletConfiguration)> jsonConfigurations = Array.Empty<(ConfigurationSource, TabletConfiguration)>();
-
             if (Directory.Exists(_appInfo.ConfigurationDirectory))
             {
-                Log.Write("Detect", $"Configuration overrides exist in '{_appInfo.ConfigurationDirectory}', overriding built-in configurations.", LogLevel.Debug);
                 var files = Directory.EnumerateFiles(_appInfo.ConfigurationDirectory, "*.json", SearchOption.AllDirectories);
 
-                jsonConfigurations = files.Select(path => Serialization.Deserialize<TabletConfiguration>(File.OpenRead(path)))
+                IEnumerable<(ConfigurationSource, TabletConfiguration)> jsonConfigurations = files
+                    .Select(path => Serialization.Deserialize<TabletConfiguration>(File.OpenRead(path)))
                     .Select(jsonConfig => (ConfigurationSource.File, jsonConfig))!;
+
+                return _inAssemblyConfigurationProvider.TabletConfigurations
+                    .Select(asmConfig => (ConfigurationSource.Assembly, asmConfig))
+                    .Concat(jsonConfigurations)
+                    .GroupBy(sourcedConfig => sourcedConfig.Item2.Name)
+                    .Select(multiSourcedConfig =>
+                    {
+                        var asmConfig = multiSourcedConfig.Where(m => m.Item1 == ConfigurationSource.Assembly)
+                            .Select(m => m.Item2)
+                            .FirstOrDefault();
+                        var jsonConfig = multiSourcedConfig.Where(m => m.Item1 == ConfigurationSource.File)
+                            .Select(m => m.Item2)
+                            .FirstOrDefault();
+
+                        return jsonConfig ?? asmConfig!;
+                    })
+                    .ToImmutableArray();
             }
 
-            return _inAssemblyConfigurationProvider.TabletConfigurations
-                .Select(asmConfig => (ConfigurationSource.Assembly, asmConfig))
-                .Concat(jsonConfigurations)
-                .GroupBy(sourcedConfig => sourcedConfig.Item2.Name)
-                .Select(multiSourcedConfig =>
-                {
-                    var asmConfig = multiSourcedConfig.Where(m => m.Item1 == ConfigurationSource.Assembly)
-                        .Select(m => m.Item2)
-                        .FirstOrDefault();
-                    var jsonConfig = multiSourcedConfig.Where(m => m.Item1 == ConfigurationSource.File)
-                        .Select(m => m.Item2)
-                        .FirstOrDefault();
-
-                    return jsonConfig ?? asmConfig!;
-                });
+            return _inAssemblyConfigurationProvider.TabletConfigurations;
         }
 
         private enum ConfigurationSource

--- a/OpenTabletDriver/Components/IDeviceConfigurationProvider.cs
+++ b/OpenTabletDriver/Components/IDeviceConfigurationProvider.cs
@@ -1,4 +1,5 @@
-using System.Collections.Generic;
+using System;
+using System.Collections.Immutable;
 using JetBrains.Annotations;
 using OpenTabletDriver.Tablet;
 
@@ -11,8 +12,19 @@ namespace OpenTabletDriver.Components
     public interface IDeviceConfigurationProvider
     {
         /// <summary>
+        /// Returns true if the provider is capable of raising the <see cref="TabletConfigurationsChanged"/> event,
+        /// otherwise false if the provided configurations are static.
+        /// </summary>
+        bool RaisesTabletConfigurationsChanged { get; }
+
+        /// <summary>
         /// Enumeration of the configurations for all supported tablets.
         /// </summary>
-        IEnumerable<TabletConfiguration> TabletConfigurations { get; }
+        ImmutableArray<TabletConfiguration> TabletConfigurations { get; }
+
+        /// <summary>
+        /// Occurs when the tablet configurations have changed.
+        /// </summary>
+        event Action<ImmutableArray<TabletConfiguration>> TabletConfigurationsChanged;
     }
 }


### PR DESCRIPTION
This removes unnecessary json parsing when nothing changes in `Configurations` directory and is in preparation for a mostly O(1) detection routine based on VID and PID.

`IDeviceConfigurationProvider` has been modified to use `ImmutableArray` instead of `IEnumerable` and now has an event that occurs when configurations have changed.