### PR TITLE
Prevent reconnection log spam

### DIFF
--- a/OpenTabletDriver.UX/EtoExtensions.cs
+++ b/OpenTabletDriver.UX/EtoExtensions.cs
@@ -16,11 +16,11 @@ namespace OpenTabletDriver.UX
         /// <param name="ex">The exception to show.</param>
         public static void Show(this Exception ex)
         {
+            if (_exceptionDialog != null)
+                return;
+
             Application.Instance.Invoke(() =>
             {
-                if (_exceptionDialog != null)
-                    return;
-
                 try
                 {
                     // Grab innermost exception

--- a/OpenTabletDriver.UX/EtoExtensions.cs
+++ b/OpenTabletDriver.UX/EtoExtensions.cs
@@ -8,17 +8,12 @@ namespace OpenTabletDriver.UX
 {
     public static class EtoExtensions
     {
-        private static ExceptionDialog? _exceptionDialog;
-
         /// <summary>
         /// Shows an exception with a MessageBox dialog.
         /// </summary>
         /// <param name="ex">The exception to show.</param>
         public static void Show(this Exception ex)
         {
-            if (_exceptionDialog != null)
-                return;
-
             Application.Instance.Invoke(() =>
             {
                 try
@@ -27,9 +22,8 @@ namespace OpenTabletDriver.UX
                     while (ex.InnerException != null)
                         ex = ex.InnerException;
 
-                    _exceptionDialog = new ExceptionDialog(ex);
-                    _exceptionDialog.ShowModal(Application.Instance.MainForm);
-                    _exceptionDialog = null;
+                    var dialog = new ExceptionDialog(ex);
+                    dialog.ShowModal(Application.Instance.MainForm);
                 }
                 catch
                 {

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -180,9 +180,14 @@ namespace OpenTabletDriver.UX
             {
                 foreach (var window in Application.Instance.Windows.SkipWhile(w => w == this).ToArray())
                     window.Close();
-            });
 
-            await _rpc.Connect();
+                MessageBox.Show(
+                    "Lost connection to daemon. Exiting...",
+                    MessageBoxType.Error
+                );
+
+                Environment.Exit(1);
+            });
         }
 
         /// <summary>


### PR DESCRIPTION
Remove unnecessary changes, and instead exit early when daemon disconnects. Same reasoning behind #2660.