### PR TITLE
(0.6.x) Backport GitHub workflows

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3.2.0
         with:
-          dotnet-version: '7.0'
+          dotnet-version: '6.0'
 
       - name: Windows
         run: dotnet restore OpenTabletDriver.Windows.slnf

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,13 +12,12 @@ jobs:
     name: Linux Publish
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: '6.0'
-          include-prerelease: True
 
       - name: Linux Publish
         env:
@@ -30,7 +29,7 @@ jobs:
           dotnet publish OpenTabletDriver.UX.Gtk "${options[@]}" --runtime "$runtime" -o "build/$runtime"
 
       - name: Upload Linux artifacts
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: OpenTabletDriver linux-x64
           path: build/linux-x64
@@ -39,7 +38,7 @@ jobs:
         run: ./generate-rules.sh > 70-opentabletdriver.rules
 
       - name: Upload udev Rules
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: udev Rules
           path: 70-opentabletdriver.rules
@@ -49,13 +48,12 @@ jobs:
     name: MacOS Publish
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: '6.0'
-          include-prerelease: True
 
       - name: MacOS Publish
         env:
@@ -67,7 +65,7 @@ jobs:
           dotnet publish OpenTabletDriver.UX.MacOS "${options[@]}" --runtime "$runtime" -o "build/$runtime"
 
       - name: Upload MacOS artifacts
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: OpenTabletDriver osx-x64
           path: build/osx-x64
@@ -77,13 +75,12 @@ jobs:
     name: Windows Publish
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: '6.0'
-          include-prerelease: True
 
       - name: Windows Publish
         env:
@@ -95,44 +92,65 @@ jobs:
           dotnet publish OpenTabletDriver.UX.Wpf $options --runtime $ENV:runtime -o build/$ENV:runtime
 
       - name: Upload Windows artifacts
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: OpenTabletDriver win-x64
           path: build/win-x64
 
   linter:
-    name: dotnet format
+    name: Lint Code
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           # Full git history is needed to get a proper list of changed files
           fetch-depth: 0
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: '6.0'
-          include-prerelease: True
 
       - name: Lint Changed Files
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.sha }} # latest commit on target branch
         run: |
-          mapfile -t files < <(git diff --name-only --diff-filter=AM HEAD^ HEAD | grep '.*\.cs$')
-          if [ ${#files[@]} -ne 0 ]; then dotnet format OpenTabletDriver --verify-no-changes --include "${files[@]}"; fi
+          mapfile -t files < <(git diff --name-only --diff-filter=AM $PR_BASE_REF HEAD | grep '.*\.cs$')
+          if [ ${#files[@]} -ne 0 ]; then dotnet format OpenTabletDriver.sln --verify-no-changes --include "${files[@]}"; fi
 
   unittests:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: '6.0'
-          include-prerelease: True
 
       - name: Run tests
         run: dotnet test
+
+  slnf:
+    name: Validate Solution Filters
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v3.2.0
+        with:
+          dotnet-version: '7.0'
+
+      - name: Windows
+        run: dotnet restore OpenTabletDriver.Windows.slnf
+
+      - name: Linux
+        run: dotnet restore OpenTabletDriver.Linux.slnf
+
+      - name: MacOS
+        run: dotnet restore OpenTabletDriver.MacOS.slnf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         run: sudo apt install -y debhelper dotnet-sdk-6.0
 
       - name: Checkout OpenTabletDriver Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Debian Build
         run: ./eng/linux/package.sh --package Debian --output ./dist/debian
@@ -47,21 +47,21 @@ jobs:
 
       - name: Upload Debian artifact (Dispatch)
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: OpenTabletDriver.deb
           path: ./dist/debian/*.deb
 
       - name: Upload generic Linux artifact (Dispatch)
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: OpenTabletDriver.linux-x64.tar.gz
           path: ./dist/tarball/*.tar.gz
 
       - name: Upload macOS artifact (Dispatch)
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: OpenTabletDriver.osx-x64.tar.gz
           path: ./dist/macos/*.tar.gz
@@ -78,7 +78,7 @@ jobs:
         run: sudo dnf install -y rpm-build systemd-rpm-macros libicu openssl-libs zlib krb5-libs git dotnet-sdk-6.0 tree
 
       - name: Checkout OpenTabletDriver Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # https://github.com/actions/checkout/issues/1169
       - run: git config --system --add safe.directory /__w/OpenTabletDriver/OpenTabletDriver
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload RPM artifact (Dispatch)
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: OpenTabletDriver.rpm
           path: ./dist/redhat/*.rpm
@@ -110,13 +110,12 @@ jobs:
       VERSION_SUFFIX: ${{ github.event.inputs.version_suffix }}
     steps:
       - name: Checkout OpenTabletDriver Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: '6.0'
-          include-prerelease: True
 
       - name: Package
         run: ./eng/windows/package.ps1
@@ -133,7 +132,7 @@ jobs:
 
       - name: Upload Windows asset (Dispatch)
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: OpenTabletDriver.win-x64.zip
           path: ./dist/*.zip

--- a/OpenTabletDriver.Linux.slnf
+++ b/OpenTabletDriver.Linux.slnf
@@ -2,18 +2,18 @@
   "solution": {
     "path": ".\\OpenTabletDriver.sln",
     "projects": [
-      ".\\OpenTabletDriver\\OpenTabletDriver.csproj",
-      ".\\OpenTabletDriver.Benchmarks\\OpenTabletDriver.Benchmarks.csproj",
-      ".\\OpenTabletDriver.Configurations\\OpenTabletDriver.Configurations.csproj",
-      ".\\OpenTabletDriver.Console\\OpenTabletDriver.Console.csproj",
-      ".\\OpenTabletDriver.Daemon\\OpenTabletDriver.Daemon.csproj",
-      ".\\OpenTabletDriver.Desktop\\OpenTabletDriver.Desktop.csproj",
-      ".\\OpenTabletDriver.Native\\OpenTabletDriver.Native.csproj",
-      ".\\OpenTabletDriver.Plugin\\OpenTabletDriver.Plugin.csproj",
-      ".\\OpenTabletDriver.Tests\\OpenTabletDriver.Tests.csproj",
-      ".\\OpenTabletDriver.Tools.udev\\OpenTabletDriver.Tools.udev.csproj",
-      ".\\OpenTabletDriver.UX\\OpenTabletDriver.UX.csproj",
-      ".\\OpenTabletDriver.UX.Gtk\\OpenTabletDriver.UX.Gtk.csproj"
+      "OpenTabletDriver\\OpenTabletDriver.csproj",
+      "OpenTabletDriver.Benchmarks\\OpenTabletDriver.Benchmarks.csproj",
+      "OpenTabletDriver.Configurations\\OpenTabletDriver.Configurations.csproj",
+      "OpenTabletDriver.Console\\OpenTabletDriver.Console.csproj",
+      "OpenTabletDriver.Daemon\\OpenTabletDriver.Daemon.csproj",
+      "OpenTabletDriver.Desktop\\OpenTabletDriver.Desktop.csproj",
+      "OpenTabletDriver.Native\\OpenTabletDriver.Native.csproj",
+      "OpenTabletDriver.Plugin\\OpenTabletDriver.Plugin.csproj",
+      "OpenTabletDriver.Tests\\OpenTabletDriver.Tests.csproj",
+      "OpenTabletDriver.Tools.udev\\OpenTabletDriver.Tools.udev.csproj",
+      "OpenTabletDriver.UX\\OpenTabletDriver.UX.csproj",
+      "OpenTabletDriver.UX.Gtk\\OpenTabletDriver.UX.Gtk.csproj"
     ]
   }
 }

--- a/OpenTabletDriver.MacOS.slnf
+++ b/OpenTabletDriver.MacOS.slnf
@@ -2,17 +2,17 @@
   "solution": {
     "path": ".\\OpenTabletDriver.sln",
     "projects": [
-      ".\\OpenTabletDriver\\OpenTabletDriver.csproj",
-      ".\\OpenTabletDriver.Benchmarks\\OpenTabletDriver.Benchmarks.csproj",
-      ".\\OpenTabletDriver.Configurations\\OpenTabletDriver.Configurations.csproj",
-      ".\\OpenTabletDriver.Console\\OpenTabletDriver.Console.csproj",
-      ".\\OpenTabletDriver.Daemon\\OpenTabletDriver.Daemon.csproj",
-      ".\\OpenTabletDriver.Desktop\\OpenTabletDriver.Desktop.csproj",
-      ".\\OpenTabletDriver.Native\\OpenTabletDriver.Native.csproj",
-      ".\\OpenTabletDriver.Plugin\\OpenTabletDriver.Plugin.csproj",
-      ".\\OpenTabletDriver.Tests\\OpenTabletDriver.Tests.csproj",
-      ".\\OpenTabletDriver.UX\\OpenTabletDriver.UX.csproj",
-      ".\\OpenTabletDriver.UX.MacOS\\OpenTabletDriver.UX.MacOS.csproj"
+      "OpenTabletDriver\\OpenTabletDriver.csproj",
+      "OpenTabletDriver.Benchmarks\\OpenTabletDriver.Benchmarks.csproj",
+      "OpenTabletDriver.Configurations\\OpenTabletDriver.Configurations.csproj",
+      "OpenTabletDriver.Console\\OpenTabletDriver.Console.csproj",
+      "OpenTabletDriver.Daemon\\OpenTabletDriver.Daemon.csproj",
+      "OpenTabletDriver.Desktop\\OpenTabletDriver.Desktop.csproj",
+      "OpenTabletDriver.Native\\OpenTabletDriver.Native.csproj",
+      "OpenTabletDriver.Plugin\\OpenTabletDriver.Plugin.csproj",
+      "OpenTabletDriver.Tests\\OpenTabletDriver.Tests.csproj",
+      "OpenTabletDriver.UX\\OpenTabletDriver.UX.csproj",
+      "OpenTabletDriver.UX.MacOS\\OpenTabletDriver.UX.MacOS.csproj"
     ]
   }
 }

--- a/OpenTabletDriver.Windows.slnf
+++ b/OpenTabletDriver.Windows.slnf
@@ -2,17 +2,17 @@
   "solution": {
     "path": ".\\OpenTabletDriver.sln",
     "projects": [
-      ".\\OpenTabletDriver\\OpenTabletDriver.csproj",
-      ".\\OpenTabletDriver.Benchmarks\\OpenTabletDriver.Benchmarks.csproj",
-      ".\\OpenTabletDriver.Configurations\\OpenTabletDriver.Configurations.csproj",
-      ".\\OpenTabletDriver.Console\\OpenTabletDriver.Console.csproj",
-      ".\\OpenTabletDriver.Daemon\\OpenTabletDriver.Daemon.csproj",
-      ".\\OpenTabletDriver.Desktop\\OpenTabletDriver.Desktop.csproj",
-      ".\\OpenTabletDriver.Native\\OpenTabletDriver.Native.csproj",
-      ".\\OpenTabletDriver.Plugin\\OpenTabletDriver.Plugin.csproj",
-      ".\\OpenTabletDriver.Tests\\OpenTabletDriver.Tests.csproj",
-      ".\\OpenTabletDriver.UX\\OpenTabletDriver.UX.csproj",
-      ".\\OpenTabletDriver.UX.Wpf\\OpenTabletDriver.UX.Wpf.csproj"
+      "OpenTabletDriver\\OpenTabletDriver.csproj",
+      "OpenTabletDriver.Benchmarks\\OpenTabletDriver.Benchmarks.csproj",
+      "OpenTabletDriver.Configurations\\OpenTabletDriver.Configurations.csproj",
+      "OpenTabletDriver.Console\\OpenTabletDriver.Console.csproj",
+      "OpenTabletDriver.Daemon\\OpenTabletDriver.Daemon.csproj",
+      "OpenTabletDriver.Desktop\\OpenTabletDriver.Desktop.csproj",
+      "OpenTabletDriver.Native\\OpenTabletDriver.Native.csproj",
+      "OpenTabletDriver.Plugin\\OpenTabletDriver.Plugin.csproj",
+      "OpenTabletDriver.Tests\\OpenTabletDriver.Tests.csproj",
+      "OpenTabletDriver.UX\\OpenTabletDriver.UX.csproj",
+      "OpenTabletDriver.UX.Wpf\\OpenTabletDriver.UX.Wpf.csproj"
     ]
   }
 }


### PR DESCRIPTION
Includes all changes up to edb80993d (latest at the time of PR) with the addition of the currently unmerged #3031

Clobbered history because its easier and 0.6.x should die >:(