### PR TITLE
Define mouse buttons for Wacom CTE series

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-430.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-430.json
@@ -12,7 +12,9 @@
       "ButtonCount": 2
     },
     "AuxiliaryButtons": null,
-    "MouseButtons": null,
+    "MouseButtons": {
+      "ButtonCount": 3
+    },
     "Touch": null
   },
   "DigitizerIdentifiers": [

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-440.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-440.json
@@ -14,7 +14,9 @@
     "AuxiliaryButtons": {
       "ButtonCount": 2
     },
-    "MouseButtons": null,
+    "MouseButtons": {
+      "ButtonCount": 3
+    },
     "Touch": null
   },
   "DigitizerIdentifiers": [

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-450.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-450.json
@@ -14,7 +14,9 @@
     "AuxiliaryButtons": {
       "ButtonCount": 4
     },
-    "MouseButtons": null,
+    "MouseButtons": {
+      "ButtonCount": 3
+    },
     "Touch": null
   },
   "DigitizerIdentifiers": [

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-630.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-630.json
@@ -12,7 +12,9 @@
       "ButtonCount": 2
     },
     "AuxiliaryButtons": null,
-    "MouseButtons": null,
+    "MouseButtons": {
+      "ButtonCount": 3
+    },
     "Touch": null
   },
   "DigitizerIdentifiers": [

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-640.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-640.json
@@ -14,7 +14,9 @@
     "AuxiliaryButtons": {
       "ButtonCount": 2
     },
-    "MouseButtons": null,
+    "MouseButtons": {
+      "ButtonCount": 3
+    },
     "Touch": null
   },
   "DigitizerIdentifiers": [


### PR DESCRIPTION
(same as #3015 but for `master`, but the diff should work without issues)

Fixes #3013

[Discord user](https://discord.com/channels/615607687467761684/723399565780189234/1175589832135823410) tested CTE-430 working with 3 buttons

Anything else was adjusted according to [Kuuube's tablet mastersheet](https://docs.google.com/spreadsheets/d/125LNzGmidy1gagwYUt12tRhrNdrWFHhWon7kxWY7iWU/edit#gid=854129046)

Configurations not changed:
 - CTE-650: #2736 already exists
 - ET-0405A-U: Already had correct config

(anything not listed in this section does not have mouse support according to the sheet)