### PR TITLE
Fix HS611 configuration file with new hid

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/HS611.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/HS611.json
@@ -34,7 +34,23 @@
       "InitializationStrings": [
         200
       ]
+    },
+    {
+      "VendorID": 9580,
+      "ProductID": 111,
+      "InputReportLength": 12,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "201": "HUION_T19c_\\d{6}$"
+      },
+      "InitializationStrings": [
+        200
+      ]
     }
+
   ],
   "AuxilaryDeviceIdentifiers": [],
   "Attributes": {


### PR DESCRIPTION
As mentioned by the issue https://github.com/OpenTabletDriver/OpenTabletDriver/issues/2766 the newer version of the Huion HS611 have a different ProductID, which means it doesn't get recognized by the driver, so this pull requests adds the file with the new ProductID.
I was able to test that this fix works with my HS611, which had the same issue.