### PR TITLE
linux/lib.sh: Test udev rules where possible

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -38,9 +38,6 @@ jobs:
       - name: Generate udev Rules
         run: ./generate-rules.sh > 70-opentabletdriver.rules
 
-      - name: Test udev rules
-        run: udevadm verify 70-opentabletdriver.rules
-
       - name: Upload udev Rules
         uses: actions/upload-artifact@master
         with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Generate udev Rules
         run: ./generate-rules.sh > 70-opentabletdriver.rules
 
+      - name: Test udev rules
+        run: udevadm verify 70-opentabletdriver.rules
+
       - name: Upload udev Rules
         uses: actions/upload-artifact@master
         with:

--- a/eng/linux/lib.sh
+++ b/eng/linux/lib.sh
@@ -28,6 +28,11 @@ test_rules() {
     return 0
   fi
 
+  if ! udevadm verify --help >/dev/null; then
+    echo "INFO: test_rules: Your udevadm does not support 'udevadm verify'. Passing."
+    return 0
+  fi
+
   if [ ! -f "${1}" ]; then
     echo "test_rules: Not a file '${1}'"
     return 1

--- a/eng/linux/lib.sh
+++ b/eng/linux/lib.sh
@@ -24,7 +24,7 @@ copy_generic_files() {
 
 test_rules() {
   if ! hash udevadm 2>/dev/null; then
-    echo "WARN: test_rules: Cannot test rules without program 'udevadm'. Passing."
+    echo "INFO: test_rules: Cannot test rules without program 'udevadm'. Passing."
     return 0
   fi
 

--- a/eng/linux/lib.sh
+++ b/eng/linux/lib.sh
@@ -22,12 +22,28 @@ copy_generic_files() {
   echo
 }
 
+test_rules() {
+  if ! hash udevadm 2>/dev/null; then
+    echo "WARN: test_rules: Cannot test rules without program 'udevadm'. Passing."
+    return 0
+  fi
+
+  if [ ! -f "${1}" ]; then
+    echo "test_rules: Not a file '${1}'"
+    return 1
+  fi
+
+  udevadm verify "${1}"
+}
+
 generate_rules() {
   local output_file="${1}"
 
   echo "Generating udev rules to ${output_file}..."
   mkdir -p $(dirname "$output_file")
   "${REPO_ROOT}/generate-rules.sh" > "${output_file}"
+
+  test_rules "$output_file"
 }
 
 generate_desktop_file() {


### PR DESCRIPTION
The shell test is made conservatively and will always pass if 'udevadm' is not present

Fixes #2973

CI integration is not possible yet, `ubuntu-latest` (`ubuntu-22.04`) only contains systemd 249 whereas `udevadm verify` is not included before systemd 254.