### PR TITLE
Add support Gaomon PD-156 Pro

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/PD156 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/PD156 Pro.json
@@ -1,0 +1,41 @@
+{
+  "Name": "Gaomon PD156 Pro",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 344.4,
+      "Height": 193.6,
+      "MaxX": 68840.0,
+      "MaxY": 38720.0
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 10
+    },
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 9580,
+      "ProductID": 109,
+      "InputReportLength": 12,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "201": "OEM02_M19h_\\d{6}$"
+      },
+      "InitializationStrings": [
+        200
+      ]
+    }
+  ],
+  "AuxiliaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -146,6 +146,7 @@
 | Gaomon M10K Pro               |  Missing Features | Wheel is not yet supported.
 | Gaomon M1220                  |  Missing Features | Wheel is not yet supported.
 | Gaomon M1230                  |  Missing Features | Touch bar is not yet supported.
+| Gaomon PD156 Pro              |  Missing Features | Wheel is not yet supported.
 | Huion GC610                   |  Missing Features | Touchpad is not yet supported.
 | Huion GT-221 Pro              |  Missing Features | Touch bar is not yet supported.
 | Huion H1161                   |  Missing Features | Tablet buttons are not yet supported.


### PR DESCRIPTION
Verification: https://discord.com/channels/615607687467761684/615611007951306863/1097282030607278121,  https://i.imgur.com/8Pp8KuX.png 
Aux: https://discord.com/channels/615607687467761684/615611007951306863/1097279132947206264 (normal but also shows wheel)
Diag: https://discord.com/channels/615607687467761684/615611007951306863/1097276339674951800 (prior to supported)
Diag: https://cdn.discordapp.com/attachments/615611007951306863/1097284776106397796/PD156_Pro_diagnostic.json (post)