### PR TITLE
Backport: Use proper values for forward/backwards Linux mouse buttons

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevAbsolutePointer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevAbsolutePointer.cs
@@ -35,8 +35,8 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
                 EventCode.BTN_LEFT,
                 EventCode.BTN_MIDDLE,
                 EventCode.BTN_RIGHT,
-                EventCode.BTN_FORWARD,
-                EventCode.BTN_BACK);
+                EventCode.BTN_SIDE,
+                EventCode.BTN_EXTRA);
 
             var result = Device.Initialize();
             switch (result)

--- a/OpenTabletDriver.Desktop/Interop/Input/EvdevVirtualMouse.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/EvdevVirtualMouse.cs
@@ -31,8 +31,8 @@ namespace OpenTabletDriver.Desktop.Interop
             MouseButton.Left => EventCode.BTN_LEFT,
             MouseButton.Middle => EventCode.BTN_MIDDLE,
             MouseButton.Right => EventCode.BTN_RIGHT,
-            MouseButton.Forward => EventCode.BTN_FORWARD,
-            MouseButton.Backward => EventCode.BTN_BACK,
+            MouseButton.Backward => EventCode.BTN_SIDE,
+            MouseButton.Forward => EventCode.BTN_EXTRA,
             _ => null
         };
 

--- a/OpenTabletDriver.Desktop/Interop/Input/Relative/EvdevRelativePointer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Relative/EvdevRelativePointer.cs
@@ -23,8 +23,8 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Relative
                 EventCode.BTN_LEFT,
                 EventCode.BTN_MIDDLE,
                 EventCode.BTN_RIGHT,
-                EventCode.BTN_FORWARD,
-                EventCode.BTN_BACK);
+                EventCode.BTN_SIDE,
+                EventCode.BTN_EXTRA);
 
             var result = Device.Initialize();
             switch (result)


### PR DESCRIPTION
Backport of #2306 

Fix #2966