### PR TITLE
(0.6.x) Deco L: Fix incorrect pressure

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco L.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco L.json
@@ -8,7 +8,7 @@
       "MaxY": 30480
     },
     "Pen": {
-      "MaxPressure": 8192,
+      "MaxPressure": 8191,
       "Buttons": {
         "ButtonCount": 2
       }


### PR DESCRIPTION
Backport of #3028

A pending Deco M PR (#3000) describes the max pressure as being 8191. I assume it is the case for the Deco L as well, and that this was just a typo.