### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,7 +30,7 @@ jobs:
           dotnet publish OpenTabletDriver.UX.Gtk "${options[@]}" --runtime "$runtime" -o "build/$runtime"
 
       - name: Upload Linux artifacts
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: OpenTabletDriver linux-x64
           path: build/linux-x64
@@ -39,7 +39,7 @@ jobs:
         run: ./generate-rules.sh > 70-opentabletdriver.rules
 
       - name: Upload udev Rules
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: udev Rules
           path: 70-opentabletdriver.rules
@@ -67,7 +67,7 @@ jobs:
           dotnet publish OpenTabletDriver.UX.MacOS "${options[@]}" --runtime "$runtime" -o "build/$runtime"
 
       - name: Upload MacOS artifacts
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: OpenTabletDriver osx-x64
           path: build/osx-x64
@@ -95,7 +95,7 @@ jobs:
           dotnet publish OpenTabletDriver.UX.Wpf $options --runtime $ENV:runtime -o build/$ENV:runtime
 
       - name: Upload Windows artifacts
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: OpenTabletDriver win-x64
           path: build/win-x64

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,7 +12,7 @@ jobs:
     name: Linux Publish
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
@@ -49,7 +49,7 @@ jobs:
     name: MacOS Publish
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
@@ -77,7 +77,7 @@ jobs:
     name: Windows Publish
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           # Full git history is needed to get a proper list of changed files
           fetch-depth: 0
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
@@ -142,7 +142,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: '7.0'
           include-prerelease: True
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: '7.0'
           include-prerelease: True
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: '7.0'
           include-prerelease: True
@@ -111,7 +111,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: '7.0'
           include-prerelease: True
@@ -129,7 +129,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: '7.0'
           include-prerelease: True
@@ -145,7 +145,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: '7.0'
           include-prerelease: True

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,7 +11,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: github/issue-labeler@v3.2
+    - uses: github/issue-labeler@v3.3
       with:
         repo-token: "${{ github.token }}"
         configuration-path: .github/labeler.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,21 +47,21 @@ jobs:
 
       - name: Upload Debian artifact (Dispatch)
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: OpenTabletDriver.deb
           path: ./dist/debian/*.deb
 
       - name: Upload generic Linux artifact (Dispatch)
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: OpenTabletDriver.linux-x64.tar.gz
           path: ./dist/tarball/*.tar.gz
 
       - name: Upload macOS artifact (Dispatch)
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: OpenTabletDriver.osx-x64.tar.gz
           path: ./dist/macos/*.tar.gz
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload RPM artifact (Dispatch)
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: OpenTabletDriver.rpm
           path: ./dist/redhat/*.rpm
@@ -133,7 +133,7 @@ jobs:
 
       - name: Upload Windows asset (Dispatch)
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: OpenTabletDriver.win-x64.zip
           path: ./dist/*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         run: sudo apt install -y debhelper dotnet-sdk-7.0
 
       - name: Checkout OpenTabletDriver Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Debian Build
         run: ./eng/linux/package.sh --package Debian --output ./dist/debian
@@ -78,7 +78,7 @@ jobs:
         run: sudo dnf install -y rpm-build systemd-rpm-macros libicu openssl-libs zlib krb5-libs git dotnet-sdk-7.0 tree
 
       - name: Checkout OpenTabletDriver Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # https://github.com/actions/checkout/issues/1169
       - run: git config --system --add safe.directory /__w/OpenTabletDriver/OpenTabletDriver
@@ -110,7 +110,7 @@ jobs:
       VERSION_SUFFIX: ${{ github.event.inputs.version_suffix }}
     steps:
       - name: Checkout OpenTabletDriver Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: '7.0'
           include-prerelease: True


### PR DESCRIPTION
"Bug fixes and optimizations" but also hopefully this should reduce the amount of warnings produced in Action builds:
![image](https://github.com/OpenTabletDriver/OpenTabletDriver/assets/421345/86bafecb-ae89-4791-ae18-781fa8b48197)
etc