### PR TITLE
Workaround exception dialog spam

### DIFF
--- a/OpenTabletDriver.UX/EtoExtensions.cs
+++ b/OpenTabletDriver.UX/EtoExtensions.cs
@@ -8,12 +8,17 @@ namespace OpenTabletDriver.UX
 {
     public static class EtoExtensions
     {
+        private static ExceptionDialog? _exceptionDialog;
+
         /// <summary>
         /// Shows an exception with a MessageBox dialog.
         /// </summary>
         /// <param name="ex">The exception to show.</param>
         public static void Show(this Exception ex)
         {
+            if (_exceptionDialog != null)
+                return;
+
             Application.Instance.Invoke(() =>
             {
                 try
@@ -22,8 +27,9 @@ namespace OpenTabletDriver.UX
                     while (ex.InnerException != null)
                         ex = ex.InnerException;
 
-                    var dialog = new ExceptionDialog(ex);
-                    dialog.ShowModal(Application.Instance.MainForm);
+                    _exceptionDialog = new ExceptionDialog(ex);
+                    _exceptionDialog.ShowModal(Application.Instance.MainForm);
+                    _exceptionDialog = null;
                 }
                 catch
                 {


### PR DESCRIPTION
Avoiding creating another exception dialog while one is already shown stops the exception dialog spam.