### PR TITLE
Add fourth Huion H430P variant

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/H430P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H430P.json
@@ -27,7 +27,7 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {
-        "201": "HUION_T(176|18a)_\\d{6}$"
+        "201": "HUION_T(176|18a|21c)_\\d{6}$"
       },
       "InitializationStrings": [
         200
@@ -42,7 +42,7 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {
-        "201": "HUION_T(176|18a)_\\d{6}$"
+        "201": "HUION_T(176|18a|21c)_\\d{6}$"
       },
       "InitializationStrings": [
         200
@@ -57,7 +57,22 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {
-        "201": "HUION_T(176|18a)_\\d{6}$"
+        "201": "HUION_T(176|18a|21c)_\\d{6}$"
+      },
+      "InitializationStrings": [
+        200
+      ]
+    },
+    {
+      "VendorID": 9580,
+      "ProductID": 100,
+      "InputReportLength": 12,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "201": "HUION_T(176|18a|21c)_\\d{6}$"
       },
       "InitializationStrings": [
         200


### PR DESCRIPTION
Verification: https://discord.com/channels/615607687467761684/615611007951306863/1139957275566551130

The tablet in question used PID 100 and `HUION_T21c_\\d{6}$` string but I've added the string to other PIDs due to how flimsy Huion tends to be with PIDs it's likely another PID will need this.