### PR TITLE
Add support for Wacom PTU-600U

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTU-600U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTU-600U.json
@@ -1,0 +1,35 @@
+{
+  "Name": "Wacom PTU-600U",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 204.8,
+      "Height": 153.6,
+      "MaxX": 20480.0,
+      "MaxY": 15360.0
+    },
+    "Pen": {
+      "MaxPressure": 511,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": null,
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 1386,
+      "ProductID": 3,
+      "InputReportLength": 8,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.PTU.PTUReportParser",
+      "FeatureInitReport": [
+        "AgI="
+      ],
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }
+  ],
+  "AuxiliaryDeviceIdentifiers": [],
+  "Attributes": {}
+}

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/PTU/PTUReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/PTU/PTUReportParser.cs
@@ -1,0 +1,12 @@
+using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Wacom.PTU
+{
+    public class PTUReportParser : IReportParser<IDeviceReport>
+    {
+        public virtual IDeviceReport Parse(byte[] report)
+        {
+            return new PTUTabletReport(report);
+        }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/PTU/PTUTabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/PTU/PTUTabletReport.cs
@@ -1,0 +1,36 @@
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Wacom.PTU
+{
+    public struct PTUTabletReport : ITabletReport, IEraserReport, IConfidenceReport
+    {
+        public PTUTabletReport(byte[] report)
+        {
+            Raw = report;
+
+            Position = new Vector2
+            {
+                X = Unsafe.ReadUnaligned<ushort>(ref report[2]),
+                Y = Unsafe.ReadUnaligned<ushort>(ref report[4])
+            };
+            Pressure = Unsafe.ReadUnaligned<ushort>(ref report[6]);
+
+            PenButtons = new bool[]
+            {
+                report[1].IsBitSet(1),
+                report[1].IsBitSet(4)
+            };
+            Eraser = report[1].IsBitSet(2);
+            HighConfidence = report[1].IsBitSet(5);
+        }
+
+        public byte[] Raw { set; get; }
+        public Vector2 Position { set; get; }
+        public uint Pressure { set; get; }
+        public bool[] PenButtons { set; get; }
+        public bool Eraser { set; get; }
+        public bool HighConfidence { set; get; }
+    }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -154,6 +154,7 @@
 | Parblo Ninos M                |    Has Quirks     | Aux buttons are not in order.
 | Parblo Ninos S                |    Has Quirks     | Aux buttons are not in order.
 | UGTABLET M708                 |    Has Quirks     | Windows: Might need Zadig's WinUSB to be installed on interface 0
+| Wacom PTU-600U                |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed
 | XP-Pen Artist 22HD            |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0
 | XP-Pen Star G430              |    Has Quirks     | Windows: Might need Zadig's WinUSB to be installed on interface 1
 | Artisul A1201                 |  Missing Features | Touch bar is not yet supported.


### PR DESCRIPTION
WinUSB interface is not specified due to this device only having a single interface.