### PR TITLE
Add VK430 V2 and match string on VK430

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/VK430 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/VK430 V2.json
@@ -1,11 +1,11 @@
 {
-  "Name": "VEIKK VK430",
+  "Name": "VEIKK VK430 V2",
   "Specifications": {
     "Digitizer": {
       "Width": 101.6,
       "Height": 76.2,
-      "MaxX": 50800,
-      "MaxY": 31750
+      "MaxX": 20320.0,
+      "MaxY": 15240.0
     },
     "Pen": {
       "MaxPressure": 8191,
@@ -31,7 +31,7 @@
         "CQMC"
       ],
       "DeviceStrings": {
-        "23": "^2022/3/21$"
+        "23": "^2022/12/9$"
       },
       "InitializationStrings": []
     }


### PR DESCRIPTION
String dumps:
[v1_strings.txt](https://github.com/OpenTabletDriver/OpenTabletDriver/files/11301734/v1_strings.txt)
[v2_strings.txt](https://github.com/OpenTabletDriver/OpenTabletDriver/files/11301735/v2_strings.txt)

Verification:
https://discord.com/channels/615607687467761684/615611007951306863/1099364743363444856
https://discord.com/channels/615607687467761684/615611007951306863/1099366405478035659

This isn't an official "V2" of the tablet. But Veikk made a firmware change affecting specs.