### PR TITLE
UX: Create directories that don't exist when trying to open them

### DIFF
--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -287,7 +287,12 @@ namespace OpenTabletDriver.UX
         private async Task OpenAppDirectory(Func<IAppInfo, string> getMember)
         {
             var appInfo = await _rpc.Instance!.GetApplicationInfo();
-            _app.Open(getMember(appInfo), true);
+
+            var path = getMember(appInfo);
+            if (!System.IO.Directory.Exists(path))
+                System.IO.Directory.CreateDirectory(path);
+
+            _app.Open(path, true);
         }
 
         /// <summary>


### PR DESCRIPTION
Plugin and preset folders would previously not open if they did not exist

Fixes #2630