### PR TITLE
Add identifier to H420x

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/H420X.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H420X.json
@@ -40,7 +40,7 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {
-        "201": "HUION_T210_\\d{6}$"
+        "201": "HUION_(T210|T223)_\\d{6}$"
       },
       "InitializationStrings": [
         200


### PR DESCRIPTION
Verification: https://canary.discord.com/channels/615607687467761684/615611007951306863/1156122643448201236
Diagnostic: https://canary.discord.com/channels/615607687467761684/615611007951306863/1156107117439238154
Strings moving about: https://canary.discord.com/channels/615607687467761684/615611007951306863/1156064754872369242 & https://canary.discord.com/channels/615607687467761684/615611007951306863/1156107138293317674




This tablet has a firmware bug, meaning that the string may shift when the device string reader is ran, we have no idea if this is specifically a problem with *this* specific tablet, or every tablet that falls under this variant, but its not a problem as long as strings are not read.