### PR TITLE
Add plugin name next to "Enable" in plugin settings editor

### DIFF
--- a/OpenTabletDriver.UX/Controls/Editors/PluginSettingsEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Editors/PluginSettingsEditor.cs
@@ -12,7 +12,7 @@ namespace OpenTabletDriver.UX.Controls.Editors
 
             var enableToggle = new CheckBox
             {
-                Text = "Enable"
+                Text = $"Enable {type.GetFriendlyName()}"
             };
 
             enableToggle.CheckedBinding.BindDataContext((PluginSettings s) => s.Enable);


### PR DESCRIPTION
This seems to have been lost during the rewrite. Not having it looks odd and can be very confusing in some cases.