### PR TITLE
partial-absolute-wheel-support

### DIFF
--- a/OpenTabletDriver.Analyzers/Emitters/TabletSpecificationsEmitter.cs
+++ b/OpenTabletDriver.Analyzers/Emitters/TabletSpecificationsEmitter.cs
@@ -43,6 +43,10 @@ namespace OpenTabletDriver.Analyzers.Emitters
                                 new ButtonSpecificationsEmitter(_specifications.MouseButtons).Emit()),
                             SyntaxFactory.AssignmentExpression(
                                 SyntaxKind.SimpleAssignmentExpression,
+                                SyntaxFactory.IdentifierName(nameof(TabletSpecifications.Wheel)),
+                                new WheelSpecificationsEmitter(_specifications.Wheel).Emit()),
+                            SyntaxFactory.AssignmentExpression(
+                                SyntaxKind.SimpleAssignmentExpression,
                                 SyntaxFactory.IdentifierName(nameof(TabletSpecifications.Touch)),
                                 new DigitizerSpecificationsEmitter(_specifications.Touch).Emit()),
                         })))

--- a/OpenTabletDriver.Analyzers/Emitters/WheelSpecificationsEmitter.cs
+++ b/OpenTabletDriver.Analyzers/Emitters/WheelSpecificationsEmitter.cs
@@ -1,0 +1,40 @@
+using System;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Analyzers.Emitters;
+
+public class WheelSpecificationsEmitter
+{
+    public const string CLASS_NAME = "global::OpenTabletDriver.Tablet.WheelSpecifications";
+
+    private readonly WheelSpecifications? _wheelSpecifications;
+
+    public WheelSpecificationsEmitter(WheelSpecifications? wheelSpecifications)
+    {
+        _wheelSpecifications = wheelSpecifications;
+    }
+
+    public ExpressionSyntax Emit()
+    {
+        if (_wheelSpecifications == null)
+           return SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression);
+
+        return
+            SyntaxFactory.ObjectCreationExpression(
+                    SyntaxFactory.ParseTypeName(CLASS_NAME))
+                .WithInitializer(
+                    SyntaxFactory.InitializerExpression(
+                        SyntaxKind.ObjectInitializerExpression,
+                        SyntaxFactory.SingletonSeparatedList<ExpressionSyntax>(
+                            SyntaxFactory.AssignmentExpression(
+                                SyntaxKind.SimpleAssignmentExpression,
+                                SyntaxFactory.IdentifierName(nameof(WheelSpecifications.StepCount)),
+                                SyntaxFactory.LiteralExpression(
+                                    SyntaxKind.NumericLiteralExpression,
+                                    SyntaxFactory.Literal(_wheelSpecifications.StepCount))))))
+                .WithArgumentList(
+                    SyntaxFactory.ArgumentList());
+    }
+}

--- a/OpenTabletDriver.Configurations/Configurations/Huion/HS610.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/HS610.json
@@ -12,7 +12,10 @@
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {
-      "ButtonCount": 12
+      "ButtonCount": 13
+    },
+    "Wheel": {
+      "StepCount": 12
     },
     "MouseButtons": null,
     "Touch": null
@@ -23,7 +26,7 @@
       "ProductID": 109,
       "InputReportLength": 12,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.HuionWheelReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {

--- a/OpenTabletDriver.Configurations/Parsers/Huion/HuionWheelReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Huion/HuionWheelReport.cs
@@ -1,0 +1,26 @@
+using System;
+using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Huion;
+
+public class HuionWheelReport : IAbsoluteWheelReport
+{
+    public HuionWheelReport(byte[] data)
+    {
+        Raw = data;
+        var wheelData = data[5];
+
+        if (wheelData == 0)
+        {
+            WheelPosition = null;
+        }
+        else
+        {
+
+            WheelPosition = wheelData - 1;
+        }
+    }
+
+    public byte[] Raw { get; set; }
+    public int? WheelPosition { get; set; }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Huion/HuionWheelReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Huion/HuionWheelReportParser.cs
@@ -1,0 +1,20 @@
+using System.Reflection.Metadata.Ecma335;
+using OpenTabletDriver.Configurations.Parsers.UCLogic;
+using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Huion
+{
+    public class HuionWheelReportParser : IReportParser<IDeviceReport>
+    {
+        public IDeviceReport Parse(byte[] data)
+        {
+            return data[1] switch
+            {
+                0xE0 => new UCLogicAuxReport(data),
+                0xF0 => new HuionWheelReport(data),
+                _ => new TiltTabletReport(data)
+            };
+
+        }
+    }
+}

--- a/OpenTabletDriver.Desktop/Profiles/BindingSettings.cs
+++ b/OpenTabletDriver.Desktop/Profiles/BindingSettings.cs
@@ -13,6 +13,7 @@ namespace OpenTabletDriver.Desktop.Profiles
         private PluginSettings? _tipButton, _eraserButton, _mouseScrollUp, _mouseScrollDown;
         private PluginSettingsCollection _penButtons = new PluginSettingsCollection(),
             _auxButtons = new PluginSettingsCollection(),
+            _wheel = new PluginSettingsCollection(),
             _mouseButtons = new PluginSettingsCollection();
 
         [DisplayName("Tip Activation Threshold"), JsonProperty("TipActivationThreshold")]
@@ -55,6 +56,13 @@ namespace OpenTabletDriver.Desktop.Profiles
         {
             set => RaiseAndSetIfChanged(ref _auxButtons!, value);
             get => _auxButtons;
+        }
+
+        [DisplayName("Wheel"), JsonProperty("Wheel")]
+        public PluginSettingsCollection Wheel
+        {
+            set => RaiseAndSetIfChanged(ref _wheel!, value);
+            get => _wheel;
         }
 
         [DisplayName("Mouse Button"), JsonProperty("MouseButtons")]

--- a/OpenTabletDriver.Desktop/RPC/ReportFormatter.cs
+++ b/OpenTabletDriver.Desktop/RPC/ReportFormatter.cs
@@ -53,6 +53,8 @@ namespace OpenTabletDriver.Desktop.RPC
                 sb.AppendLines(GetStringFormat(mouseReport));
             if (report is IToolReport toolReport)
                 sb.AppendLines(GetStringFormat(toolReport));
+            if(report is IAbsoluteWheelReport absoluteWheelReport)
+                sb.AppendLines(GetStringFormat(absoluteWheelReport));
             if (report is OutOfRangeReport)
                 sb.AppendLine("Out of range");
 
@@ -114,6 +116,11 @@ namespace OpenTabletDriver.Desktop.RPC
             yield return $"Tool:{Enum.GetName(toolReport.Tool)}";
             yield return $"RawToolID:{toolReport.RawToolID}";
             yield return $"Serial:{toolReport.Serial}";
+        }
+
+        private static IEnumerable<string> GetStringFormat(IAbsoluteWheelReport toolReport)
+        {
+            yield return $"Wheel:{toolReport.WheelPosition?.ToString() ?? "Idle"}";
         }
 
         private static void AppendLines(this StringBuilder sb, IEnumerable<string> lines)

--- a/OpenTabletDriver.UX/Controls/ProfilePanel.cs
+++ b/OpenTabletDriver.UX/Controls/ProfilePanel.cs
@@ -20,6 +20,7 @@ namespace OpenTabletDriver.UX.Controls
             var filtersPage = CreatePage<FiltersPanel>("Filters");
             var penPage = CreatePage<PenPanel>("Pen");
             var auxPage = CreatePage<AuxPanel>("Auxiliary");
+            var wheelPage = CreatePage<WheelPanel>("Wheel");
             var mousePage = CreatePage<MousePanel>("Mouse");
             var toolsPage = CreatePage<ToolsPanel>("Tools");
             var logPage = CreatePage<LogViewer>("Log");
@@ -74,6 +75,9 @@ namespace OpenTabletDriver.UX.Controls
 
                     if (specifications.AuxiliaryButtons != null)
                         pages.Add(auxPage);
+
+                    if(specifications.Wheel != null)
+                        pages.Add(wheelPage);
 
                     if (specifications.MouseButtons != null)
                         pages.Add(mousePage);

--- a/OpenTabletDriver.UX/Controls/WheelPanel.cs
+++ b/OpenTabletDriver.UX/Controls/WheelPanel.cs
@@ -1,0 +1,39 @@
+using Eto.Forms;
+using OpenTabletDriver.Desktop.Profiles;
+using OpenTabletDriver.UX.Components;
+
+namespace OpenTabletDriver.UX.Controls
+{
+    public class WheelPanel : BindingPanel
+    {
+        private const int DIRECTION_PSEUDOBUTTONS = 2;
+
+        public WheelPanel(IControlBuilder controlBuilder, App app) : base(controlBuilder)
+        {
+            var buttons = new StackLayout
+            {
+                HorizontalContentAlignment = HorizontalAlignment.Stretch,
+                Spacing = 5
+            };
+
+            DataContextChanged += delegate
+            {
+                buttons.Items.Clear();
+
+                if (DataContext is not Profile profile)
+                    return;
+
+                var tablet = app.Tablets.First(t => t.Name == profile.Tablet);
+                var buttonCount = DIRECTION_PSEUDOBUTTONS + tablet.Specifications.Wheel?.StepCount ?? 0;
+
+                foreach (var button in ButtonsFor(c => c.BindingSettings.Wheel, buttonCount))
+                    buttons.Items.Add(button);
+            };
+
+            Content = new Scrollable
+            {
+                Content = buttons
+            };
+        }
+    }
+}

--- a/OpenTabletDriver/Tablet/IAbsoluteWheelReport.cs
+++ b/OpenTabletDriver/Tablet/IAbsoluteWheelReport.cs
@@ -1,0 +1,16 @@
+using JetBrains.Annotations;
+
+namespace OpenTabletDriver.Tablet
+{
+    /// <summary>
+    /// An auxiliary report containing states of express keys.
+    /// </summary>
+    [PublicAPI]
+    public interface IAbsoluteWheelReport : IDeviceReport
+    {
+        /// <summary>
+        /// The position of the wheel
+        /// </summary>
+        int? WheelPosition { get; set; }
+    }
+}

--- a/OpenTabletDriver/Tablet/TabletSpecifications.cs
+++ b/OpenTabletDriver/Tablet/TabletSpecifications.cs
@@ -32,6 +32,11 @@ namespace OpenTabletDriver.Tablet
         public ButtonSpecifications? MouseButtons { set; get; }
 
         /// <summary>
+        /// Specifications for the wheel.
+        /// </summary>
+        public WheelSpecifications? Wheel { get; set; }
+
+        /// <summary>
         /// Specifications for the touch digitizer.
         /// </summary>
         public DigitizerSpecifications? Touch { set; get; }

--- a/OpenTabletDriver/Tablet/WheelSpecifications.cs
+++ b/OpenTabletDriver/Tablet/WheelSpecifications.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel;
+using JetBrains.Annotations;
+
+namespace OpenTabletDriver.Tablet
+{
+    /// <summary>
+    /// Device specifications for a wheel.
+    /// </summary>
+    [PublicAPI]
+    public class WheelSpecifications
+    {
+        /// <summary>
+        /// The amount of steps making up a whole rotation.
+        /// </summary>
+        [DisplayName("Steps")]
+        public uint StepCount { set; get; }
+    }
+}


### PR DESCRIPTION
This commit adds some support for tablets with rings (#1367), by treating the ring as a bunch of buttons.

It most certainly needs a second pass, but its far enough along that I would like some thoughts on the general approach/structure.

In short, this pull adds support for treating the ring as positions + 2 individual buttons, the first two buttons being clockwise and anticlockwise buttons. This can be configured in a new "Wheel" UI tab. 

This is a different approach than what #2256 does, which I was not aware of when I started on this. A final solution probably includes content from both.

