### PR TITLE
Prevent log spams

### DIFF
--- a/OpenTabletDriver.UX/Extensions.cs
+++ b/OpenTabletDriver.UX/Extensions.cs
@@ -13,7 +13,6 @@ namespace OpenTabletDriver.UX
     {
         public static void ShowMessageBox(this Exception exception)
         {
-            Log.Exception(exception);
             MessageBox.Show(
                 exception.Message + Environment.NewLine + exception.StackTrace,
                 $"Error: {exception.GetType().Name}",

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -380,14 +380,22 @@ namespace OpenTabletDriver.UX
                 SetTitle(tablets);
         });
 
-        private void HandleDaemonDisconnected(object sender, EventArgs e) => Application.Instance.AsyncInvoke(async () =>
+        private void HandleDaemonDisconnected(object sender, EventArgs e)
         {
             // Hide all controls until reconnected
-            base.Content = placeholder;
-            base.Menu = null;
-            // Attempt to reconnect
-            await Driver.Connect();
-        });
+            Application.Instance.Invoke(() =>
+            {
+                base.Content = placeholder;
+                base.Menu = null;
+
+                MessageBox.Show(
+                    "Lost connection to daemon, exiting...",
+                    MessageBoxType.Error
+                );
+
+                Environment.Exit(1);
+            });
+        }
 
         private async Task ResetSettings()
         {


### PR DESCRIPTION
Doing an asynchronous invoke would have let the function continue without actually executing the entirety of `HandleDaemonDisconnected`, so using `Application.Invoke` here is a must. If we suddenly disconnected from daemon there's no reason to reconnect unless we can reason out that it's not a "connection time" issue (stuff where reconnecting will just trigger another reconnect).

`Log.Exception()` is removed from `ShowMessageBox()` because it's already logged via `ShowUnhandledException()`.

Alternative to:
- #2658 

## Repro

- Run 0.7.x daemon
- Run 0.6.x UX