### PR TITLE
Fix rotation reports causing broken pressure, tilt, and pen buttons

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3ReportParser.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Numerics;
 using OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1;
 using OpenTabletDriver.Tablet;
@@ -30,8 +31,8 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3
             return new DeviceReport(data);
         }
 
-        private uint _prevPressure = 0;
-        private Vector2 _prevTilt = new Vector2();
-        private bool[] _prevPenButtons = new bool[] {};
+        private uint _prevPressure;
+        private Vector2 _prevTilt;
+        private bool[] _prevPenButtons = Array.Empty<bool>();
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3ReportParser.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1;
 using OpenTabletDriver.Tablet;
 
@@ -10,7 +11,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3
             return data[0] switch
             {
                 0x02 => GetToolReport(data),
-                0x10 => new IntuosV1TabletReport(data),
+                0x10 => new IntuosV1TabletReport(data, ref _prevPressure, ref _prevTilt, ref _prevPenButtons),
                 0x03 => new IntuosV1AuxReport(data),
                 0x0C => new Intuos3AuxReport(data),
                 _ => new DeviceReport(data)
@@ -19,14 +20,18 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3
 
         private IDeviceReport GetToolReport(byte[] data)
         {
-            return (data[1] & 0xF0) switch
-            {
-                0xE0 => new IntuosV1TabletReport(data),
-                0xA0 => new IntuosV1TabletReport(data),
-                0xF0 => new Intuos3MouseReport(data),
-                0xB0 => new Intuos3MouseReport(data),
-                _ => new DeviceReport(data)
-            };
+            if (data[1] == 0xEA || data[1] == 0xAA)
+                return new IntuosV1RotationReport(data, ref _prevPressure, ref _prevTilt, ref _prevPenButtons);
+            if ((data[1] & 0xF0) == 0xE0 || (data[1] & 0xF0) == 0xA0)
+                return new IntuosV1TabletReport(data, ref _prevPressure, ref _prevTilt, ref _prevPenButtons);
+            if ((data[1] & 0xF0) == 0xF0 || (data[1] & 0xF0) == 0xB0)
+                return new Intuos3MouseReport(data);
+
+            return new DeviceReport(data);
         }
+
+        private uint _prevPressure = 0;
+        private Vector2 _prevTilt = new Vector2();
+        private bool[] _prevPenButtons = new bool[] {};
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1ReportParser.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Numerics;
 using OpenTabletDriver.Configurations.Parsers.Wacom.Intuos4;
 using OpenTabletDriver.Tablet;
@@ -34,8 +35,8 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1
             return new DeviceReport(report);
         }
 
-        private uint _prevPressure = 0;
-        private Vector2 _prevTilt = new Vector2();
-        private bool[] _prevPenButtons = new bool[] {};
+        private uint _prevPressure;
+        private Vector2 _prevTilt;
+        private bool[] _prevPenButtons = Array.Empty<bool>();
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1ReportParser.cs
@@ -1,4 +1,5 @@
-﻿using OpenTabletDriver.Configurations.Parsers.Wacom.Intuos4;
+using System.Numerics;
+using OpenTabletDriver.Configurations.Parsers.Wacom.Intuos4;
 using OpenTabletDriver.Tablet;
 
 namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1
@@ -23,12 +24,18 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1
                 return new DeviceReport(report);
             if (report[1] == 0x80)
                 return new OutOfRangeReport(report);
+            if (report[1].IsBitSet(1) && report[1].IsBitSet(3))
+                return new IntuosV1RotationReport(report, ref _prevPressure, ref _prevTilt, ref _prevPenButtons);
             if (report[1].IsBitSet(5))
-                return new IntuosV1TabletReport(report);
+                return new IntuosV1TabletReport(report, ref _prevPressure, ref _prevTilt, ref _prevPenButtons);
             else if (report[1] == 0xC2)
                 return new IntuosV1ToolReport(report);
 
             return new DeviceReport(report);
         }
+
+        private uint _prevPressure = 0;
+        private Vector2 _prevTilt = new Vector2();
+        private bool[] _prevPenButtons = new bool[] {};
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1RotationReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1RotationReport.cs
@@ -17,7 +17,6 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1
             Tilt = _prevTilt;
             Pressure = _prevPressure;
 
-            var penByte = report[1];
             PenButtons = _prevPenButtons;
             HighConfidence = report[1].IsBitSet(6);
             HoverDistance = (uint)report[9];

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1RotationReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1RotationReport.cs
@@ -3,9 +3,9 @@ using OpenTabletDriver.Tablet;
 
 namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1
 {
-    public struct IntuosV1TabletReport : ITabletReport, IHoverReport, IConfidenceReport, ITiltReport
+    public struct IntuosV1RotationReport : ITabletReport, IHoverReport, IConfidenceReport, ITiltReport
     {
-        public IntuosV1TabletReport(byte[] report, ref uint _prevPressure, ref Vector2 _prevTilt, ref bool[] _prevPenButtons)
+        public IntuosV1RotationReport(byte[] report, ref uint _prevPressure, ref Vector2 _prevTilt, ref bool[] _prevPenButtons)
         {
             Raw = report;
 
@@ -14,22 +14,11 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1
                 X = (report[3] | report[2] << 8) << 1 | ((report[9] >> 1) & 1),
                 Y = (report[5] | report[4] << 8) << 1 | (report[9] & 1)
             };
-            Tilt = new Vector2
-            {
-                X = (((report[7] << 1) & 0x7E) | (report[8] >> 7)) - 64,
-                Y = (report[8] & 0x7F) - 64
-            };
-            _prevTilt = Tilt;
-            Pressure = (uint)((report[6] << 3) | ((report[7] & 0xC0) >> 5) | (report[1] & 1));
-            _prevPressure = Pressure;
+            Tilt = _prevTilt;
+            Pressure = _prevPressure;
 
             var penByte = report[1];
-            PenButtons = new bool[]
-            {
-                penByte.IsBitSet(1),
-                penByte.IsBitSet(2)
-            };
-            _prevPenButtons = PenButtons;
+            PenButtons = _prevPenButtons;
             HighConfidence = report[1].IsBitSet(6);
             HoverDistance = (uint)report[9];
         }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1TabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1TabletReport.cs
@@ -19,9 +19,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1
                 X = (((report[7] << 1) & 0x7E) | (report[8] >> 7)) - 64,
                 Y = (report[8] & 0x7F) - 64
             };
-            _prevTilt = Tilt;
             Pressure = (uint)((report[6] << 3) | ((report[7] & 0xC0) >> 5) | (report[1] & 1));
-            _prevPressure = Pressure;
 
             var penByte = report[1];
             PenButtons = new bool[]
@@ -29,9 +27,12 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1
                 penByte.IsBitSet(1),
                 penByte.IsBitSet(2)
             };
-            _prevPenButtons = PenButtons;
-            HighConfidence = report[1].IsBitSet(6);
+            HighConfidence = penByte.IsBitSet(6);
             HoverDistance = (uint)report[9];
+
+            _prevPressure = Pressure;
+            _prevTilt = Tilt;
+            _prevPenButtons = PenButtons;
         }
 
         public byte[] Raw { set; get; }


### PR DESCRIPTION
Currently, trying to use a ZP-600 or KP-701E pen with any wacom tablets that use the IntuosV1 parsers causes broken input. Pressure, tilt, and pen buttons flip between the normal values and the rotation report values every other report. 

These changes allow the pens to work as expected. (albeit missing the rotation parsing)

Tested on Wacom PTZ-431W, PTK-440, and DTK-1301.