### PR TITLE
Fix pipeline race condition

### DIFF
--- a/OpenTabletDriver/InputDeviceTree.cs
+++ b/OpenTabletDriver/InputDeviceTree.cs
@@ -31,6 +31,7 @@ namespace OpenTabletDriver
         }
 
         private bool connected = true;
+        private object sync = new object();
         private IList<InputDevice> inputDevices;
 
         public event EventHandler<EventArgs>? Disconnected;
@@ -57,7 +58,10 @@ namespace OpenTabletDriver
 
         private void HandleReport(object? sender, IDeviceReport report)
         {
-            OutputMode?.Read(report);
+            lock (sync)
+            {
+                OutputMode?.Read(report);
+            }
         }
 
         public static implicit operator TabletReference(InputDeviceTree deviceGroup) => deviceGroup.CreateReference();


### PR DESCRIPTION
For devices with an auxiliary, it is possible to corrupt the pipeline's state when both digitizer and auxiliary reports about the same time. Synchronizing both to a mutex fixes that issue.