### PR TITLE
(0.6.x) Tests: Verify tablet configuration with JSON Schema

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-660.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-660.json
@@ -9,7 +9,9 @@
     },
     "Pen": {
       "MaxPressure": 511,
-      "ButtonCount": 2
+      "Buttons": {
+        "ButtonCount": 2
+      }
     },
     "AuxiliaryButtons": null,
     "MouseButtons": null,

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-1300.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-1300.json
@@ -34,5 +34,6 @@
       "InitializationStrings": []
     }
   ],
+  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {}
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTZ-1200W.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTZ-1200W.json
@@ -34,5 +34,6 @@
       "InitializationStrings": []
     }
   ],
+  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {}
 }

--- a/OpenTabletDriver.Plugin/OpenTabletDriver.Plugin.csproj
+++ b/OpenTabletDriver.Plugin/OpenTabletDriver.Plugin.csproj
@@ -14,6 +14,10 @@
     </AssemblyAttribute>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+  </ItemGroup>
+
   <PropertyGroup Label="NuGet Package Information">
     <PackageId>OpenTabletDriver.Plugin</PackageId>
     <Description>Library used to create OpenTabletDriver plugins.</Description>

--- a/OpenTabletDriver.Plugin/Tablet/ButtonSpecifications.cs
+++ b/OpenTabletDriver.Plugin/Tablet/ButtonSpecifications.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace OpenTabletDriver.Plugin.Tablet
 {
     public class ButtonSpecifications
@@ -5,6 +7,7 @@ namespace OpenTabletDriver.Plugin.Tablet
         /// <summary>
         /// The amount of buttons.
         /// </summary>
+        [Required(ErrorMessage = $"{nameof(ButtonCount)} must be defined")]
         public uint ButtonCount { set; get; }
     }
 }

--- a/OpenTabletDriver.Plugin/Tablet/DeviceIdentifier.cs
+++ b/OpenTabletDriver.Plugin/Tablet/DeviceIdentifier.cs
@@ -34,7 +34,7 @@ namespace OpenTabletDriver.Plugin.Tablet
         /// <summary>
         /// The device report parser used by the detected device.
         /// </summary>
-        [RegularExpression(@"^OpenTabletDriver(\.[\w\d]+)+$", ErrorMessage = $"{nameof(ReportParser)} for identifier must match regular expression")]
+        [RegularExpression(@"^([A-Za-z]+\w*)(\.[A-Za-z]+\w*)+$", ErrorMessage = $"{nameof(ReportParser)} for identifier must match regular expression")]
         public string ReportParser { set; get; } = string.Empty;
 
         /// <summary>

--- a/OpenTabletDriver.Plugin/Tablet/DeviceIdentifier.cs
+++ b/OpenTabletDriver.Plugin/Tablet/DeviceIdentifier.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 #nullable enable
 
@@ -9,11 +10,15 @@ namespace OpenTabletDriver.Plugin.Tablet
         /// <summary>
         /// The Vendor ID of the device.
         /// </summary>
+        [Required(ErrorMessage = $"{nameof(VendorID)} identifier must be defined")]
+        [Range(0, 0xFFFF)]
         public int VendorID { set; get; }
 
         /// <summary>
         /// The Product ID of the device.
         /// </summary>
+        [Required(ErrorMessage = $"{nameof(ProductID)} identifier must be defined")]
+        [Range(0, 0xFFFF)]
         public int ProductID { set; get; }
 
         /// <summary>
@@ -29,6 +34,7 @@ namespace OpenTabletDriver.Plugin.Tablet
         /// <summary>
         /// The device report parser used by the detected device.
         /// </summary>
+        [RegularExpression(@"^OpenTabletDriver(\.[\w\d]+)+$", ErrorMessage = $"{nameof(ReportParser)} for identifier must match regular expression")]
         public string ReportParser { set; get; } = string.Empty;
 
         /// <summary>

--- a/OpenTabletDriver.Plugin/Tablet/DigitizerSpecifications.cs
+++ b/OpenTabletDriver.Plugin/Tablet/DigitizerSpecifications.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace OpenTabletDriver.Plugin.Tablet
 {
     public class DigitizerSpecifications
@@ -5,21 +7,25 @@ namespace OpenTabletDriver.Plugin.Tablet
         /// <summary>
         /// The width of the digitizer in millimeters.
         /// </summary>
+        [Required(ErrorMessage = $"Digitizer ${nameof(Width)} must be defined")]
         public float Width { set; get; }
 
         /// <summary>
         /// The height of the digitizer in millimeters.
         /// </summary>
+        [Required(ErrorMessage = $"Digitizer ${nameof(Height)} must be defined")]
         public float Height { set; get; }
 
         /// <summary>
         /// The maximum X coordinate for the digitizer.
         /// </summary>
+        [Required(ErrorMessage = $"Digitizer ${nameof(MaxX)} must be defined")]
         public float MaxX { set; get; }
 
         /// <summary>
         /// The maximum Y coordinate for the digitizer.
         /// </summary>
+        [Required(ErrorMessage = $"Digitizer ${nameof(MaxY)} must be defined")]
         public float MaxY { set; get; }
     }
 }

--- a/OpenTabletDriver.Plugin/Tablet/PenSpecifications.cs
+++ b/OpenTabletDriver.Plugin/Tablet/PenSpecifications.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace OpenTabletDriver.Plugin.Tablet
 {
     public class PenSpecifications
@@ -5,11 +7,13 @@ namespace OpenTabletDriver.Plugin.Tablet
         /// <summary>
         /// The maximum pressure that the pen supports.
         /// </summary>
+        [Required(ErrorMessage = $"Pen {nameof(MaxPressure)} must be defined")]
         public uint MaxPressure { set; get; }
 
         /// <summary>
         /// Specifications for the pen buttons.
         /// </summary>
+        [Required(ErrorMessage = $"{nameof(Buttons)} must be defined")]
         public ButtonSpecifications Buttons { set; get; } = new ButtonSpecifications();
     }
 }

--- a/OpenTabletDriver.Plugin/Tablet/TabletConfiguration.cs
+++ b/OpenTabletDriver.Plugin/Tablet/TabletConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 #nullable enable
 
@@ -9,26 +10,32 @@ namespace OpenTabletDriver.Plugin.Tablet
         /// <summary>
         /// The tablet's name.
         /// </summary>
+        [Required(ErrorMessage = $"Tablet {nameof(Name)} is required")]
         public string Name { set; get; } = string.Empty;
 
         /// <summary>
         /// The tablet's specifications.
         /// </summary>
+        [Required(ErrorMessage = $"Tablet {nameof(Specifications)} is required")]
         public TabletSpecifications Specifications { set; get; } = new TabletSpecifications();
 
         /// <summary>
         /// The digitizer device identifier.
         /// </summary>
+        [Required(ErrorMessage = $"Tablet {nameof(DigitizerIdentifiers)} are required")]
+        [MinLength(1, ErrorMessage = "Requires at least 1 identifier")]
         public List<DeviceIdentifier> DigitizerIdentifiers { set; get; } = new List<DeviceIdentifier>();
 
         /// <summary>
         /// The auxiliary device identifier.
         /// </summary>
+        [Required(ErrorMessage = $"Tablet {nameof(AuxilaryDeviceIdentifiers)} must be present")]
         public List<DeviceIdentifier> AuxilaryDeviceIdentifiers { set; get; } = new List<DeviceIdentifier>();
 
         /// <summary>
         /// Other information about the tablet that can be used in tools or other applications.
         /// </summary>
+        [Required(ErrorMessage = $"Tablet {nameof(Attributes)} must be present")]
         public Dictionary<string, string> Attributes { set; get; } = new Dictionary<string, string>();
     }
 }

--- a/OpenTabletDriver.Plugin/Tablet/TabletSpecifications.cs
+++ b/OpenTabletDriver.Plugin/Tablet/TabletSpecifications.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace OpenTabletDriver.Plugin.Tablet
 {
     public class TabletSpecifications
@@ -5,11 +7,13 @@ namespace OpenTabletDriver.Plugin.Tablet
         /// <summary>
         /// Specifications for the tablet digitizer.
         /// </summary>
+        [Required(ErrorMessage = $"{nameof(Digitizer)} specifications must be defined")]
         public DigitizerSpecifications Digitizer { set; get; }
 
         /// <summary>
         /// Specifications for the tablet's pen.
         /// </summary>
+        [Required(ErrorMessage = $"{nameof(Pen)} specifications must be defined")]
         public PenSpecifications Pen { set; get; }
 
         /// <summary>

--- a/OpenTabletDriver.Tests/OpenTabletDriver.Tests.csproj
+++ b/OpenTabletDriver.Tests/OpenTabletDriver.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.15" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Backport of #3027

Includes config changes to ensure tests pass.

- [x] needs cherry pick: ebfff1c9cee7b1948adc2d20b6d63f3871475bab