### PR TITLE
Add new string to Gaomon 1060 Pro

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/1060 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/1060 Pro.json
@@ -72,7 +72,7 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {
-        "201": "GM001_T213_\\d{6}$"
+        "201": "GM001_(T213|T216)_\\d{6}$"
       },
       "InitializationStrings": [
         200


### PR DESCRIPTION
supposedly fixes #2865, waiting for the user to confirm at this time. Opening as draft until we receive this.

Adding support with the string `GM001_T216_220814` for tablet `Index 2: Gaomon Tablet_1060Pro`