### PR TITLE
Wacom CTE-x40: Fix aux keys

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-440.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-440.json
@@ -25,7 +25,7 @@
       "ProductID": 21,
       "InputReportLength": 9,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.BambooV2.BambooV2ReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-640.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-640.json
@@ -25,7 +25,7 @@
       "ProductID": 22,
       "InputReportLength": 8,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.BambooV2.BambooV2ReportParser",
       "FeatureInitReport": [
         "AgI="
       ],

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/BambooV2/BambooV2AuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/BambooV2/BambooV2AuxReport.cs
@@ -1,0 +1,22 @@
+using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Wacom.BambooV2
+{
+    public struct BambooV2AuxReport : IAuxReport
+    {
+        public BambooV2AuxReport(byte[] report)
+        {
+            Raw = report;
+
+            var auxByte = report[7];
+            AuxButtons = new bool[]
+            {
+                auxByte.IsBitSet(6), // CTE-440 left
+                auxByte.IsBitSet(7), // CTE-440 right
+            };
+        }
+
+        public byte[] Raw { set; get; }
+        public bool[] AuxButtons { set; get; }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/BambooV2/BambooV2ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/BambooV2/BambooV2ReportParser.cs
@@ -1,0 +1,41 @@
+using System.Runtime.CompilerServices;
+using OpenTabletDriver.Tablet;
+using OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo;
+
+namespace OpenTabletDriver.Configurations.Parsers.Wacom.BambooV2
+{
+    // duplicate of BambooReportParser except for the aux handling
+    public class BambooV2ReportParser : IReportParser<IDeviceReport>
+    {
+        public IDeviceReport Parse(byte[] report)
+        {
+            return report[0] switch
+            {
+                0x02 => GetToolReport(report),
+                _ => new DeviceReport(report)
+            };
+        }
+
+        private static IDeviceReport GetToolReport(byte[] report)
+        {
+            // If position is available
+            if (report[1].IsBitSet(7)
+                || Unsafe.ReadUnaligned<uint>(ref report[2]) != 0
+                || (report[6] | ((report[7] & 0x03) << 8)) != 0)
+            {
+                if (report[1].IsBitSet(6))
+                {
+                    return new BambooMouseReport(report);
+                }
+
+                return new BambooTabletReport(report);
+            }
+
+            // rel. wheel report on CTE-440: 0x08 up / 0x38 down
+            if ((report[7] & 0x8) != 0) // if wheel report
+                return new DeviceReport(report);
+
+            return new BambooV2AuxReport(report);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2992

This changes the aux reports to match linked issue and discard wheel outputs for now.

The wheel output has been noted in code for later use

Leaving as draft until tested

