### PR TITLE
Remove unnecessary array allocation

### DIFF
--- a/OpenTabletDriver.Desktop/DesktopServiceCollection.cs
+++ b/OpenTabletDriver.Desktop/DesktopServiceCollection.cs
@@ -20,35 +20,28 @@ namespace OpenTabletDriver.Desktop
 
     public class DesktopServiceCollection : ServiceCollection
     {
-        private static readonly IEnumerable<ServiceDescriptor> RequiredServices = new[]
-        {
-            // Core Services
-            Singleton<SynchronizationContext>(_ => new NonConcurrentSynchronizationContext(false)),
-            Singleton<IDriver, Driver>(),
-            Singleton<IReportParserProvider, ReportParserProvider>(),
-            Singleton<IDeviceHubsProvider, DeviceHubsProvider>(p => new DeviceHubsProvider(p)),
-            Singleton<ICompositeDeviceHub, RootHub>(RootHub.WithProvider),
-            Singleton<IDeviceConfigurationProvider, DesktopDeviceConfigurationProvider>(),
-            Singleton<IReportParserProvider, DesktopReportParserProvider>(),
-            // Desktop Services
-            Singleton<IGitHubClient>(new GitHubClient(ProductHeaderValue.Parse("OpenTabletDriver"))),
-            Transient<EnvironmentDictionary, EnvironmentDictionary>(),
-            Singleton<IPluginManager, PluginManager>(),
-            Singleton<ISettingsManager, SettingsManager>(),
-            Singleton<IPresetManager, PresetManager>(),
-            Singleton<IPluginFactory, PluginFactory>(),
-            Singleton<ISleepDetector, SleepDetector>(),
-            Transient(p => p.GetRequiredService<ISettingsManager>().Settings)
-        };
-
         public DesktopServiceCollection()
         {
-            this.AddServices(RequiredServices);
-        }
-
-        protected DesktopServiceCollection(IEnumerable<ServiceDescriptor> overridingServices) : this()
-        {
-            this.AddServices(overridingServices);
+            this.AddServices(new[]
+            {
+                // Core Services
+                Singleton<SynchronizationContext>(_ => new NonConcurrentSynchronizationContext(false)),
+                Singleton<IDriver, Driver>(),
+                Singleton<IReportParserProvider, ReportParserProvider>(),
+                Singleton<IDeviceHubsProvider, DeviceHubsProvider>(p => new DeviceHubsProvider(p)),
+                Singleton<ICompositeDeviceHub, RootHub>(RootHub.WithProvider),
+                Singleton<IDeviceConfigurationProvider, DesktopDeviceConfigurationProvider>(),
+                Singleton<IReportParserProvider, DesktopReportParserProvider>(),
+                // Desktop Services
+                Singleton<IGitHubClient>(new GitHubClient(ProductHeaderValue.Parse("OpenTabletDriver"))),
+                Transient<EnvironmentDictionary, EnvironmentDictionary>(),
+                Singleton<IPluginManager, PluginManager>(),
+                Singleton<ISettingsManager, SettingsManager>(),
+                Singleton<IPresetManager, PresetManager>(),
+                Singleton<IPluginFactory, PluginFactory>(),
+                Singleton<ISleepDetector, SleepDetector>(),
+                Transient(p => p.GetRequiredService<ISettingsManager>().Settings)
+            });
         }
 
         public static DesktopServiceCollection GetPlatformServiceCollection()

--- a/OpenTabletDriver.Desktop/Interop/DesktopLinuxServiceCollection.cs
+++ b/OpenTabletDriver.Desktop/Interop/DesktopLinuxServiceCollection.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTabletDriver.Desktop.Diagnostics;
 using OpenTabletDriver.Desktop.Interop.Display;
@@ -19,21 +18,20 @@ namespace OpenTabletDriver.Desktop.Interop
 
     public sealed class DesktopLinuxServiceCollection : DesktopServiceCollection
     {
-        private static readonly IEnumerable<ServiceDescriptor> PlatformRequiredServices = new[]
+        public DesktopLinuxServiceCollection() : base()
         {
-            Transient<IEnvironmentHandler, LinuxEnvironmentHandler>(),
-            Transient<EnvironmentDictionary, LinuxEnvironmentDictionary>(),
-            Transient<ITimer, LinuxTimer>(),
-            Singleton<IAbsolutePointer, EvdevAbsolutePointer>(),
-            Singleton<IRelativePointer, EvdevRelativePointer>(),
-            Singleton<IPressureHandler, EvdevVirtualTablet>(),
-            Singleton<IVirtualKeyboard, EvdevVirtualKeyboard>(),
-            Singleton<IKeysProvider, LinuxKeysProvider>(),
-            GetVirtualScreen()
-        };
-
-        public DesktopLinuxServiceCollection() : base(PlatformRequiredServices)
-        {
+            this.AddServices(new[]
+            {
+                Transient<IEnvironmentHandler, LinuxEnvironmentHandler>(),
+                Transient<EnvironmentDictionary, LinuxEnvironmentDictionary>(),
+                Transient<ITimer, LinuxTimer>(),
+                Singleton<IAbsolutePointer, EvdevAbsolutePointer>(),
+                Singleton<IRelativePointer, EvdevRelativePointer>(),
+                Singleton<IPressureHandler, EvdevVirtualTablet>(),
+                Singleton<IVirtualKeyboard, EvdevVirtualKeyboard>(),
+                Singleton<IKeysProvider, LinuxKeysProvider>(),
+                GetVirtualScreen()
+            });
         }
 
         private static ServiceDescriptor GetVirtualScreen()

--- a/OpenTabletDriver.Desktop/Interop/DesktopMacOSServiceCollection.cs
+++ b/OpenTabletDriver.Desktop/Interop/DesktopMacOSServiceCollection.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTabletDriver.Desktop.Interop.Display;
 using OpenTabletDriver.Desktop.Interop.Environment;
@@ -18,20 +17,18 @@ namespace OpenTabletDriver.Desktop.Interop
 
     public sealed class DesktopMacOSServiceCollection : DesktopServiceCollection
     {
-        private static readonly IEnumerable<ServiceDescriptor> PlatformRequiredServices = new[]
+        public DesktopMacOSServiceCollection() : base()
         {
-            Transient<ITimer, MacOSTimer>(),
-            Transient<IAbsolutePointer, MacOSAbsolutePointer>(),
-            Transient<IRelativePointer, MacOSRelativePointer>(),
-            Transient<IVirtualKeyboard, MacOSVirtualKeyboard>(),
-            Transient<IKeysProvider, MacOSKeysProvider>(),
-            Transient<IVirtualScreen, MacOSDisplay>(),
-            Transient<IEnvironmentHandler, MacOSEnvironmentHandler>(),
-            Transient<IUpdater, MacOSUpdater>()
-        };
-
-        public DesktopMacOSServiceCollection() : base(PlatformRequiredServices)
-        {
+            this.AddServices(new[] {
+                Transient<ITimer, MacOSTimer>(),
+                Transient<IAbsolutePointer, MacOSAbsolutePointer>(),
+                Transient<IRelativePointer, MacOSRelativePointer>(),
+                Transient<IVirtualKeyboard, MacOSVirtualKeyboard>(),
+                Transient<IKeysProvider, MacOSKeysProvider>(),
+                Transient<IVirtualScreen, MacOSDisplay>(),
+                Transient<IEnvironmentHandler, MacOSEnvironmentHandler>(),
+                Transient<IUpdater, MacOSUpdater>()
+            });
         }
     }
 }

--- a/OpenTabletDriver.Desktop/Interop/DesktopWindowsServiceCollection.cs
+++ b/OpenTabletDriver.Desktop/Interop/DesktopWindowsServiceCollection.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTabletDriver.Desktop.Diagnostics;
 using OpenTabletDriver.Desktop.Interop.Display;
@@ -19,21 +18,19 @@ namespace OpenTabletDriver.Desktop.Interop
 
     public sealed class DesktopWindowsServiceCollection : DesktopServiceCollection
     {
-        private static readonly IEnumerable<ServiceDescriptor> PlatformRequiredServices = new[]
+        public DesktopWindowsServiceCollection() : base()
         {
-            Transient<IEnvironmentHandler, WindowsEnvironmentHandler>(),
-            Transient<EnvironmentDictionary, WindowsEnvironmentDictionary>(),
-            Transient<ITimer, WindowsTimer>(),
-            Transient<IAbsolutePointer, WindowsAbsolutePointer>(),
-            Transient<IRelativePointer, WindowsRelativePointer>(),
-            Transient<IVirtualKeyboard, WindowsVirtualKeyboard>(),
-            Singleton<IKeysProvider, WindowsKeysProvider>(),
-            Transient<IVirtualScreen, WindowsDisplay>(),
-            Transient<IUpdater, WindowsUpdater>()
-        };
-
-        public DesktopWindowsServiceCollection() : base(PlatformRequiredServices)
-        {
+            this.AddServices(new[] {
+                Transient<IEnvironmentHandler, WindowsEnvironmentHandler>(),
+                Transient<EnvironmentDictionary, WindowsEnvironmentDictionary>(),
+                Transient<ITimer, WindowsTimer>(),
+                Transient<IAbsolutePointer, WindowsAbsolutePointer>(),
+                Transient<IRelativePointer, WindowsRelativePointer>(),
+                Transient<IVirtualKeyboard, WindowsVirtualKeyboard>(),
+                Singleton<IKeysProvider, WindowsKeysProvider>(),
+                Transient<IVirtualScreen, WindowsDisplay>(),
+                Transient<IUpdater, WindowsUpdater>()
+            });
         }
     }
 }


### PR DESCRIPTION
These static arrays will just consume memory for OTD's whole lifetime and there's no point for them to exist.