### PR TITLE
Fix I/O hang when initializing XP-Pen Star G640

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640.json
@@ -27,7 +27,10 @@
         "ArAC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [
+        100,
+        110
+      ]
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],


### PR DESCRIPTION
Apparently, some firmware revisions of Star G640 hangs when these strings aren't sent first before vendor mode initialization.

Verification: https://discord.com/channels/615607687467761684/615611007951306863/1110214051503542293