### PR TITLE
workflows: Drop obsolete setup-dotnet config keys

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,7 +18,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '7.0'
-          include-prerelease: True
 
       - name: Linux Publish
         env:
@@ -55,7 +54,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '7.0'
-          include-prerelease: True
 
       - name: MacOS Publish
         env:
@@ -83,7 +81,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '7.0'
-          include-prerelease: True
 
       - name: Windows Publish
         env:
@@ -114,7 +111,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '7.0'
-          include-prerelease: True
 
       - name: Lint Changed Files
         run: |
@@ -132,7 +128,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '7.0'
-          include-prerelease: True
 
       - name: Run tests
         run: dotnet test
@@ -148,7 +143,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '7.0'
-          include-prerelease: True
 
       - name: Windows
         run: dotnet restore OpenTabletDriver.Windows.slnf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,6 @@ jobs:
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: '7.0'
-          include-prerelease: True
 
       - name: Package
         run: ./eng/windows/package.ps1


### PR DESCRIPTION
Should fix the action warnings introduced in #3030