### PR TITLE
Always show Tools panel

### DIFF
--- a/OpenTabletDriver.UX/Controls/ProfilePanel.cs
+++ b/OpenTabletDriver.UX/Controls/ProfilePanel.cs
@@ -89,6 +89,7 @@ namespace OpenTabletDriver.UX.Controls
                 else
                 {
                     pages.Add(placeholderPage);
+                    pages.Add(toolsPage);
                     pages.Add(logPage);
 
                     tabControl.SelectedPage = placeholderPage;


### PR DESCRIPTION
Tools don't need any tablets to be functional, and some tools will have to operate without any tablets.