### PR TITLE
Redetect when configurations change

### DIFF
--- a/OpenTabletDriver.Desktop/DesktopDeviceConfigurationProvider.cs
+++ b/OpenTabletDriver.Desktop/DesktopDeviceConfigurationProvider.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using OpenTabletDriver.Components;
@@ -70,31 +71,44 @@ namespace OpenTabletDriver.Desktop
         {
             if (Directory.Exists(_appInfo.ConfigurationDirectory))
             {
-                var files = Directory.EnumerateFiles(_appInfo.ConfigurationDirectory, "*.json", SearchOption.AllDirectories);
+                IEnumerable<TabletConfiguration> configOverrides = Directory.EnumerateFiles(_appInfo.ConfigurationDirectory, "*.json", SearchOption.AllDirectories)
+                    .Select(ParseConfiguration)
+                    .Where(config => config != null)!;
 
-                IEnumerable<(ConfigurationSource, TabletConfiguration)> jsonConfigurations = files
-                    .Select(path => Serialization.Deserialize<TabletConfiguration>(File.OpenRead(path)))
-                    .Select(jsonConfig => (ConfigurationSource.File, jsonConfig))!;
+                var configMap = new Dictionary<string, TabletConfiguration>();
 
-                return _inAssemblyConfigurationProvider.TabletConfigurations
-                    .Select(asmConfig => (ConfigurationSource.Assembly, asmConfig))
-                    .Concat(jsonConfigurations)
-                    .GroupBy(sourcedConfig => sourcedConfig.Item2.Name)
-                    .Select(multiSourcedConfig =>
-                    {
-                        var asmConfig = multiSourcedConfig.Where(m => m.Item1 == ConfigurationSource.Assembly)
-                            .Select(m => m.Item2)
-                            .FirstOrDefault();
-                        var jsonConfig = multiSourcedConfig.Where(m => m.Item1 == ConfigurationSource.File)
-                            .Select(m => m.Item2)
-                            .FirstOrDefault();
+                // populate configMap with all configurations from the assembly
+                // and then populate it with overrides from the user's config directory,
+                // replacing any existing configurations with the same name
+                PopulateMap(configMap, _inAssemblyConfigurationProvider.TabletConfigurations);
+                PopulateMap(configMap, configOverrides);
 
-                        return jsonConfig ?? asmConfig!;
-                    })
-                    .ToImmutableArray();
+                return configMap.Values.OrderBy(config => config.Name).ToImmutableArray();
             }
 
             return _inAssemblyConfigurationProvider.TabletConfigurations;
+        }
+
+        private static TabletConfiguration? ParseConfiguration(string path)
+        {
+            try
+            {
+                return Serialization.Deserialize<TabletConfiguration>(File.OpenRead(path));
+            }
+            catch
+            {
+                Log.Write("Configuration", $"Failed to parse configuration at '{path}'", LogLevel.Error);
+                return null;
+            }
+        }
+
+        private static void PopulateMap(Dictionary<string, TabletConfiguration> configMap, IEnumerable<TabletConfiguration> configs)
+        {
+            foreach (var config in configs)
+            {
+                ref var configInMap = ref CollectionsMarshal.GetValueRefOrAddDefault(configMap, config.Name, out _);
+                configInMap = config;
+            }
         }
 
         private enum ConfigurationSource

--- a/OpenTabletDriver.Desktop/DesktopDeviceConfigurationProvider.cs
+++ b/OpenTabletDriver.Desktop/DesktopDeviceConfigurationProvider.cs
@@ -115,11 +115,5 @@ namespace OpenTabletDriver.Desktop
                 configInMap = config;
             }
         }
-
-        private enum ConfigurationSource
-        {
-            Assembly,
-            File
-        }
     }
 }

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -39,8 +39,11 @@ namespace OpenTabletDriver
 
             if (_deviceConfigurationProvider.RaisesTabletConfigurationsChanged)
             {
-                _deviceConfigurationProvider.TabletConfigurationsChanged +=
-                    configs => _configHashMap = ConstructConfigHashMap(configs);
+                _deviceConfigurationProvider.TabletConfigurationsChanged += configs =>
+                {
+                    _configHashMap = ConstructConfigHashMap(configs);
+                    Detect();
+                };
             }
 
             _configHashMap = ConstructConfigHashMap(_deviceConfigurationProvider.TabletConfigurations);


### PR DESCRIPTION
The new implementation for configuration override has a much simpler logic, where it just puts every known configuration to a dictionary. The second call to `PopulateMap` replaces the configurations of the same name from in-assembly configuration provider to that of the configuration from `Configurations` folder.

The sorting is there purely just for making the log look pretty in case it's a device with lots of VID/PID conflict.

When the configuration from the `Configurations` folder is invalid, it won't be used as an override and will be logged.