### PR TITLE
Bump issue labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,12 +4,11 @@ on:
     types: [opened]
   pull_request:
     types: [opened]
-
 jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: github/issue-labeler@v2.5
+    - uses: github/issue-labeler@v3.1
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler.yml


### PR DESCRIPTION
~~This action has not worked for months, but now fails completely presumably due to the GitHub action node update bump.~~

Bumped the dependency as it fixed the other issue as well as this one.