### PR TITLE
Make rpm package compatible with openSUSE

### DIFF
--- a/eng/linux/RedHat/package.sh
+++ b/eng/linux/RedHat/package.sh
@@ -50,7 +50,10 @@ Suggests: libX11
 Suggests: libXrandr
 Requires(post): udev
 Requires(post): grep
+
+%if 0%{?suse_version}
 Requires(post): /usr/bin/lsmod
+%endif
 
 %description
 ${OTD_LONG_DESC}

--- a/eng/linux/RedHat/package.sh
+++ b/eng/linux/RedHat/package.sh
@@ -42,18 +42,22 @@ BuildArch: x86_64
 License: LGPLv3
 URL: ${OTD_UPSTREAM_URL}
 
-AutoReq: 0
 BuildRequires: systemd-rpm-macros
 Requires: dotnet-runtime-6.0
-Requires: libevdev
+Requires: libevdev.so.2()(64bit)
 Requires: gtk3
 Suggests: libX11
 Suggests: libXrandr
+Requires(post): udev
+Requires(post): grep
+Requires(post): /usr/bin/lsmod
 
 %description
 ${OTD_LONG_DESC}
 
 ${OTD_LONG_DESC2}
+
+%global __requires_exclude_from ^/usr/lib/${OTD_LNAME}/.*$
 
 # No debug symbols
 %global debug_package %{nil}


### PR DESCRIPTION
The added `Requires(post)` is for satisfying `zypper`.

- Fixes #2794 