### PR TITLE
Configuration File for Huion G930L

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/G930L.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/G930L.json
@@ -1,0 +1,39 @@
+{
+  "Name": "Huion G930L",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 345.44,
+      "Height": 215.9,
+      "MaxX": 69088,
+      "MaxY": 43180
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 6
+    },
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 9580,
+      "ProductID": 97,
+      "InputReportLength": 12,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "201": "HUION_T209_\\d{6}$"
+      },
+      "InitializationStrings": [
+    200
+    ]
+    }
+  ],
+  "AuxiliaryDeviceIdentifiers": [],
+  "Attributes": {}
+}

--- a/OpenTabletDriver.Configurations/Configurations/Huion/G930L.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/G930L.json
@@ -30,8 +30,8 @@
         "201": "HUION_T209_\\d{6}$"
       },
       "InitializationStrings": [
-    200
-    ]
+        200
+      ]
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -11,6 +11,7 @@
 | Gaomon S620                   |     Supported     |
 | Genius G-Pen 560              |     Supported     | Soft-buttons are bindable as aux buttons
 | Huion 1060 Plus               |     Supported     |
+| Huion G930L                   |     Supported     |
 | Huion GT-220 V2               |     Supported     |
 | Huion H320M                   |     Supported     |
 | Huion H420X                   |     Supported     |


### PR DESCRIPTION
Config file for HUION Inspiroy Giano (G930L). Tested on my own device. Calculated from https://www.huion.com/index.php?m=content&c=index&a=manual&id=479, tested using Tablet Debugger and edited to correct dimensions. 

Chat where Config was developed: https://discord.com/channels/615607687467761684/645408221322018837/1062928160007667823

Diagnostics file showing tablet connected:
https://discord.com/channels/615607687467761684/645408221322018837/1062932599175131277