### PR TITLE
Handle binding before output

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -236,7 +236,6 @@ namespace OpenTabletDriver.Daemon
                         Log.Write(group, $"Output mode: {outputModeName}");
 
                         var outputMode = device.OutputMode;
-                        SetOutputModeSettings(device, outputMode, profile);
 
                         var mouseButtonHandler = (outputMode as IMouseButtonSource)?.MouseButtonHandler;
 
@@ -248,10 +247,7 @@ namespace OpenTabletDriver.Daemon
                         }.Where(o => o != null).ToArray() as object[];
 
                         var bindingHandler = _serviceProvider.CreateInstance<BindingHandler>(deps);
-
-                        var lastElement = outputMode.Elements?.LastOrDefault() ??
-                                        outputMode as IPipelineElement<IDeviceReport>;
-                        lastElement.Emit += bindingHandler.Consume;
+                        SetOutputModeElements(device, outputMode, profile, bindingHandler);
                     }
                 }
 
@@ -306,7 +302,7 @@ namespace OpenTabletDriver.Daemon
             await DetectTablets();
         }
 
-        private void SetOutputModeSettings(InputDevice dev, IOutputMode outputMode, Profile profile)
+        private void SetOutputModeElements(InputDevice dev, IOutputMode outputMode, Profile profile, BindingHandler bindingHandler)
         {
             string group = dev.Configuration.Name;
 
@@ -316,7 +312,7 @@ namespace OpenTabletDriver.Daemon
                 where filter != null
                 select filter;
 
-            outputMode.Elements = elements.ToList();
+            outputMode.Elements = elements.Append(bindingHandler).ToList();
 
             if (outputMode.Elements.Any())
                 Log.Write(group, $"Filters: {string.Join(", ", outputMode.Elements)}");

--- a/OpenTabletDriver.Desktop/Binding/BindingHandler.cs
+++ b/OpenTabletDriver.Desktop/Binding/BindingHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenTabletDriver.Attributes;
 using OpenTabletDriver.Desktop.Profiles;
 using OpenTabletDriver.Desktop.Reflection;
 using OpenTabletDriver.Output;
@@ -9,6 +10,7 @@ using OpenTabletDriver.Tablet;
 
 namespace OpenTabletDriver.Desktop.Binding
 {
+    [PluginIgnore]
     public class BindingHandler : IDevicePipelineElement
     {
         private readonly InputDevice _device;

--- a/OpenTabletDriver.Desktop/Binding/BindingHandler.cs
+++ b/OpenTabletDriver.Desktop/Binding/BindingHandler.cs
@@ -9,7 +9,7 @@ using OpenTabletDriver.Tablet;
 
 namespace OpenTabletDriver.Desktop.Binding
 {
-    public class BindingHandler : IPipelineElement<IDeviceReport>
+    public class BindingHandler : IDevicePipelineElement
     {
         private readonly InputDevice _device;
         private readonly IServiceProvider _serviceProvider;
@@ -19,12 +19,6 @@ namespace OpenTabletDriver.Desktop.Binding
         {
             _serviceProvider = serviceProvider;
             _device = device;
-
-            var outputMode = _device.OutputMode!;
-
-            // Force consume all reports from the last element
-            var lastElement = outputMode.Elements?.LastOrDefault() ?? (IPipelineElement<IDeviceReport>)outputMode;
-            lastElement.Emit += Consume;
 
             Tip = CreateBindingState<ThresholdBindingState>(settings.TipButton, device, mouseButtonHandler);
 
@@ -52,6 +46,8 @@ namespace OpenTabletDriver.Desktop.Binding
 
         private BindingState? MouseScrollDown { get; }
         private BindingState? MouseScrollUp { get; }
+
+        public PipelinePosition Position => PipelinePosition.PostTransform;
 
         public event Action<IDeviceReport>? Emit;
 


### PR DESCRIPTION
Pointer events are send on flush since #2764, hence mouse button binding have to happens before output.