### PR TITLE
Fix PrintScreen key mapping.

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/Keyboard/WindowsVirtualKeyboard.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Keyboard/WindowsVirtualKeyboard.cs
@@ -139,7 +139,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Keyboard
             { "Space", VirtualKey.VK_SPACE },
             { "CapsLock", VirtualKey.VK_CAPITAL },
             { "ScrollLock", VirtualKey.VK_SCROLL },
-            { "PrintScreen", VirtualKey.VK_PRINT },
+            { "PrintScreen", VirtualKey.VK_SNAPSHOT },
             { "NumberLock", VirtualKey.VK_NUMLOCK },
             { "Enter", VirtualKey.VK_RETURN },
             { "Escape", VirtualKey.VK_ESCAPE },


### PR DESCRIPTION
VK_PRINT keycode is from back in the days of the 83/84 key keyboard. To get PrintScreen working lets use VK_SNAPSHOT which is VK_PRINT+2. 
(ref. https://stackoverflow.com/questions/5815471/whats-the-purpose-of-vk-print)
Solution for https://github.com/OpenTabletDriver/OpenTabletDriver/issues/2728