### PR TITLE
Fix: unable to find auxiliary devices

### DIFF
--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -128,7 +128,7 @@ namespace OpenTabletDriver
                                 }
 
                                 var pair = pairList[pairIndex];
-                                pair.Auxiliary = digitizerEndpoint;
+                                pair.Auxiliary = auxEndpoint;
                                 Log.Debug("Detect", $"Found '{candidateConfig.Name}' auxiliary: '{deviceName}'");
                                 break;
                             }


### PR DESCRIPTION
I noticed that no touch events where registered with my tablet.
Looks like a variable name was not changed and causes that no auxiliary devices are found.