### PR TITLE
Add default VSCode tasks and launch.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # IDE
 .vs/
-.vscode/
+.vscode/**
+!.vscode/launch.json
+!.vscode/tasks.json
 .idea/
 
 # Build Artifacts

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,71 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Daemon",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "Build Daemon",
+            "cwd": "${workspaceFolder}/OpenTabletDriver.Daemon/bin/Debug/net6.0",
+            "program": "${workspaceFolder}/OpenTabletDriver.Daemon/bin/Debug/net6.0/OpenTabletDriver.Daemon.dll",
+            "args": [
+              "--config",
+              "${workspaceFolder}/bin/Configurations"
+            ],
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "UX",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "Build UX",
+            "program": "",
+            "args": [],
+            "console": "internalConsole",
+            "stopAtEntry": false,
+            "windows": {
+                "cwd": "${workspaceFolder}/OpenTabletDriver.UX.Wpf/bin/Debug/net6.0-windows",
+                "program": "${workspaceFolder}/OpenTabletDriver.UX.Wpf/bin/Debug/net6.0-windows/OpenTabletDriver.UX.Wpf.dll",
+            },
+            "linux": {
+                "cwd": "${workspaceFolder}/OpenTabletDriver.UX.Gtk/bin/Debug/net6.0/",
+                "program": "${workspaceFolder}/OpenTabletDriver.UX.Gtk/bin/Debug/net6.0/OpenTabletDriver.UX.Gtk.dll",
+            },
+            "osx": {
+                "cwd": "${workspaceFolder}/OpenTabletDriver.UX.MacOS/bin/Debug/net6.0/OpenTabletDriver.UX.MacOS.app/Contents/MacOS/",
+                "program": "${workspaceFolder}/OpenTabletDriver.UX.MacOS/bin/Debug/net6.0/OpenTabletDriver.UX.MacOS.app/Contents/MacOS/OpenTabletDriver.UX.MacOS.dll",
+            }
+        },
+        {
+            "name": "Daemon (Persistent)",
+            "type": "coreclr",
+            "request": "launch",
+            "cwd": "${workspaceFolder}/bin",
+            "windows": {
+                "program": "${workspaceFolder}/bin/OpenTabletDriver.Daemon.exe",
+            },
+            "linux": {
+                "program": "${workspaceFolder}/bin/OpenTabletDriver.Daemon",
+            },
+            "args": [],
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "UX (Persistent)",
+            "type": "coreclr",
+            "request": "launch",
+            "cwd": "${workspaceFolder}/bin",
+            "windows": {
+                "program": "${workspaceFolder}/bin/OpenTabletDriver.UX.Wpf.exe",
+            },
+            "linux": {
+                "program": "${workspaceFolder}/bin/OpenTabletDriver.UX.Gtk",
+            },
+            "args": [],
+            "console": "internalConsole",
+            "stopAtEntry": false
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,62 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build Daemon",
+            "type": "process",
+            "isBuildCommand": true,
+            "command": "dotnet",
+            "args": [
+                "build",
+                "${workspaceFolder}/OpenTabletDriver.Daemon/OpenTabletDriver.Daemon.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Build UX",
+            "type": "process",
+            "isBuildCommand": true,
+            "command": "dotnet",
+            "args": [],
+            "problemMatcher": "$msCompile",
+            "windows": {
+                "args": [
+                    "build",
+                    "${workspaceFolder}/OpenTabletDriver.UX.Wpf/OpenTabletDriver.UX.Wpf.csproj",
+                    "/property:GenerateFullPaths=true",
+                    "/consoleloggerparameters:NoSummary"
+                ]
+            },
+            "linux": {
+                "args": [
+                    "build",
+                    "${workspaceFolder}/OpenTabletDriver.UX.Gtk/OpenTabletDriver.UX.Gtk.csproj",
+                    "/property:GenerateFullPaths=true",
+                    "/consoleloggerparameters:NoSummary"
+                ]
+            },
+            "osx": {
+                "args": [
+                    "build",
+                    "${workspaceFolder}/OpenTabletDriver.UX.MacOS/OpenTabletDriver.UX.MacOS.csproj",
+                    "/property:GenerateFullPaths=true",
+                    "/consoleloggerparameters:NoSummary"
+                ]
+            }
+        },
+        {
+            "label": "Build Persistent Binaries",
+            "type": "process",
+            "isBuildCommand": true,
+            "windows": {
+                "command": "./build.ps1"
+            },
+            "linux": {
+                "command": "./build.sh"
+            },
+            "problemMatcher": "$msCompile"
+        },
+    ]
+}


### PR DESCRIPTION
Taken from current `master`, specifically ed86667df7114ef3e28fd4402f7b608b66454981 and updated to use .NET 6.0 instead of 7.0.