### PR TITLE
Support modifier click, double click, tilt and pressure for macOS

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/MacOSAbsolutePointer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/MacOSAbsolutePointer.cs
@@ -9,7 +9,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
 {
     using static MacOS;
 
-    public class MacOSAbsolutePointer : MacOSVirtualMouse, IAbsolutePointer
+    public class MacOSAbsolutePointer : MacOSVirtualMouse, IAbsolutePointer, IPressureHandler
     {
         private Vector2 offset;
 
@@ -23,6 +23,11 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
         {
             var newPos = pos - offset;
             QueuePendingPosition(newPos.X, newPos.Y);
+        }
+
+        public void SetPressure(float percentage)
+        {
+            base.setPressure(percentage);
         }
 
         protected override void SetPendingPosition(IntPtr mouseEvent, float x, float y)

--- a/OpenTabletDriver.Desktop/Interop/Input/MacOSVirtualMouse.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/MacOSVirtualMouse.cs
@@ -1,28 +1,57 @@
 using System;
+using System.Diagnostics;
+using System.Numerics;
 using OpenTabletDriver.Native.MacOS;
 using OpenTabletDriver.Native.MacOS.Input;
+using OpenTabletDriver.Native.OSX.Input;
 using OpenTabletDriver.Platform.Pointer;
 
 namespace OpenTabletDriver.Desktop.Interop.Input
 {
     using static MacOS;
 
-    public abstract class MacOSVirtualMouse : IMouseButtonHandler, ISynchronousPointer
+    public abstract class MacOSVirtualMouse : IMouseButtonHandler, ISynchronousPointer, ITiltHandler, IEraserHandler
     {
+        private const int _DoubleClickMoveTolerance = 8;
+        private const int _ProximityExpiresDurationInMs = 200;
+
         private int _currButtonStates;
         private int _prevButtonStates;
         private float? _pendingX;
         private float? _pendingY;
+        private float? _pressure;
+        private Vector2? _tilt;
+        private bool? _isEraser;
         private CGMouseButton _lastButton;
-        private readonly IntPtr _mouseEvent = CGEventCreate(IntPtr.Zero);
+        private Vector2 _lastMouseDownPosition;
+        private bool _mouseMovedSinceLastDown;
+        private int _clickState;
+        private readonly Stopwatch _stopWatch;
+        private readonly Stopwatch _doubleClickStopWatch;
+        private readonly IntPtr _eventSource;
+        private readonly IntPtr _mouseEvent;
+        private readonly double _doubleClickIntervalInMs;
+
+        public MacOSVirtualMouse()
+        {
+
+            _doubleClickIntervalInMs = GetDoubleClickInterval() * 1000;
+            _doubleClickStopWatch = new Stopwatch();
+            _stopWatch = new Stopwatch();
+            _stopWatch.Start();
+            _eventSource = CGEventSourceCreate(CGEventSourceStateHIDSystemState);
+            _mouseEvent = CGEventCreate(_eventSource);
+        }
 
         public void MouseDown(MouseButton button)
         {
+            QueuePendingPositionFromSystem();
             SetButtonState(ref _currButtonStates, ToCGMouseButton(button), true);
         }
 
         public void MouseUp(MouseButton button)
         {
+            QueuePendingPositionFromSystem();
             SetButtonState(ref _currButtonStates, ToCGMouseButton(button), false);
         }
 
@@ -40,6 +69,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input
                 var lastButtonSet = IsButtonSet(_currButtonStates, _lastButton);
                 var cgEventType = ToDragCGEventType(_lastButton, lastButtonSet);
                 CGEventSetType(_mouseEvent, cgEventType);
+                ApplyTabletValues();
                 CGEventPost(CGEventTapLocation.kCGHIDEventTap, _mouseEvent);
             }
         }
@@ -55,6 +85,16 @@ namespace OpenTabletDriver.Desktop.Interop.Input
             }
         }
 
+        public void SetEraser(bool isEraser)
+        {
+            _isEraser = isEraser;
+        }
+
+        public void SetTilt(Vector2 tilt)
+        {
+            _tilt = tilt;
+        }
+
         protected abstract void SetPendingPosition(IntPtr mouseEvent, float x, float y);
         protected abstract void ResetPendingPosition(IntPtr mouseEvent);
 
@@ -62,13 +102,22 @@ namespace OpenTabletDriver.Desktop.Interop.Input
         {
             _pendingX = x;
             _pendingY = y;
+            if (Vector2.Distance(_lastMouseDownPosition, new Vector2(x, y)) > _DoubleClickMoveTolerance)
+            {
+                _mouseMovedSinceLastDown = true;
+            }
+        }
+
+        protected void setPressure(float percentage)
+        {
+            _pressure = percentage;
         }
 
         private bool DrainPendingPosition()
         {
             if (_pendingX.HasValue)
             {
-                SetPendingPosition(_mouseEvent, _pendingX.Value, _pendingY.Value);
+                SetPendingPosition(_mouseEvent, _pendingX.Value, _pendingY!.Value);
                 _pendingX = null;
                 _pendingY = null;
                 return true;
@@ -87,6 +136,30 @@ namespace OpenTabletDriver.Desktop.Interop.Input
 
                 if (currState != prevState)
                 {
+                    var doubleClickInvalidated = _mouseMovedSinceLastDown || _doubleClickStopWatch.ElapsedMilliseconds > _doubleClickIntervalInMs;
+
+                    if (currState)
+                    {
+                        if (_pendingX.HasValue && (_clickState == 0 || doubleClickInvalidated))
+                        {
+                            _doubleClickStopWatch.Reset();
+                            _lastMouseDownPosition = new Vector2(_pendingX.Value, _pendingY!.Value);
+                            _mouseMovedSinceLastDown = false;
+                            _clickState = 1;
+                        }
+                        else
+                        {
+                            _clickState++;
+                        }
+                    }
+                    else
+                    {
+                        if (doubleClickInvalidated)
+                        {
+                            _clickState = 0;
+                        }
+                    }
+
                     // prepare the mouse event, we reset it here in case
                     // it's a relative event
                     ResetPendingPosition(_mouseEvent);
@@ -97,8 +170,8 @@ namespace OpenTabletDriver.Desktop.Interop.Input
 
                     CGEventSetType(_mouseEvent, cgEventType);
                     CGEventSetIntegerValueField(_mouseEvent, CGEventField.mouseEventButtonNumber, i);
-                    CGEventSetIntegerValueField(_mouseEvent, CGEventField.mouseEventClickState, 1); // clickState should be set to 1 (or more) during up, down, and drag events
-
+                    CGEventSetIntegerValueField(_mouseEvent, CGEventField.mouseEventClickState, _clickState); // clickState should be set to 1 (or more) during up, down, and drag events
+                    ApplyTabletValues();
                     CGEventPost(CGEventTapLocation.kCGHIDEventTap, _mouseEvent);
 
                     _lastButton = button;
@@ -107,9 +180,8 @@ namespace OpenTabletDriver.Desktop.Interop.Input
 
             if (currButtonStates == 0)
             {
-                // no buttons are pressed, reset button and click state to 0
+                // no buttons are pressed, reset button to 0
                 CGEventSetIntegerValueField(_mouseEvent, CGEventField.mouseEventButtonNumber, 0);
-                CGEventSetIntegerValueField(_mouseEvent, CGEventField.mouseEventClickState, 0);
             }
         }
 
@@ -161,6 +233,86 @@ namespace OpenTabletDriver.Desktop.Interop.Input
                 buttonStates |= 1 << (int)button;
             else
                 buttonStates &= ~(1 << (int)button);
+        }
+
+        private void ApplyTabletValues()
+        {
+            // send proximity events if there are no reports for a while.
+            if (_currButtonStates == 0)
+            {
+                var elapsed = _stopWatch.ElapsedMilliseconds;
+                _stopWatch.Restart();
+                if (elapsed > _ProximityExpiresDurationInMs)
+                {
+                    var pointerType = _isEraser ?? false ?
+                            NSPointingDeviceType.Eraser : NSPointingDeviceType.Pen;
+
+                    var proximityEvent = CGEventCreate(_eventSource);
+                    CGEventSetType(proximityEvent, CGEventType.kCGEventTabletProximity);
+                    CGEventSetIntegerValueField(proximityEvent, CGEventField.tabletProximityEventEnterProximity, 1);
+                    CGEventSetIntegerValueField(proximityEvent, CGEventField.tabletProximityEventPointerType, (long)(_isEraser ?? false ?
+                            NSPointingDeviceType.Eraser : NSPointingDeviceType.Pen));
+                    CGEventPost(CGEventTapLocation.kCGHIDEventTap, proximityEvent);
+                    CFRelease(proximityEvent);
+
+                    CGEventSetIntegerValueField(_mouseEvent, CGEventField.mouseEventSubtype, (long)CGMouseEventSubtype.TabletProximity);
+                    CGEventSetIntegerValueField(_mouseEvent, CGEventField.tabletProximityEventEnterProximity, 1);
+                    CGEventSetIntegerValueField(_mouseEvent, CGEventField.tabletProximityEventPointerType, (long)pointerType);
+                    return;
+                }
+            }
+
+            // Qt < 5.9 interprets kCGTabletEventPointButtons as left, right, middle mouse click.
+            // see https://codereview.qt-project.org/c/qt/qtbase/+/180717
+            int buttons = 0;
+            if (IsButtonSet(_currButtonStates, CGMouseButton.kCGMouseButtonLeft))
+                buttons |= 1;
+            else if (IsButtonSet(_currButtonStates, CGMouseButton.kCGMouseButtonRight))
+                buttons |= 2;
+            else if (IsButtonSet(_currButtonStates, CGMouseButton.kCGMouseButtonCenter))
+                buttons |= 4;
+            CGEventSetIntegerValueField(_mouseEvent, CGEventField.tabletEventPointButtons, buttons);
+
+            CGEventSetIntegerValueField(_mouseEvent, CGEventField.mouseEventSubtype, (long)CGMouseEventSubtype.TabletPoint);
+            CGEventSetDoubleValueField(_mouseEvent, CGEventField.mouseEventPressure, _pressure ?? 1.0);
+            CGEventSetDoubleValueField(_mouseEvent, CGEventField.tabletEventPointPressure, _pressure ?? 1.0);
+
+            if (_tilt != null)
+            {
+                CGEventSetDoubleValueField(_mouseEvent, CGEventField.tabletEventTiltX, _tilt.Value.X / 90.0);
+                // TiltY is inverted on MacOS
+                // see https://github.com/chromium/chromium/blob/62f1a92b04c1172431a64d581be9e64742c81576/content/browser/renderer_host/input/web_input_event_builders_mac.mm#L431
+                CGEventSetDoubleValueField(_mouseEvent, CGEventField.tabletEventTiltY, -_tilt.Value.Y / 90.0);
+            }
+
+            // set keyboard modifier and filter out `nonCoalesced` and 0x20000000 flags
+            // see https://github.com/Hammerspoon/hammerspoon/blob/0ccc9d07641a660140d1d2f05b76f682b501a0e8/extensions/eventtap/libeventtap_event.m#L1558-L1560
+            CGEventSetFlags(_mouseEvent, CGEventSourceFlagsState(CGEventSourceStateHIDSystemState) & (0xffffffff ^ 0x20000100));
+        }
+
+        // binding can be triggered by auxiliary buttons and cursor might be moved by other devices.
+        // in such case we fetch the position from system.
+        private void QueuePendingPositionFromSystem()
+        {
+            if (!_pendingX.HasValue)
+            {
+                var eventRef = CGEventCreate(IntPtr.Zero);
+                var pos = CGEventGetLocation(eventRef);
+                CFRelease(eventRef);
+                QueuePendingPosition((float)pos.x, (float)pos.y);
+            }
+        }
+
+        ~MacOSVirtualMouse()
+        {
+            if (_eventSource != IntPtr.Zero)
+            {
+                CFRelease(_eventSource);
+            }
+            if (_mouseEvent != IntPtr.Zero)
+            {
+                CFRelease(_mouseEvent);
+            }
         }
     }
 }

--- a/OpenTabletDriver.Desktop/Interop/Input/Relative/MacOSRelativePointer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Relative/MacOSRelativePointer.cs
@@ -10,7 +10,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Relative
 {
     using static MacOS;
 
-    public class MacOSRelativePointer : MacOSVirtualMouse, IRelativePointer
+    public class MacOSRelativePointer : MacOSVirtualMouse, IRelativePointer, IPressureHandler
     {
         private CGPoint offset;
 
@@ -25,6 +25,11 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Relative
             QueuePendingPosition(delta.X, delta.Y);
         }
 
+        public void SetPressure(float percentage)
+        {
+            base.setPressure(percentage);
+        }
+        
         protected override void SetPendingPosition(IntPtr mouseEvent, float x, float y)
         {
             CGEventSetLocation(mouseEvent, GetCursorPosition() + new CGPoint(x, y));

--- a/OpenTabletDriver.Native.MacOS/Generic/NSPointingDeviceType.cs
+++ b/OpenTabletDriver.Native.MacOS/Generic/NSPointingDeviceType.cs
@@ -1,0 +1,7 @@
+public enum NSPointingDeviceType
+{
+    Unknown = 0,
+    Pen = 1,
+    Cursor = 2,
+    Eraser = 3
+}

--- a/OpenTabletDriver.Native.MacOS/Input/CGEventField.cs
+++ b/OpenTabletDriver.Native.MacOS/Input/CGEventField.cs
@@ -23,5 +23,11 @@ namespace OpenTabletDriver.Native.MacOS.Input
         scrollWheelEventPointDeltaAxis2 = 97, // int
         scrollWheelEventPointDeltaAxis3 = 98, // int
         scrollWheelEventInstantMouser = 14, // int
+        tabletEventPointButtons = 18, //int
+        tabletEventPointPressure = 19, //double
+        tabletEventTiltX = 20, // double
+        tabletEventTiltY = 21, // double
+        tabletProximityEventPointerType = 37, //int
+        tabletProximityEventEnterProximity = 38, //int
     }
 }

--- a/OpenTabletDriver.Native.MacOS/Input/CGEventType.cs
+++ b/OpenTabletDriver.Native.MacOS/Input/CGEventType.cs
@@ -12,6 +12,7 @@
         kCGEventRightMouseDragged = 7,
         kCGEventKeyDown = 10,
         kCGEventKeyUp = 11,
+        kCGEventTabletProximity = 24,
         kCGEventOtherMouseDown = 25,
         kCGEventOtherMouseUp = 26,
         kCGEventOtherMouseDragged = 27

--- a/OpenTabletDriver.Native.MacOS/Input/CGMouseEventSubtype.cs
+++ b/OpenTabletDriver.Native.MacOS/Input/CGMouseEventSubtype.cs
@@ -1,0 +1,9 @@
+﻿namespace OpenTabletDriver.Native.OSX.Input
+{
+    public enum CGMouseEventSubtype : long
+    {
+        Default = 0,
+        TabletPoint = 1,
+        TabletProximity = 2
+    }
+}

--- a/OpenTabletDriver.Native.MacOS/OSX.cs
+++ b/OpenTabletDriver.Native.MacOS/OSX.cs
@@ -5,6 +5,7 @@ using OpenTabletDriver.Native.MacOS.Input;
 
 namespace OpenTabletDriver.Native.MacOS
 {
+    using static ObjectiveCRuntime;
     using CGDirectDisplayID = UInt32;
     using CGError = Int32;
     using CGEventRef = IntPtr;
@@ -12,8 +13,17 @@ namespace OpenTabletDriver.Native.MacOS
 
     public static class MacOS
     {
+        public const int CGEventSourceStateHIDSystemState = 1;
+
         private const string Quartz = "/System/Library/Frameworks/Quartz.framework/Versions/Current/Quartz";
         private const string Foundation = "/System/Library/Frameworks/Foundation.framework/Foundation";
+        private const string AppKit = "/System/Library/Frameworks/AppKit.framework/AppKit";
+
+        static MacOS()
+        {
+            LibSystem.dlopen(AppKit, 0);
+        }
+
 
         [DllImport(Foundation)]
         public static extern void CFRelease(IntPtr handle);
@@ -44,6 +54,15 @@ namespace OpenTabletDriver.Native.MacOS
         public extern static void CGEventSetLocation(CGEventRef eventRef, CGPoint location);
 
         [DllImport(Quartz)]
+        public extern static void CGEventSetFlags(CGEventRef eventRef, ulong flags);
+
+        [DllImport(Quartz)]
+        public extern static CGEventSourceRef CGEventSourceCreate(int stateID);
+
+        [DllImport(Quartz)]
+        public extern static ulong CGEventSourceFlagsState(int stateID);
+
+        [DllImport(Quartz)]
         public extern static CGEventRef CGEventPost(CGEventTapLocation tap, CGEventRef eventRef);
 
         [DllImport(Quartz)]
@@ -52,5 +71,10 @@ namespace OpenTabletDriver.Native.MacOS
 
         [DllImport(Quartz)]
         public extern static CGRect CGDisplayBounds(CGDirectDisplayID displayID);
+
+        public static double GetDoubleClickInterval()
+        {
+            return objc_msgSend_double(objc_getClass("NSEvent"), sel_registerName("doubleClickInterval"));
+        }
     }
 }

--- a/OpenTabletDriver.Native.MacOS/ObjectiveCRuntime.cs
+++ b/OpenTabletDriver.Native.MacOS/ObjectiveCRuntime.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace OpenTabletDriver.Native.MacOS
+{
+    public static class ObjectiveCRuntime
+    {
+        private const string ObjCLibrary = "/usr/lib/libobjc.A.dylib";
+
+        [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
+        public static extern double objc_msgSend_double(IntPtr receiver, IntPtr selector);
+
+        [DllImport(ObjCLibrary, CharSet = CharSet.Ansi)]
+        public static extern IntPtr sel_registerName(string name);
+
+        [DllImport(ObjCLibrary, CharSet = CharSet.Ansi)]
+        public static extern IntPtr objc_getClass(string namePtr);
+    }
+}
+


### PR DESCRIPTION
Finishing  #2371
Fix #2871, #2291

Dedicated artist mode seems unnecessary for macOS as it does not change the behaviour like Windows Ink.

The tilt functionality has not been tested with a real device, so the scale normalisation may differ from that of the official driver.

