### PR TITLE
workflows: Correctly lint all commits in PR

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Lint Changed Files
         env:
-          PR_BASE_REF: ${{ github.event.pull_request.head.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.sha }}
         run: |
           mapfile -t files < <(git diff --name-only --diff-filter=AM $PR_BASE_REF HEAD | grep '.*\.cs$')
           echo "New .cs files in $PR_BASE_REF: ${#files[@]}"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Lint Changed Files
         env:
-          PR_BASE_REF: ${{ github.base_ref }}
+          PR_BASE_REF: ${{ github.event.pull_request.head.sha }}
         run: |
           mapfile -t files < <(git diff --name-only --diff-filter=AM $PR_BASE_REF HEAD | grep '.*\.cs$')
           echo "New .cs files in $PR_BASE_REF: ${#files[@]}"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -98,7 +98,7 @@ jobs:
           path: build/win-x64
 
   linter:
-    name: dotnet format
+    name: Lint Code
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -114,10 +114,9 @@ jobs:
 
       - name: Lint Changed Files
         env:
-          PR_BASE_REF: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.sha }} # latest commit on target branch
         run: |
           mapfile -t files < <(git diff --name-only --diff-filter=AM $PR_BASE_REF HEAD | grep '.*\.cs$')
-          echo "New .cs files in $PR_BASE_REF: ${#files[@]}"
           if [ ${#files[@]} -ne 0 ]; then dotnet format OpenTabletDriver --verify-no-changes --include "${files[@]}"; fi
 
   unittests:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -113,8 +113,11 @@ jobs:
           dotnet-version: '7.0'
 
       - name: Lint Changed Files
+        env:
+          PR_BASE_REF: ${{ github.base_ref }}
         run: |
-          mapfile -t files < <(git diff --name-only --diff-filter=AM HEAD^ HEAD | grep '.*\.cs$')
+          mapfile -t files < <(git diff --name-only --diff-filter=AM $PR_BASE_REF HEAD | grep '.*\.cs$')
+          echo "New .cs files in $PR_BASE_REF: ${#files[@]}"
           if [ ${#files[@]} -ne 0 ]; then dotnet format OpenTabletDriver --verify-no-changes --include "${files[@]}"; fi
 
   unittests:


### PR DESCRIPTION
Previously, we would only lint the last commit in a PR.

Fixes #3032