### PR TITLE
Migrate to the new website

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -75,8 +75,8 @@ body:
         Please make sure you are able to tick the items below, so that all parties involved have an easier time.
         Your issue is very likely to be closed and ignored if these conditions are not met.
       options:
-        - label: I have installed OpenTabletDriver by following its [official installation instructions](https://opentabletdriver.net/).
-        - label: I have checked the [OpenTabletDriver Wiki](https://opentabletdriver.net/Wiki) and respective FAQ pages, and my issue was not covered or actually fixed.
+        - label: I have installed OpenTabletDriver by following its [official installation instructions](https://opentabletdriver.github.io/).
+        - label: I have checked the [OpenTabletDriver Wiki](https://opentabletdriver.github.io/Wiki) and respective FAQ pages, and my issue was not covered or actually fixed.
           required: true
         - label: I have searched the existing issues and this new issue is not a duplicate of any.
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: OpenTabletDriver Discord Guild
-    url: https://opentabletdriver.net/Discord
+    url: https://opentabletdriver.github.io/Discord
     about: You may also wish to seek assistance through our Discord guild

--- a/.github/ISSUE_TEMPLATE/support_request.yml
+++ b/.github/ISSUE_TEMPLATE/support_request.yml
@@ -55,8 +55,8 @@ body:
         Please make sure you are able to tick the items below, so that all parties involved have an easier time.
         Your issue is very likely to be closed and ignored if these conditions are not met.
       options:
-        - label: I have installed OpenTabletDriver by following its [official installation instructions](https://opentabletdriver.net/).
-        - label: I have checked the [OpenTabletDriver Wiki](https://opentabletdriver.net/Wiki) and respective FAQ pages, and my issue was not covered or actually fixed.
+        - label: I have installed OpenTabletDriver by following its [official installation instructions](https://opentabletdriver.github.io/).
+        - label: I have checked the [OpenTabletDriver Wiki](https://opentabletdriver.github.io/Wiki) and respective FAQ pages, and my issue was not covered or actually fixed.
           required: true
         - label: I have searched the existing issues and this new issue is not a duplicate of any.
           required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ device, also referred to as a digitizer, functional.
 ## Adding a Configuration
 
 Documentation for the fields within configurations can be found on the official OpenTabletDriver
-website, [here](https://opentabletdriver.net/Wiki/Development/Configurations).
+website, [here](https://opentabletdriver.github.io/Wiki/Development/Configurations).
 
 When adding a new tablet configuration file to the `OpenTabletDriver.Configurations` project, these
 rules must be followed:

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -114,7 +114,7 @@ namespace OpenTabletDriver.Daemon
                     SystemPlatform.MacOS => "MacOS",
                     _ => null
                 };
-                var wikiUrl = $"https://opentabletdriver.net/Wiki/FAQ/{os}";
+                var wikiUrl = $"https://opentabletdriver.github.io/Wiki/FAQ/{os}";
 
                 var message = new StringBuilder();
                 message.Append($"'{driverInfo.Name}' driver is detected.");

--- a/OpenTabletDriver.UX/Dialogs/OfflineAboutDialog.cs
+++ b/OpenTabletDriver.UX/Dialogs/OfflineAboutDialog.cs
@@ -10,7 +10,7 @@ namespace OpenTabletDriver.UX.Dialogs
             ProgramName = "OpenTabletDriver";
             ProgramDescription = "Open source, cross-platform tablet configurator";
             WebsiteLabel = "OpenTabletDriver";
-            Website = new Uri(@"https://opentabletdriver.net");
+            Website = new Uri(@"https://opentabletdriver.github.io");
             Version = $"v{Metadata.FullVersion}";
             Developers = new[] { "InfinityGhost" };
             Designers = new[] { "InfinityGhost" };

--- a/OpenTabletDriver.UX/Metadata.cs
+++ b/OpenTabletDriver.UX/Metadata.cs
@@ -5,7 +5,7 @@ namespace OpenTabletDriver.UX
 {
     public static class Metadata
     {
-        public const string WIKI_URL = "https://opentabletdriver.net/Wiki";
+        public const string WIKI_URL = "https://opentabletdriver.github.io/Wiki";
 
         public static string FullVersion { get; } =
             Assembly.GetEntryAssembly()!.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -140,7 +140,7 @@ namespace OpenTabletDriver
                         Log.Write(
                             "Driver",
                             "The current user does not have the permissions to open the device stream. " +
-                            "Follow the instructions from https://opentabletdriver.net/Wiki/FAQ/Linux#fail-device-streams to resolve this issue.",
+                            "Follow the instructions from https://opentabletdriver.github.io/Wiki/FAQ/Linux#fail-device-streams to resolve this issue.",
                             LogLevel.Error
                         );
                     }
@@ -150,7 +150,7 @@ namespace OpenTabletDriver
                         Log.Write(
                             "Driver",
                             "Device is currently in use by another kernel module. " +
-                            "Follow the instructions from https://opentabletdriver.net/Wiki/FAQ/Linux#argumentoutofrangeexception to resolve this issue.",
+                            "Follow the instructions from https://opentabletdriver.github.io/Wiki/FAQ/Linux#argumentoutofrangeexception to resolve this issue.",
                             LogLevel.Error
                         );
                     }

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ OpenTabletDriver is an open source, cross platform, user mode tablet driver. The
 
 All statuses of tablets that are supported, untested, and planned to be supported can be found here. Common issue workarounds can be found in the wiki for your platform.
 
-- [Supported Tablets](https://opentabletdriver.net/Tablets)
+- [Supported Tablets](https://opentabletdriver.github.io/Tablets)
 
 # Installation
 
-- [Windows](https://opentabletdriver.net/Wiki/Install/Windows)
-- [Linux](https://opentabletdriver.net/Wiki/Install/Linux)
-- [MacOS](https://opentabletdriver.net/Wiki/Install/MacOS)
+- [Windows](https://opentabletdriver.github.io/Wiki/Install/Windows)
+- [Linux](https://opentabletdriver.github.io/Wiki/Install/Linux)
+- [MacOS](https://opentabletdriver.github.io/Wiki/Install/MacOS)
 
 # Running OpenTabletDriver binaries
 
@@ -113,7 +113,7 @@ for a new tablet is quite easy.
 
 For issues and PRs related to OpenTabletDriver's packaging, please see the repository [here](https://github.com/OpenTabletDriver/OpenTabletDriver.Packaging).
 
-For issues and PRs related to OpenTabletDriver's [web page](https://opentabletdriver.net), see the repository [here](https://github.com/OpenTabletDriver/OpenTabletDriver.Web).
+For issues and PRs related to OpenTabletDriver's [web page](https://opentabletdriver.github.io), see the repository [here](https://github.com/OpenTabletDriver/OpenTabletDriver.Web).
 
 ### Supporting a new tablet
 

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -16,13 +16,13 @@ OpenTabletDriver是一个开源的，跨平台的数位板驱动。其目标是�
 
 所有已经被支持的、未测试的、以及计划被支持的数位板都可以在这里被找到。如果您的数位板在您的平台上无法正常工作的话可以在Wiki之中寻找一些解决方法
 
-- [数位板支持](https://opentabletdriver.net/Tablets)
+- [数位板支持](https://opentabletdriver.github.io/Tablets)
 
 # 安装方法
 
-- [Windows](https://opentabletdriver.net/Wiki/Install/Windows)
-- [Linux](https://opentabletdriver.net/Wiki/Install/Linux)
-- [MacOS](https://opentabletdriver.net/Wiki/Install/MacOS)
+- [Windows](https://opentabletdriver.github.io/Wiki/Install/Windows)
+- [Linux](https://opentabletdriver.github.io/Wiki/Install/Linux)
+- [MacOS](https://opentabletdriver.github.io/Wiki/Install/MacOS)
 
 # 运行OpenTabletDriver
 

--- a/docs/README_DE.md
+++ b/docs/README_DE.md
@@ -16,13 +16,13 @@ OpenTabletDriver ist ein plattformübergreifender Open Source Benutzermodustreib
 
 Der Status aller unterstützten, ungetesteten und zur Unterstützung geplanten Tablets kann hier eingesehen werden. Häufige Fehler und deren Lösungen sind auf den Wikis der jeweiligen Plattform zu finden.
 
-- [Unterstützte Tablets](https://opentabletdriver.net/Tablets)
+- [Unterstützte Tablets](https://opentabletdriver.github.io/Tablets)
 
 # Installation
 
-- [Windows](https://opentabletdriver.net/Wiki/Install/Windows)
-- [Linux](https://opentabletdriver.net/Wiki/Install/Linux)
-- [MacOS](https://opentabletdriver.net/Wiki/Install/MacOS)
+- [Windows](https://opentabletdriver.github.io/Wiki/Install/Windows)
+- [Linux](https://opentabletdriver.github.io/Wiki/Install/Linux)
+- [MacOS](https://opentabletdriver.github.io/Wiki/Install/MacOS)
 
 # OpenTabletDriver ausführen
 

--- a/docs/README_ES.md
+++ b/docs/README_ES.md
@@ -16,13 +16,13 @@ OpenTabletDriver es un driver de tabletas multiplataforma, open-source y en modo
 
 Los estados de las tabletas que son soportadas, no probadas y planeadas para ser soportadas se pueden encontrar aquí. Las soluciones a los problemas más comunes pueden ser encontradas en la wiki de su plataforma.
 
-- [Tabletas compatibles](https://opentabletdriver.net/Tablets)
+- [Tabletas compatibles](https://opentabletdriver.github.io/Tablets)
 
 # Instalación
 
-- [Windows](https://opentabletdriver.net/Wiki/Install/Windows)
-- [Linux](https://opentabletdriver.net/Wiki/Install/Linux)
-- [MacOS](https://opentabletdriver.net/Wiki/Install/MacOS)
+- [Windows](https://opentabletdriver.github.io/Wiki/Install/Windows)
+- [Linux](https://opentabletdriver.github.io/Wiki/Install/Linux)
+- [MacOS](https://opentabletdriver.github.io/Wiki/Install/MacOS)
 
 # Ejecución de los binarios de OpenTabletDriver
 

--- a/docs/README_FR.md
+++ b/docs/README_FR.md
@@ -16,13 +16,13 @@ OpenTabletDriver est un driver de tablette en mode utilisateur, open source et m
 
 Tous les modèles de tablettes supportés, non testées, et prévus pour être supportés peuvent-être trouvés ici. Des solutions alternatives peuvent-être trouvées sur le wiki pour votre plateforme.
 
-- [Tablettes supportées](https://opentabletdriver.net/Tablets)
+- [Tablettes supportées](https://opentabletdriver.github.io/Tablets)
 
 # Installation
 
-- [Windows](https://opentabletdriver.net/Wiki/Install/Windows)
-- [Linux](https://opentabletdriver.net/Wiki/Install/Linux)
-- [MacOS](https://opentabletdriver.net/Wiki/Install/MacOS)
+- [Windows](https://opentabletdriver.github.io/Wiki/Install/Windows)
+- [Linux](https://opentabletdriver.github.io/Wiki/Install/Linux)
+- [MacOS](https://opentabletdriver.github.io/Wiki/Install/MacOS)
 
 # Exécuter OpenTabletDriver
 

--- a/docs/README_KO.md
+++ b/docs/README_KO.md
@@ -16,13 +16,13 @@ OpenTabletDriver는 관리자 권한 없이 여러 플랫폼에서 작동하는 
 
 OpenTabletDriver에서 지원하거나, 아직 테스트가 부족하거나, 아니면 지원 예정인 타블렛들의 목록은 여기서 확인하실 수 있습니다. 각 플랫폼에 대해 자주 발생하는 문제에 대한 해결책은 위키를 찾아보세요.
 
-- [지원하는 타블렛](https://opentabletdriver.net/Tablets)
+- [지원하는 타블렛](https://opentabletdriver.github.io/Tablets)
 
 # 설치
 
-- [Windows](https://opentabletdriver.net/Wiki/Install/Windows)
-- [Linux](https://opentabletdriver.net/Wiki/Install/Linux)
-- [MacOS](https://opentabletdriver.net/Wiki/Install/MacOS)
+- [Windows](https://opentabletdriver.github.io/Wiki/Install/Windows)
+- [Linux](https://opentabletdriver.github.io/Wiki/Install/Linux)
+- [MacOS](https://opentabletdriver.github.io/Wiki/Install/MacOS)
 
 # OpenTabletDriver 실행하기
 

--- a/docs/README_PTBR.md
+++ b/docs/README_PTBR.md
@@ -16,19 +16,19 @@ OpenTabletDriver é um programa de código aberto, multi-plataforma, driver de t
 
 Todos os status dos tablets que estão suportados, não testados ou que estão em planejamento para serem testados estão aqui. Soluções de problemas comuns podem ser encontrados na wiki.
 
-- [Tablets suportados](https://opentabletdriver.net/Tablets)
+- [Tablets suportados](https://opentabletdriver.github.io/Tablets)
 
 # Instalação
 
-- [Windows](https://opentabletdriver.net/Wiki/Install/Windows)
-- [Linux](https://opentabletdriver.net/Wiki/Install/Linux)
-- [MacOS](https://opentabletdriver.net/Wiki/Install/MacOS)
+- [Windows](https://opentabletdriver.github.io/Wiki/Install/Windows)
+- [Linux](https://opentabletdriver.github.io/Wiki/Install/Linux)
+- [MacOS](https://opentabletdriver.github.io/Wiki/Install/MacOS)
 
 # Executando OpenTabletDriver
 
 O OpenTabletDriver funciona como dois processos separados que comunicam-se entre si para poder funcionar perfeitamente. O programa ativo que lida com todos o manuseio de dados é `OpenTabletDriver.Daemon`, enquanto o GUI (interface) é `OpenTabletDriver.UX.*`, onde `*` depende da plataforma<sup>1</sup>. O daemon deve ser inicializado para que tudo possa rodar sem problemas, enquanto o GUI não é necessário. Se você possui uma configuração já pronta, elas devem ser aplicadas quando o daemon iniciar.
 
-> <sup>1</sup>Windows usa `Wpf`, Linux usa `Gtk`, e MacOS usa `MacOS`. O que pode ser ignorado por grande parte da aplicação se você não compilar a partir da fonte, já que apenas a versão correta será fornecida. 
+> <sup>1</sup>Windows usa `Wpf`, Linux usa `Gtk`, e MacOS usa `MacOS`. O que pode ser ignorado por grande parte da aplicação se você não compilar a partir da fonte, já que apenas a versão correta será fornecida.
 
 ## Buildando OpenTabletDriver da fonte
 
@@ -108,7 +108,7 @@ Somos gratos aos relatos de bugs quanto aos pedidos de novos tablets para adicio
 
 Para issues (problemas) e PRs relacionados aos pacotes do OpenTabletDriver, por favor veja neste repositório [aqui](https://github.com/OpenTabletDriver/OpenTabletDriver.Packaging).
 
-Para issues e PRs relacionados ao site do OpenTabletDriver [página web](https://opentabletdriver.net), veja este repositório [aqui](https://github.com/OpenTabletDriver/OpenTabletDriver.Web).
+Para issues e PRs relacionados ao site do OpenTabletDriver [página web](https://opentabletdriver.github.io), veja este repositório [aqui](https://github.com/OpenTabletDriver/OpenTabletDriver.Web).
 
 ### Adicionando suporte a um novo tablet
 

--- a/docs/README_RU.md
+++ b/docs/README_RU.md
@@ -14,7 +14,7 @@ OpenTabletDriver — кроссплатформенный драйвер с от
 
 # Поддерживаемые планшеты
 
-Статус поддержки различных моделей можно найти по [этой ссылке](https://opentabletdriver.net/Tablets).
+Статус поддержки различных моделей можно найти по [этой ссылке](https://opentabletdriver.github.io/Tablets).
 
 Возможные типы статуса поддержки:
 
@@ -28,9 +28,9 @@ OpenTabletDriver — кроссплатформенный драйвер с от
 
 # Установка
 
-- [Windows](https://opentabletdriver.net/Wiki/Install/Windows)
-- [Linux](https://opentabletdriver.net/Wiki/Install/Linux)
-- [MacOS](https://opentabletdriver.net/Wiki/Install/MacOS)
+- [Windows](https://opentabletdriver.github.io/Wiki/Install/Windows)
+- [Linux](https://opentabletdriver.github.io/Wiki/Install/Linux)
+- [MacOS](https://opentabletdriver.github.io/Wiki/Install/MacOS)
 
 # Запуск и использование OpenTabletDriver
 

--- a/eng/lib.sh
+++ b/eng/lib.sh
@@ -54,7 +54,7 @@ OTD_MAINTAINERS=(
   "InfinityGhost <infinityghostgit@gmail.com>" \
   "X9VoiD <oscar.silvestrexx@gmail.com>" \
 )
-OTD_UPSTREAM_URL="https://opentabletdriver.net"
+OTD_UPSTREAM_URL="https://opentabletdriver.github.io"
 OTD_REPO_URL="https://github.com/OpenTabletDriver/OpenTabletDriver"
 OTD_GIT="https://github.com/OpenTabletDriver/OpenTabletDriver.git"
 OTD_VERSION_BASE="$(sed -n 's|.*<VersionBase>\(.*\)</VersionBase>.*|\1|p' "${REPO_ROOT}/Directory.Build.props")"


### PR DESCRIPTION
Temporarily migrate codebase to use the new URL for the new website until it takes over `opentabletdriver.net`.