### PR TITLE
Fix misuse of INPUT_PROP_DIRECT for Linux Artist Mode

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -30,7 +30,8 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
         {
             Device = new EvdevDevice("OpenTabletDriver Virtual Artist Tablet");
 
-            Device.EnableType(EventType.INPUT_PROP_DIRECT);
+            Device.EnableProperty(InputProperty.INPUT_PROP_DIRECT);
+
             Device.EnableType(EventType.EV_ABS);
 
             var xAbs = new input_absinfo

--- a/OpenTabletDriver.Native.Linux/Evdev/Evdev.cs
+++ b/OpenTabletDriver.Native.Linux/Evdev/Evdev.cs
@@ -14,6 +14,9 @@ namespace OpenTabletDriver.Native.Linux.Evdev
         public extern static void libevdev_set_name(IntPtr dev, string name);
 
         [DllImport(libevdev)]
+        public extern static int libevdev_enable_property(IntPtr dev, uint prop);
+
+        [DllImport(libevdev)]
         public extern static int libevdev_enable_event_type(IntPtr dev, uint type);
 
         [DllImport(libevdev)]

--- a/OpenTabletDriver.Native.Linux/Evdev/EvdevDevice.cs
+++ b/OpenTabletDriver.Native.Linux/Evdev/EvdevDevice.cs
@@ -36,6 +36,8 @@ namespace OpenTabletDriver.Native.Linux.Evdev
             }
         }
 
+        public void EnableProperty(InputProperty prop) => libevdev_enable_property(this.device, (uint) prop);
+
         public void EnableType(EventType type) => libevdev_enable_event_type(this.device, (uint) type);
 
         public void EnableCode(EventType type, EventCode code) =>

--- a/OpenTabletDriver.Native.Linux/Evdev/EventType.cs
+++ b/OpenTabletDriver.Native.Linux/Evdev/EventType.cs
@@ -1,11 +1,15 @@
 namespace OpenTabletDriver.Native.Linux.Evdev
 {
+    public enum InputProperty : uint
+    {
+        INPUT_PROP_DIRECT = 0x01,
+    }
+
     public enum EventType : uint
     {
         EV_SYN = 0x00,
         EV_KEY = 0x01,
         EV_REL = 0x02,
         EV_ABS = 0x03,
-        INPUT_PROP_DIRECT = 0x01
     }
 }


### PR DESCRIPTION
Previously, we would actually be sending `EnableType(EventType.EV_KEY)` rather than `EnableProp(InputProperty.INPUT_PROP_DIRECT)` because of the overlap of values.

There does not seem to be a functional difference pre- and post-PR.