### PR TITLE
Fix configs that still use 0.6.x syntax

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Lifetec/LT9570.json
+++ b/OpenTabletDriver.Configurations/Configurations/Lifetec/LT9570.json
@@ -9,9 +9,7 @@
     },
     "Pen": {
       "MaxPressure": 1023,
-      "Buttons": {
-        "ButtonCount": 2
-      }
+      "ButtonCount": 2
     },
     "AuxiliaryButtons": null,
     "MouseButtons": null,
@@ -40,7 +38,7 @@
       "InitializationStrings": []
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
+  "AuxiliaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-301.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-301.json
@@ -9,9 +9,7 @@
     },
     "Pen": {
       "MaxPressure": 511,
-      "Buttons": {
-        "ButtonCount": 1
-      }
+      "ButtonCount": 1
     },
     "AuxiliaryButtons": {
       "ButtonCount": 2

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-1300.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-1300.json
@@ -9,9 +9,7 @@
     },
     "Pen": {
       "MaxPressure": 2048,
-      "Buttons": {
-        "ButtonCount": 2
-      }
+      "ButtonCount": 2
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-1300.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-1300.json
@@ -32,5 +32,6 @@
       "InitializationStrings": []
     }
   ],
+  "AuxiliaryDeviceIdentifiers": [],
   "Attributes": {}
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTZ-1200W.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTZ-1200W.json
@@ -32,5 +32,6 @@
       "InitializationStrings": []
     }
   ],
+  "AuxiliaryDeviceIdentifiers": [],
   "Attributes": {}
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTZ-1200W.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTZ-1200W.json
@@ -9,9 +9,7 @@
     },
     "Pen": {
       "MaxPressure": 2046,
-      "Buttons": {
-        "ButtonCount": 2
-      }
+      "ButtonCount": 2
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16 (2nd Gen).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16 (2nd Gen).json
@@ -9,9 +9,7 @@
     },
     "Pen": {
       "MaxPressure": 8191,
-      "Buttons": {
-        "ButtonCount": 2
-      }
+      "ButtonCount": 2
     },
     "AuxiliaryButtons": {
       "ButtonCount": 10


### PR DESCRIPTION
Fortunately it seems like the worst that we've been missing are just the buttons on the pen. The one missing aux identifier was not really an issue because it was already blank to begin with.

This fixes failing tests in #3024 and #3027

Does not need a configuration backport for 0.6.x