### PR TITLE
fix: switch to tilt report parser on HS611

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/HS611.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/HS611.json
@@ -23,7 +23,7 @@
       "ProductID": 109,
       "InputReportLength": 12,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {
@@ -38,7 +38,7 @@
       "ProductID": 111,
       "InputReportLength": 12,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {


### PR DESCRIPTION
This is on hotfix, but not master. I missed it when I was adding the identifier in #2908