### PR TITLE
Prevent OpenTabletDriver from being recognized as joysticks

### DIFF
--- a/OpenTabletDriver.Tools.udev/Program.cs
+++ b/OpenTabletDriver.Tools.udev/Program.cs
@@ -32,6 +32,16 @@ namespace OpenTabletDriver.Tools.udev
                 "https://github.com/OpenTabletDriver/OpenTabletDriver"
             );
 
+            //Prevent OpenTabletDriver from being recognized as joysticks.
+            Console.WriteLine(
+                new Rule(
+                    new Token("KERNEL", Operator.Equal, "js[0-9]*"),
+                    new Token("SUBSYSTEM", Operator.Equal, "input"),
+                    new ATTRS("name", Operator.Equal, "OpenTabletDriver Virtual Tablet"),
+                    new Token("RUN", Operator.Add, "/bin/rm %E{DEVNAME}")
+                )
+            );
+
             Console.WriteLine(
                 new Rule(
                     new Token("KERNEL", Operator.Equal, "uinput"),

--- a/OpenTabletDriver.Tools.udev/Program.cs
+++ b/OpenTabletDriver.Tools.udev/Program.cs
@@ -38,7 +38,7 @@ namespace OpenTabletDriver.Tools.udev
                     new Token("KERNEL", Operator.Equal, "js[0-9]*"),
                     new Token("SUBSYSTEM", Operator.Equal, "input"),
                     new ATTRS("name", Operator.Equal, "OpenTabletDriver Virtual Tablet"),
-                    new Token("RUN", Operator.Add, "/bin/rm %E{DEVNAME}")
+                    new Token("RUN", Operator.Add, "/usr/bin/env rm %E{DEVNAME}")
                 )
             );
 


### PR DESCRIPTION
https://github.com/torvalds/linux/blob/9f3ebbef746f89f860a90ced99a359202ea86fde/drivers/input/joydev.c#L777-L803
Joydev considers OpenTabletDriver as a device to be joysticks because it is not on the joydev blacklist. This commit adds udev rules to remove the joydev device.