### PR TITLE
(0.6.x) TABLETS.md: VEIKK A15 Pro: Clarify unsupported tilt

### DIFF
--- a/TABLETS.md
+++ b/TABLETS.md
@@ -157,7 +157,7 @@
 | Parblo Intangbo M             |  Missing Features | Wheel is not yet supported.
 | Parblo Intangbo S             |  Missing Features | Wheel is not yet supported.
 | UGEE EX08                     |  Missing Features | Tilt is not yet supported. Uses the same configuration as the XP-Pen Deco 01 V2.
-| VEIKK A15 Pro                 |  Missing Features | Wheel is not yet supported.
+| VEIKK A15 Pro                 |  Missing Features | Tilt and Wheel is not yet supported.
 | VEIKK A30                     |  Missing Features | Touchpad is not yet supported.
 | Veikk A30 V2                  |  Missing Features | Touchpad is not yet supported.
 | VEIKK A50                     |  Missing Features | Touchpad is not yet supported.


### PR DESCRIPTION
The A15 Pro seems to have later had tilt support added somehow.

Backport of #2979

Can be used in place of #2982