### PR TITLE
Fix I/O hang when initializing XP-Pen Star G640

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640.json
@@ -29,7 +29,10 @@
         "ArAC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [
+        100,
+        110
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [],


### PR DESCRIPTION
Backports #2749 to `hotfix` branch