### PR TITLE
Add new WH1409 variant

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/WH1409 V2 (Variant 2).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/WH1409 V2 (Variant 2).json
@@ -1,0 +1,41 @@
+{
+  "Name": "Huion WH1409 V2 (Variant 2)",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 350.52,
+      "Height": 219.0623,
+      "MaxX": 55200,
+      "MaxY": 34498
+    },
+    "Pen": {
+      "MaxPressure": 2047,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 12
+    },
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 9580,
+      "ProductID": 110,
+      "InputReportLength": 64,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "201": "HUION_T153_\\d{6}$"
+      },
+      "InitializationStrings": [
+        200
+      ]
+    }
+  ],
+  "AuxiliaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -132,6 +132,7 @@
 | Huion H690                    |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0
 | Huion New 1060 Plus (2048)    |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 1
 | Huion osu! Tablet             |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0
+| Huion WH1409 V2 (Variant 2)   |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0
 | KENTING K5540                 |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed
 | Parblo Ninos S                |    Has Quirks     | Aux buttons are not in order.
 | Parblo Ninos M                |    Has Quirks     | Aux buttons are not in order.


### PR DESCRIPTION
Everything works. Using naming `(Variant 2)` since this tablet already had V2 in the official name.

Verification:
https://discord.com/channels/615607687467761684/615611007951306863/1100802226965979227

Strings:
[string-dump.txt](https://github.com/OpenTabletDriver/OpenTabletDriver/files/11334528/string-dump.txt)