### PR TITLE
Use elevated daemon to update on some installations

### DIFF
--- a/OpenTabletDriver.Console/CommandTools.cs
+++ b/OpenTabletDriver.Console/CommandTools.cs
@@ -1,109 +1,113 @@
 using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace OpenTabletDriver.Console
 {
     static class CommandTools
     {
+        private static Command SetupCommand<T>(T action, string description, params string[] aliases)
+            where T : Delegate
+        {
+            var command = new Command(action.Method.Name.ToLower(), description);
+            foreach (var alias in aliases.Skip(1))
+                command.AddAlias(alias);
+            return command;
+        }
+
+        private static Argument<T> SetupArgument<T>(Command command, string name)
+        {
+            var arg = new Argument<T>(name.ToLower());
+            command.AddArgument(arg);
+            return arg;
+        }
+
         public static Command CreateCommand(Func<Task> action, string description, params string[] aliases)
         {
-            var command = new Command(action.Method.Name.ToLower(), description)
-            {
-                Handler = CommandHandler.Create(action)
-            };
-            foreach (var alias in aliases)
-                command.AddAlias(alias);
+            var command = SetupCommand(action, description, aliases);
+            command.SetHandler(action);
             return command;
         }
 
         public static Command CreateCommand<T1>(Func<T1, Task> action, string description, params string[] aliases)
         {
             var parameters = action.Method.GetParameters();
-            var command = new Command(action.Method.Name.ToLower(), description)
-            {
-                new Argument<T1>(parameters[0].Name.ToLower())
-            };
-            command.Handler = CommandHandler.Create<T1>(action);
-            foreach (var alias in aliases)
-                command.AddAlias(alias);
+            var command = SetupCommand(action, description, aliases);
+
+            var arg1 = SetupArgument<T1>(command, parameters[0].Name.ToLower());
+            command.SetHandler(action, arg1);
+
             return command;
         }
 
         public static Command CreateCommand<T1, T2>(Func<T1, T2, Task> action, string description, params string[] aliases)
         {
             var parameters = action.Method.GetParameters();
-            var command = new Command(action.Method.Name.ToLower(), description)
-            {
-                new Argument<T1>(parameters[0].Name.ToLower()),
-                new Argument<T2>(parameters[1].Name.ToLower())
-            };
-            command.Handler = CommandHandler.Create<T1, T2>(action);
-            foreach (var alias in aliases)
-                command.AddAlias(alias);
+            var command = SetupCommand(action, description, aliases);
+
+            var arg1 = SetupArgument<T1>(command, parameters[0].Name.ToLower());
+            var arg2 = SetupArgument<T2>(command, parameters[1].Name.ToLower());
+            command.SetHandler(action, arg1, arg2);
+
             return command;
         }
 
         public static Command CreateCommand<T1, T2, T3>(Func<T1, T2, T3, Task> action, string description, params string[] aliases)
         {
             var parameters = action.Method.GetParameters();
-            var command = new Command(action.Method.Name.ToLower(), description)
-            {
-                new Argument<T1>(parameters[0].Name.ToLower()),
-                new Argument<T2>(parameters[1].Name.ToLower()),
-                new Argument<T3>(parameters[2].Name.ToLower())
-            };
-            command.Handler = CommandHandler.Create<T1, T2, T3>(action);
-            foreach (var alias in aliases)
-                command.AddAlias(alias);
+            var command = SetupCommand(action, description, aliases);
+
+            var arg1 = SetupArgument<T1>(command, parameters[0].Name.ToLower());
+            var arg2 = SetupArgument<T2>(command, parameters[1].Name.ToLower());
+            var arg3 = SetupArgument<T3>(command, parameters[2].Name.ToLower());
+            command.SetHandler(action, arg1, arg2, arg3);
+
             return command;
         }
 
         public static Command CreateCommand<T1, T2, T3, T4>(Func<T1, T2, T3, T4, Task> action, string description, params string[] aliases)
         {
             var parameters = action.Method.GetParameters();
-            var command = new Command(action.Method.Name.ToLower(), description)
-            {
-                new Argument<T1>(parameters[0].Name.ToLower()),
-                new Argument<T2>(parameters[1].Name.ToLower()),
-                new Argument<T3>(parameters[2].Name.ToLower()),
-                new Argument<T4>(parameters[3].Name.ToLower())
-            };
-            command.Handler = CommandHandler.Create<T1, T2, T3, T4>(action);
-            foreach (var alias in aliases)
-                command.AddAlias(alias);
+            var command = SetupCommand(action, description, aliases);
+
+            var arg1 = SetupArgument<T1>(command, parameters[0].Name.ToLower());
+            var arg2 = SetupArgument<T2>(command, parameters[1].Name.ToLower());
+            var arg3 = SetupArgument<T3>(command, parameters[2].Name.ToLower());
+            var arg4 = SetupArgument<T4>(command, parameters[3].Name.ToLower());
+            command.SetHandler(action, arg1, arg2, arg3, arg4);
+
             return command;
         }
 
         public static Command CreateCommand<T1, T2, T3, T4, T5>(Func<T1, T2, T3, T4, T5, Task> action, string description, params string[] aliases)
         {
             var parameters = action.Method.GetParameters();
-            var command = new Command(action.Method.Name.ToLower(), description)
-            {
-                new Argument<T1>(parameters[0].Name.ToLower()),
-                new Argument<T2>(parameters[1].Name.ToLower()),
-                new Argument<T3>(parameters[2].Name.ToLower()),
-                new Argument<T4>(parameters[3].Name.ToLower()),
-                new Argument<T5>(parameters[4].Name.ToLower())
-            };
-            command.Handler = CommandHandler.Create<T1, T2, T3, T4, T5>(action);
+            var command = SetupCommand(action, description, aliases);
+
+            var arg1 = SetupArgument<T1>(command, parameters[0].Name.ToLower());
+            var arg2 = SetupArgument<T2>(command, parameters[1].Name.ToLower());
+            var arg3 = SetupArgument<T3>(command, parameters[2].Name.ToLower());
+            var arg4 = SetupArgument<T4>(command, parameters[3].Name.ToLower());
+            var arg5 = SetupArgument<T5>(command, parameters[4].Name.ToLower());
+            command.SetHandler(action, arg1, arg2, arg3, arg4, arg5);
+
             return command;
         }
 
         public static Command CreateCommand<T1, T2, T3, T4, T5, T6>(Func<T1, T2, T3, T4, T5, T6, Task> action, string description, params string[] aliases)
         {
             var parameters = action.Method.GetParameters();
-            var command = new Command(action.Method.Name.ToLower(), description)
-            {
-                new Argument<T1>(parameters[0].Name.ToLower()),
-                new Argument<T2>(parameters[1].Name.ToLower()),
-                new Argument<T3>(parameters[2].Name.ToLower()),
-                new Argument<T4>(parameters[3].Name.ToLower()),
-                new Argument<T5>(parameters[4].Name.ToLower()),
-                new Argument<T6>(parameters[5].Name.ToLower())
-            };
-            command.Handler = CommandHandler.Create<T1, T2, T3, T4, T5, T6>(action);
+            var command = SetupCommand(action, description, aliases);
+
+            var arg1 = SetupArgument<T1>(command, parameters[0].Name.ToLower());
+            var arg2 = SetupArgument<T2>(command, parameters[1].Name.ToLower());
+            var arg3 = SetupArgument<T3>(command, parameters[2].Name.ToLower());
+            var arg4 = SetupArgument<T4>(command, parameters[3].Name.ToLower());
+            var arg5 = SetupArgument<T5>(command, parameters[4].Name.ToLower());
+            var arg6 = SetupArgument<T6>(command, parameters[5].Name.ToLower());
+            command.SetHandler(action, arg1, arg2, arg3, arg4, arg5, arg6);
+
             return command;
         }
     }

--- a/OpenTabletDriver.Console/Extensions.cs
+++ b/OpenTabletDriver.Console/Extensions.cs
@@ -7,10 +7,10 @@ namespace OpenTabletDriver.Console
 {
     public static class Extensions
     {
-        public static void AddRange(this Command command, IEnumerable<Symbol> symbols)
+        public static void AddCommands(this Command command, IEnumerable<Command> commands)
         {
-            foreach (var sym in symbols)
-                command.Add(sym);
+            foreach (var addedCommand in commands)
+                command.AddCommand(addedCommand);
         }
 
         public static string Format(this PluginSetting setting)

--- a/OpenTabletDriver.Console/Program.cs
+++ b/OpenTabletDriver.Console/Program.cs
@@ -26,14 +26,14 @@ namespace OpenTabletDriver.Console
                 Name = "otd"
             };
 
-            root.AddRange(IOCommands);
-            root.AddRange(ActionCommands);
-            root.AddRange(DebugCommands);
-            root.AddRange(ModifyCommands);
-            root.AddRange(RequestCommands);
-            root.AddRange(UpdateCommands);
-            root.AddRange(ListCommands);
-            root.AddRange(ScriptingCommands);
+            root.AddCommands(IOCommands);
+            root.AddCommands(ActionCommands);
+            root.AddCommands(DebugCommands);
+            root.AddCommands(ModifyCommands);
+            root.AddCommands(RequestCommands);
+            root.AddCommands(UpdateCommands);
+            root.AddCommands(ListCommands);
+            root.AddCommands(ScriptingCommands);
 
             return root;
         }

--- a/OpenTabletDriver.Daemon/Program.cs
+++ b/OpenTabletDriver.Daemon/Program.cs
@@ -47,7 +47,7 @@ namespace OpenTabletDriver.Daemon
                 var destination = updateCommandOptions.Destination.FullName;
                 var ret = 0;
 
-                using (var file = File.Open(Path.Join(AppInfo.Current.AppDataDirectory, "daemon-update.log"), FileMode.Truncate))
+                using (var file = File.Open(Path.Join(AppInfo.Current.AppDataDirectory, "daemon-update.log"), FileMode.Create))
                 {
                     var logger = new StreamWriter(file) { AutoFlush = true };
 

--- a/OpenTabletDriver.Daemon/Program.cs
+++ b/OpenTabletDriver.Daemon/Program.cs
@@ -1,21 +1,84 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTabletDriver.Desktop;
+using OpenTabletDriver.Desktop.Interop;
 using OpenTabletDriver.Desktop.RPC;
+using OpenTabletDriver.Desktop.Updater;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Components;
 
 namespace OpenTabletDriver.Daemon
 {
+    class CommandLineOptions
+    {
+        public object SpecialCommand { get; set; }
+        public DirectoryInfo AppDataDirectory { get; set; }
+        public DirectoryInfo ConfigurationDirectory { get; set; }
+    }
+
+    class UpdateCommandOptions
+    {
+        public List<DirectoryInfo> Sources { get; set; }
+        public DirectoryInfo Destination { get; set; }
+    }
+
     partial class Program
     {
         static async Task Main(string[] args)
         {
+            var cmdLineOptions = ParseCmdLineOptions(args);
+
+            if (!string.IsNullOrWhiteSpace(cmdLineOptions?.AppDataDirectory?.FullName))
+                AppInfo.Current.AppDataDirectory = cmdLineOptions.AppDataDirectory.FullName;
+            if (!string.IsNullOrWhiteSpace(cmdLineOptions?.ConfigurationDirectory?.FullName))
+                AppInfo.Current.ConfigurationDirectory = cmdLineOptions.ConfigurationDirectory.FullName;
+
+            if (cmdLineOptions.SpecialCommand is UpdateCommandOptions updateCommandOptions)
+            {
+                var sources = updateCommandOptions.Sources.Select(x => x.FullName).ToArray();
+                var destination = updateCommandOptions.Destination.FullName;
+                var ret = 0;
+
+                using (var file = File.Open(Path.Join(AppInfo.Current.AppDataDirectory, "daemon-update.log"), FileMode.Truncate))
+                {
+                    var logger = new StreamWriter(file) { AutoFlush = true };
+
+                    await logger.WriteLineAsync("Starting update using following files...");
+                    foreach (var source in sources)
+                        await logger.WriteLineAsync($" {source}");
+                    await logger.WriteLineAsync($"Destination: {destination}");
+
+                    try
+                    {
+                        await DesktopInterop.Updater.Install(
+                            // bypass CheckForUpdate
+                            new Update(
+                                new Version(0, 0, 0, 0),
+                                sources.ToImmutableArray(),
+                                destination
+                            )
+                        );
+                        await logger.WriteLineAsync("Update complete.");
+                    }
+                    catch (Exception ex)
+                    {
+                        await logger.WriteLineAsync(ex.ToString());
+                        await logger.WriteLineAsync("Update failed!");
+                        ret = 1;
+                    }
+                }
+
+                Environment.Exit(ret);
+            }
+
             using (var instance = new Instance("OpenTabletDriver.Daemon"))
             {
                 if (instance.AlreadyExists)
@@ -41,31 +104,73 @@ namespace OpenTabletDriver.Daemon
                     );
                 };
 
-                var rootCommand = new RootCommand("OpenTabletDriver")
-                {
-                    new Option(new string[] { "--appdata", "-a" }, "Application data directory")
-                    {
-                        Argument = new Argument<DirectoryInfo>("appdata")
-                    },
-                    new Option(new string[] { "--config", "-c" }, "Configuration directory")
-                    {
-                        Argument = new Argument<DirectoryInfo> ("config")
-                    }
-                };
-                rootCommand.Handler = CommandHandler.Create<DirectoryInfo, DirectoryInfo>((appdata, config) =>
-                {
-                    if (!string.IsNullOrWhiteSpace(appdata?.FullName))
-                        AppInfo.Current.AppDataDirectory = appdata.FullName;
-                    if (!string.IsNullOrWhiteSpace(config?.FullName))
-                        AppInfo.Current.ConfigurationDirectory = config.FullName;
-                });
-                rootCommand.Invoke(args);
-
                 var host = new RpcHost<DriverDaemon>("OpenTabletDriver.Daemon");
                 host.ConnectionStateChanged += (sender, state) =>
                     Log.Write("IPC", $"{(state ? "Connected to" : "Disconnected from")} a client.", LogLevel.Debug);
 
                 await host.Run(BuildDaemon());
+            }
+        }
+
+        static CommandLineOptions ParseCmdLineOptions(string[] args)
+        {
+            var cmdLineOptions = new CommandLineOptions();
+
+            var rootCommand = new RootCommand("OpenTabletDriver")
+            {
+                TreatUnmatchedTokensAsErrors = true
+            };
+
+            var updateCommand = new Command("update") { IsHidden = true };
+
+            rootCommand.AddCommand(updateCommand);
+
+            var appDataOption = new Option<DirectoryInfo>(
+                aliases: new[] { "--appdata", "-a" },
+                description: "Application data directory"
+            );
+
+            var configOption = new Option<DirectoryInfo>(
+                aliases: new[] { "--config", "-c" },
+                description: "Configuration directory"
+            );
+
+            rootCommand.AddGlobalOption(appDataOption);
+            rootCommand.AddGlobalOption(configOption);
+
+            rootCommand.SetHandler(setupGlobalOptions, appDataOption, configOption);
+
+            var sourcesArg = new Option<List<DirectoryInfo>>("--sources")
+            {
+                IsRequired = true,
+                AllowMultipleArgumentsPerToken = true
+            };
+            var destArg = new Option<DirectoryInfo>("--destination")
+            {
+                IsRequired = true
+            };
+
+            updateCommand.AddOption(sourcesArg);
+            updateCommand.AddOption(destArg);
+
+            updateCommand.SetHandler((appData, config, src, dest) =>
+            {
+                setupGlobalOptions(appData, config);
+                cmdLineOptions.SpecialCommand = new UpdateCommandOptions
+                {
+                    Sources = src,
+                    Destination = dest
+                };
+            }, appDataOption, configOption, sourcesArg, destArg);
+
+            rootCommand.Invoke(args);
+
+            return cmdLineOptions;
+
+            void setupGlobalOptions(DirectoryInfo appData, DirectoryInfo config)
+            {
+                cmdLineOptions.AppDataDirectory = appData;
+                cmdLineOptions.ConfigurationDirectory = config;
             }
         }
 

--- a/OpenTabletDriver.Desktop/OpenTabletDriver.Desktop.csproj
+++ b/OpenTabletDriver.Desktop/OpenTabletDriver.Desktop.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="StreamJsonRpc" Version="2.6.121" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20253.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="WaylandNET" Version="0.2.0" />
   </ItemGroup>
 

--- a/OpenTabletDriver.Desktop/Updater/IUpdate.cs
+++ b/OpenTabletDriver.Desktop/Updater/IUpdate.cs
@@ -5,10 +5,11 @@ namespace OpenTabletDriver.Desktop.Updater
 {
     public record Update
     {
-        public Update(Version version, ImmutableArray<string> paths)
+        public Update(Version version, ImmutableArray<string> paths, string binaryDirectory)
         {
             Version = version;
             Paths = paths;
+            BinaryDirectory = binaryDirectory;
         }
 
         public Version Version { get; init; }
@@ -17,5 +18,10 @@ namespace OpenTabletDriver.Desktop.Updater
         /// Gets the paths of files/directories directly in the root of the update.
         /// </summary>
         public ImmutableArray<string> Paths { get; init; }
+
+        /// <summary>
+        /// Gets the directory where updated binaries are to be installed.
+        /// </summary>
+        public string BinaryDirectory { get; init; }
     }
 }

--- a/OpenTabletDriver.Desktop/Updater/MacOSUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/MacOSUpdater.cs
@@ -46,7 +46,8 @@ namespace OpenTabletDriver.Desktop.Updater
 
             return new Update(
                 version,
-                ImmutableArray.Create(Directory.GetFileSystemEntries(downloadPath))
+                ImmutableArray.Create(Directory.GetFileSystemEntries(downloadPath)),
+                BinaryDirectory
             );
         }
     }

--- a/OpenTabletDriver.Tests/Fakes/FakeUpdater.cs
+++ b/OpenTabletDriver.Tests/Fakes/FakeUpdater.cs
@@ -32,7 +32,8 @@ namespace OpenTabletDriver.Tests.Updater
 
             _update = new Update(
                 version,
-                ImmutableArray.Create(Directory.GetFileSystemEntries(_downloadPath))
+                ImmutableArray.Create(Directory.GetFileSystemEntries(_downloadPath)),
+                BinaryDirectory
             );
         }
 

--- a/OpenTabletDriver.UX/DaemonWatchdog.cs
+++ b/OpenTabletDriver.UX/DaemonWatchdog.cs
@@ -53,6 +53,7 @@ namespace OpenTabletDriver.UX
 
         public void Stop()
         {
+            DaemonExited = null; // unregister all event handlers
             this.daemonProcess?.Kill();
             this.daemonProcess?.Dispose();
             this.daemonProcess = null;

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -80,6 +80,8 @@ namespace OpenTabletDriver.UX
         private Placeholder placeholder;
         private TrayIcon trayIcon;
 
+        public bool SilenceDaemonShutdown { get; set; }
+
         protected override void InitializeForm()
         {
             var bounds = Screen.FromPoint(Mouse.Position).Bounds;
@@ -412,6 +414,9 @@ namespace OpenTabletDriver.UX
 
         private void HandleDaemonDisconnected(object sender, EventArgs e)
         {
+            if (SilenceDaemonShutdown)
+                return;
+
             // Hide all controls until reconnected
             Application.Instance.Invoke(() =>
             {


### PR DESCRIPTION
Fixes issues with some install environment on Windows where OpenTabletDriver has no access to its own folder due to it being placed inside an Admin-owned folder (no write access to a non-elevated user).

An example would be placing OpenTabletDriver inside `C:\Program Files\OpenTabletDriver`.