### PR TITLE
(0.6.x.) UI Title: Remove 'No tablets detected'

### DIFF
--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -341,17 +341,19 @@ namespace OpenTabletDriver.UX
 
         private void SetTitle(IEnumerable<TabletReference> tablets = null)
         {
-            string prefix = $"OpenTabletDriver v{App.Version} - ";
+            string prefix = $"OpenTabletDriver v{App.Version}";
+            string affix = string.Empty;
+
             if (tablets?.Any() ?? false)
             {
                 // Limit to 3 tablets in the title
                 int numTablets = Math.Min(tablets.Count(), 3);
-                this.Title = prefix + string.Join(", ", tablets.Take(numTablets).Select(t => t.Properties.Name));
+                affix = string.Join(", ", tablets.Take(numTablets).Select(t => t.Properties.Name));
             }
-            else
-            {
-                this.Title = prefix + "No tablets detected.";
-            }
+
+            this.Title = !string.IsNullOrEmpty(affix)
+                ? $"{prefix} - {affix}"
+                : prefix;
         }
 
         private void HandleDaemonConnected(object sender, EventArgs e) => Application.Instance.AsyncInvoke(async () =>


### PR DESCRIPTION
When the daemon is not connected, the title confusingly still shows no tablets detected. This PR simplifies that behavior to the following:

Tablet detected and daemon connected:
> "OpenTabletDriver v0.6.3.0 - YourTablet Model"

No tablets detected and/or daemon not connected:
> "OpenTabletDriver v0.6.3.0"

The change isn't tested, but it should work.