### PR TITLE
Add support for UGEE U1200 tablet

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/UGEE/U1200.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/U1200.json
@@ -2,8 +2,8 @@
   "Name": "UGEE U1200",
   "Specifications": {
     "Digitizer": {
-      "Width": 263.5,
-      "Height": 147.5,
+      "Width": 263.22,
+      "Height": 148.055,
       "MaxX": 52644,
       "MaxY": 29611
     },

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/U1200.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/U1200.json
@@ -1,0 +1,37 @@
+{
+  "Name": "UGEE U1200",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 263.5,
+      "Height": 147.5,
+      "MaxX": 52644,
+      "MaxY": 29611
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": null,
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 10429,
+      "ProductID": 2363,
+      "InputReportLength": 12,
+      "OutputReportLength": 12,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": [
+        "ArAE"
+      ],
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }
+  ],
+  "AuxiliaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -46,6 +46,7 @@
 | UC-Logic 1060N                |     Supported     |
 | UC-Logic PF1209               |     Supported     |
 | UGEE S640                     |     Supported     |
+| UGEE U1200                    |     Supported     |
 | UGEE U1600                    |     Supported     |
 | UGTABLET M708 V2              |     Supported     |
 | VEIKK A15                     |     Supported     |


### PR DESCRIPTION
I own the tablet, and thus tested it. I also measured the dimensions of the digitizer myself, as the ones on [UGEE's website](https://shop.ugee.com/products/ugee-drawing-tablet-1200) were off by about a millimeter.

Diagnostics: [u1200 diagnostics.txt](https://github.com/OpenTabletDriver/OpenTabletDriver/files/12135804/u1200.diagnostics.txt)
