### PR TITLE
workflows: Fix linting not working on other than OpenTabletDriver folder

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -117,7 +117,7 @@ jobs:
           PR_BASE_REF: ${{ github.event.pull_request.base.sha }} # latest commit on target branch
         run: |
           mapfile -t files < <(git diff --name-only --diff-filter=AM $PR_BASE_REF HEAD | grep '.*\.cs$')
-          if [ ${#files[@]} -ne 0 ]; then dotnet format OpenTabletDriver --verify-no-changes --include "${files[@]}"; fi
+          if [ ${#files[@]} -ne 0 ]; then dotnet format OpenTabletDriver.sln --verify-no-changes --include "${files[@]}"; fi
 
   unittests:
     name: Unit Tests


### PR DESCRIPTION
`dotnet format` expects a solution or project file - if a folder is provided, it will search that folder for a solution or project file, meaning only code in the `OpenTabletDriver` subfolder was being linted