### PR TITLE
Add support for Huion H951P

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/H951P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H951P.json
@@ -1,0 +1,39 @@
+{
+  "Name": "Huion H951P",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 221.0,
+      "Height": 141.0,
+      "MaxX": 44197.0,
+      "MaxY": 27599.0
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "Buttons": {
+        "ButtonCount": 2
+      }
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 11
+    },
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 9580,
+      "ProductID": 103,
+      "InputReportLength": 12,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "201": "HUION_T21k_\\d{6}$"
+      }
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H951P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H951P.json
@@ -3,9 +3,9 @@
   "Specifications": {
     "Digitizer": {
       "Width": 221.0,
-      "Height": 141.0,
-      "MaxX": 44197.0,
-      "MaxY": 27599.0
+      "Height": 138.0,
+      "MaxX": 44200.0,
+      "MaxY": 27600.0
     },
     "Pen": {
       "MaxPressure": 8191,
@@ -24,12 +24,15 @@
       "ProductID": 103,
       "InputReportLength": 12,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.InspiroyReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T21k_\\d{6}$"
-      }
+      },
+      "InitializationStrings": [
+        200
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H951P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H951P.json
@@ -2,20 +2,19 @@
   "Name": "Huion H951P",
   "Specifications": {
     "Digitizer": {
-      "Width": 221.0,
-      "Height": 138.0,
-      "MaxX": 44200.0,
-      "MaxY": 27600.0
+      "Width": 221,
+      "Height": 138,
+      "MaxX": 44200,
+      "MaxY": 27600
     },
     "Pen": {
       "MaxPressure": 8191,
-      "Buttons": {
-        "ButtonCount": 2
-      }
+      "ButtonCount": 2
     },
     "AuxiliaryButtons": {
       "ButtonCount": 11
     },
+    "MouseButtons": null,
     "Touch": null
   },
   "DigitizerIdentifiers": [
@@ -35,7 +34,7 @@
       ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
+  "AuxiliaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Parsers/Huion/InspiroyReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Huion/InspiroyReportParser.cs
@@ -7,15 +7,25 @@ namespace OpenTabletDriver.Configurations.Parsers.Huion
     {
         public IDeviceReport Parse(byte[] data)
         {
-            return data[1] switch
+            switch (data[1])
             {
-                0xe0 => new UCLogicAuxReport(data),
-                // Group buttons, no way to use them properly for now
-                0xe3 => new UCLogicAuxReport(data),
-                // Wheel data, reported in data[5], ignoring
-                0xf1 => new DeviceReport(data),
-                _ => new TiltTabletReport(data)
+                case 0xe0:
+                    return new UCLogicAuxReport(data);
+                case 0xe3:
+                    // Group buttons, no way to use them properly for now
+                    return new UCLogicAuxReport(data);
+                case 0xf1:
+                    // Wheel data, reported in data[5], ignoring
+                    return new DeviceReport(data);
+                case 0x00:
+                    return new OutOfRangeReport(data);
             };
+
+            if (data[1].IsBitSet(7)) {
+                return new TiltTabletReport(data);
+            }
+
+            return new DeviceReport(data);
         }
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Huion/InspiroyReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Huion/InspiroyReportParser.cs
@@ -1,0 +1,21 @@
+using OpenTabletDriver.Configurations.Parsers.UCLogic;
+using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Huion
+{
+    public class InspiroyReportParser : IReportParser<IDeviceReport>
+    {
+        public IDeviceReport Parse(byte[] data)
+        {
+            return data[1] switch
+            {
+                0xe0 => new UCLogicAuxReport(data),
+                // Group buttons, no way to use them properly for now
+                0xe3 => new UCLogicAuxReport(data),
+                // Wheel data, reported in data[5], ignoring
+                0xf1 => new DeviceReport(data),
+                _ => new TiltTabletReport(data)
+            };
+        }
+    }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -171,6 +171,7 @@
 | Huion GT-221 Pro              |  Missing Features | Touch bar is not yet supported.
 | Huion H1161                   |  Missing Features | Tablet buttons are not yet supported.
 | Huion H610 Pro V3             |  Missing Features | Tablet buttons are not yet supported. Windows: Requires Zadig's WinUSB to be installed on interface 1
+| Huion H951P                   |  Missing Features | 'Wheel-up' and 'Wheel-down' duplicate two regular buttons. Switching groups is not yet supported; group selectors are mapped as regular buttons.
 | Huion HC16                    |  Missing Features | Wheel is not yet supported.
 | Huion HS610                   |  Missing Features | Wheel is not yet supported.
 | Huion HS611                   |  Missing Features | Touch bar is not yet supported.

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -171,7 +171,7 @@
 | Huion GT-221 Pro              |  Missing Features | Touch bar is not yet supported.
 | Huion H1161                   |  Missing Features | Tablet buttons are not yet supported.
 | Huion H610 Pro V3             |  Missing Features | Tablet buttons are not yet supported. Windows: Requires Zadig's WinUSB to be installed on interface 1
-| Huion H951P                   |  Missing Features | 'Wheel-up' and 'Wheel-down' duplicate two regular buttons. Switching groups is not yet supported; group selectors are mapped as regular buttons.
+| Huion H951P                   |  Missing Features | Wheel is not yet supported. Switching groups is not yet supported; group selectors are mapped as regular buttons.
 | Huion HC16                    |  Missing Features | Wheel is not yet supported.
 | Huion HS610                   |  Missing Features | Wheel is not yet supported.
 | Huion HS611                   |  Missing Features | Touch bar is not yet supported.

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -171,7 +171,7 @@
 | Huion GT-221 Pro              |  Missing Features | Touch bar is not yet supported.
 | Huion H1161                   |  Missing Features | Tablet buttons are not yet supported.
 | Huion H610 Pro V3             |  Missing Features | Tablet buttons are not yet supported. Windows: Requires Zadig's WinUSB to be installed on interface 1
-| Huion H951P                   |  Missing Features | Wheel is not yet supported. Switching groups is not yet supported; group selectors are mapped as regular buttons.
+| Huion H951P                   |  Missing Features | Tilt Y-axis is inverted. Wheel is not yet supported. Switching groups is not yet supported; group selectors are mapped as regular buttons.
 | Huion HC16                    |  Missing Features | Wheel is not yet supported.
 | Huion HS610                   |  Missing Features | Wheel is not yet supported.
 | Huion HS611                   |  Missing Features | Touch bar is not yet supported.


### PR DESCRIPTION
Verified the configuration on my own tablet.
The digitizer height is as measured on my device, it's a bit more than in official specs

Diagnostics:
[diagnostics.txt](https://github.com/OpenTabletDriver/OpenTabletDriver/files/12592943/diagnostics.txt)
