### PR TITLE
Fix supported status on Wacom PTZ Tablets

### DIFF
--- a/TABLETS.md
+++ b/TABLETS.md
@@ -177,7 +177,7 @@
 | Wacom CTH-461                 |  Missing Features | Tablet buttons and touch are not yet supported.
 | Wacom CTL-6100WL              |  Missing Features | Wireless is not yet supported.
 | Wacom DTK-1300                |  Missing Features | Center button is not yet supported.
-| Wacom DTZ-1200W               |  Missing Features | Touch strips and top side buttons are not yet supported.
+| Wacom DTZ-1200W               |  Missing Features | Touch bars and top side buttons are not yet supported.
 | Wacom MTE-450                 |  Missing Features | Wheel is not yet supported.
 | Wacom PTH-450                 |  Missing Features | Wheel is not yet supported.
 | Wacom PTH-451                 |  Missing Features | Wheel is not yet supported.
@@ -193,9 +193,9 @@
 | Wacom PTK-540WL               |  Missing Features | Wheel is not yet supported.
 | Wacom PTK-640                 |  Missing Features | Wheel is not yet supported.
 | Wacom PTK-840                 |  Missing Features | Wheel is not yet supported.
-| Wacom PTZ-1230                |  Missing Features | Tablet buttons and touch bars are not yet supported.
-| Wacom PTZ-431W                |  Missing Features | Tablet buttons and touch bars are not yet supported.
-| Wacom PTZ-630                 |  Missing Features | Tablet buttons and touch bars are not yet supported.
+| Wacom PTZ-1230                |  Missing Features | Touch bars are not yet supported.
+| Wacom PTZ-431W                |  Missing Features | Touch bars are not yet supported.
+| Wacom PTZ-630                 |  Missing Features | Touch bars are not yet supported.
 | Wacom PTZ-631W                |  Missing Features | Touch bars are not yet supported.
 | Wacom PTZ-930                 |  Missing Features | Touch bars are not yet supported.
 | Wacom PTZ-1231W               |  Missing Features | Touch bars are not yet supported.


### PR DESCRIPTION
Also changes the last occurrence of "strips" to "bars"

Verification with PTZ-630 aux data:
```0C 00 00 00 00 01 00 00 00 00
0C 00 00 00 00 00 00 00 00 00
0C 00 00 00 00 02 00 00 00 00
0C 00 00 00 00 00 00 00 00 00
0C 00 00 00 00 04 00 00 00 00
0C 00 00 00 00 00 00 00 00 00
0C 00 00 00 00 08 00 00 00 00
0C 00 00 00 00 00 00 00 00 00
0C 00 00 00 00 00 01 00 00 00
0C 00 00 00 00 00 00 00 00 00
0C 00 00 00 00 00 02 00 00 00
0C 00 00 00 00 00 00 00 00 00
0C 00 00 00 00 00 04 00 00 00
0C 00 00 00 00 00 00 00 00 00
0C 00 00 00 00 00 08 00 00 00
0C 00 00 00 00 00 00 00 00 00
```
OTD correctly parses this reporting the correct buttons.