### PR TITLE
Add support for Huion Q630M

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/Q630M.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Q630M.json
@@ -30,7 +30,7 @@
         "201": "HUION_T216_\\d{6}$"
       },
       "InitializationStrings": [
-	200
+        200
       ]
     }
   ],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Q630M.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Q630M.json
@@ -1,0 +1,41 @@
+{
+  "Name": "Huion Q630M",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 266.7,
+      "Height": 166.7,
+      "MaxX": 53340,
+      "MaxY": 33340
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 6
+    },
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 9580,
+      "ProductID": 96,
+      "InputReportLength": 12,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "201": "HUION_T216_\\d{6}$"
+      },
+      "InitializationStrings": [
+	200
+      ]
+    }
+  ],
+  "AuxiliaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -159,6 +159,7 @@
 | Huion Kamvas Pro 20           |  Missing Features | Touch bar is not yet supported.
 | Huion Kamvas Pro 24           |  Missing Features | Touch bar is not yet supported.
 | Huion Q620M                   |  Missing Features | Wheel is not yet supported.
+| Huion Q630M                   |  Missing Features | Dials/Wheels are not yet supported.
 | Huion RTM-500                 |  Missing Features | Touch bar is not yet supported.
 | Lifetec LT9570                |  Missing Features | Aux buttons and tilt is not yet supported.
 | Monoprice MP1060-HA60         |  Missing Features | Tablet buttons are not yet supported. Windows: Requires Zadig's WinUSB to be installed on interface 0


### PR DESCRIPTION
Tested on Fedora Linux on Wayland. Everything is working except the two dials/wheels.