### PR TITLE
Deco L: Fix incorrect pressure

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco L.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco L.json
@@ -8,7 +8,7 @@
       "MaxY": 30480
     },
     "Pen": {
-      "MaxPressure": 8192,
+      "MaxPressure": 8191,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {


### PR DESCRIPTION
A pending Deco M PR (#3000) describes the max pressure as being 8191.

According to the Discord verification linked in the original PR adding the tablet (#2867), the max pressure should indeed be 8191.