### PR TITLE
Added support for the XP-Pen Artist 16 (2nd Gen)

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16 (2nd Gen).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16 (2nd Gen).json
@@ -9,9 +9,7 @@
     },
     "Pen": {
       "MaxPressure": 8191,
-      "Buttons": {
-        "ButtonCount": 2
-      }
+      "ButtonCount": 2
     },
     "AuxiliaryButtons": {
       "ButtonCount": 9
@@ -34,7 +32,7 @@
       "InitializationStrings": []
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
+  "AuxiliaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16 (2nd Gen).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16 (2nd Gen).json
@@ -1,0 +1,41 @@
+{
+  "Name": "XP-Pen Artist 16 (2nd Gen)",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 340.99,
+      "Height": 191.81,
+      "MaxX": 68199.0,
+      "MaxY": 38359.0
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "Buttons": {
+        "ButtonCount": 2
+      }
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 9
+    },
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 10429,
+      "ProductID": 2380,
+      "InputReportLength": 12,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenOffsetPressureReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": [
+        "ArAE"
+      ],
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16 (2nd Gen).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16 (2nd Gen).json
@@ -2,8 +2,8 @@
   "Name": "XP-Pen Artist 16 (2nd Gen)",
   "Specifications": {
     "Digitizer": {
-      "Width": 340.99,
-      "Height": 191.81,
+      "Width": 340.995,
+      "Height": 191.795,
       "MaxX": 68199.0,
       "MaxY": 38359.0
     },
@@ -12,7 +12,7 @@
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {
-      "ButtonCount": 9
+      "ButtonCount": 10
     },
     "MouseButtons": null,
     "Touch": null

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -103,6 +103,7 @@
 | XP-Pen Artist 13.3            |     Supported     |
 | XP-Pen Artist 13 (2nd Gen)    |     Supported     |
 | XP-Pen Artist 15.6            |     Supported     |
+| XP-Pen Artist 16 (2nd Gen)    |     Supported     |
 | XP-Pen CT430                  |     Supported     |
 | XP-Pen CT640                  |     Supported     |
 | XP-Pen Deco Fun L (CT1060)    |     Supported     |
@@ -203,7 +204,6 @@
 | XP-Pen Artist 13.3 Pro        |  Missing Features | Wheel is not yet supported.
 | XP-Pen Artist 15.6 Pro        |  Missing Features | Tilt and wheel are not yet supported.
 | XP-Pen Artist 16 Pro          |  Missing Features | Wheel is not yet supported.
-| XP-Pen Artist 16 (2nd Gen)    |  Missing Features | Button 10 is not yet supported.
 | XP-Pen Artist Pro 16TP        |  Missing Features | Touch is not yet supported.
 | XP-Pen Deco 01 V2             |  Missing Features | Tilt is not yet supported.
 | XP-Pen Deco 01 V2 (variant 2) |  Missing Features | Tilt is not yet supported

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -203,7 +203,7 @@
 | XP-Pen Artist 13.3 Pro        |  Missing Features | Wheel is not yet supported.
 | XP-Pen Artist 15.6 Pro        |  Missing Features | Tilt and wheel are not yet supported.
 | XP-Pen Artist 16 Pro          |  Missing Features | Wheel is not yet supported.
-| XP-Pen Artist 16 (2nd Gen)    |  Missing Features | The 10th button is not detected and cannot be used.
+| XP-Pen Artist 16 (2nd Gen)    |  Missing Features | Button 10 is not yet supported.
 | XP-Pen Artist Pro 16TP        |  Missing Features | Touch is not yet supported.
 | XP-Pen Deco 01 V2             |  Missing Features | Tilt is not yet supported.
 | XP-Pen Deco 01 V2 (variant 2) |  Missing Features | Tilt is not yet supported

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -203,6 +203,7 @@
 | XP-Pen Artist 13.3 Pro        |  Missing Features | Wheel is not yet supported.
 | XP-Pen Artist 15.6 Pro        |  Missing Features | Tilt and wheel are not yet supported.
 | XP-Pen Artist 16 Pro          |  Missing Features | Wheel is not yet supported.
+| XP-Pen Artist 16 (2nd Gen)    |  Missing Features | The 10th button is not detected and cannot be used.
 | XP-Pen Artist Pro 16TP        |  Missing Features | Touch is not yet supported.
 | XP-Pen Deco 01 V2             |  Missing Features | Tilt is not yet supported.
 | XP-Pen Deco 01 V2 (variant 2) |  Missing Features | Tilt is not yet supported


### PR DESCRIPTION
The specs were pulled from XP-Pen's official website for the dimensions: https://www.xp-pen.com/product/1203.html
Configuration files checked against the other models of the same generation by XP-Pen (such as the Artist 13 2nd Gen).
The MaxX and MaxY properties were acquired via the Tablet Debugger inside of OpenTabletDriver.
The Width/MaxX ratio matches the one of the other already submitted models (Artist 13 2nd Gen as a reference).

There is an issue where the last button on the tablet isn't being detected by the tablet debugger and therefore isn't usable at all.
However the raw tablet data does change with the 4th byte having it's 2nd bit flipped, it just isn't enumerated in the AuxButtons collection. (might have to modify the ReportParser?)

Asides from that button issue, everything else works as intended.

Self-tested on:
- Windows 11 22H2 (via the proprietary XP-Pen cable)
- macOS Ventura 13.1 (via a USB-C 3.1 Gen1 cable)