### PR TITLE
generic/postinst: Specify systemd user service

### DIFF
--- a/eng/linux/Generic/postinst
+++ b/eng/linux/Generic/postinst
@@ -18,4 +18,4 @@ if udevadm control --reload-rules; then
     udevadm trigger && udevadm settle -t 15 || true
 fi
 
-printf "Run the daemon by invoking 'otd-daemon', or by enabling opentabletdriver.service"
+printf "Run the daemon by invoking 'otd-daemon', or by enabling the systemd user service opentabletdriver.service"


### PR DESCRIPTION
Not having this may confuse users into thinking there is a system service rather than a user service; the main differentiator being you should run `systemctl --user start opentabletdriver` rather than `systemctl start opentabletdriver`.