### PR TITLE
Add new identifier to UGEE S640

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/UGEE/S640.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/S640.json
@@ -30,6 +30,19 @@
       ],
       "DeviceStrings": {},
       "InitializationStrings": []
+    },
+    {
+      "VendorID": 10429,
+      "ProductID": 2359,
+      "InputReportLength": 12,
+      "OutputReportLength": 12,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": [
+        "ArAE"
+      ],
+      "DeviceStrings": {},
+      "InitializationStrings": []
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],


### PR DESCRIPTION
fixes #2896 

No idea if I can do 12 null in this case because I think I recall some issues with stuff like that in the past.