### PR TITLE
Add DTC-133 second pen button

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTC-133.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTC-133.json
@@ -9,7 +9,7 @@
     },
     "Pen": {
       "MaxPressure": 4095,
-      "ButtonCount": 1
+      "ButtonCount": 2
     },
     "AuxiliaryButtons": null,
     "MouseButtons": null,


### PR DESCRIPTION
The default DTC-133 pen (CP-913) only has one button. However, it supports many pens which do have two buttons. Our parsers already correctly parse pens with the second button for this tablet.