### PR TITLE
MacOS: Set mouse delta to move and drag event

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/MacOSAbsolutePointer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/MacOSAbsolutePointer.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Numerics;
 using OpenTabletDriver.Native.MacOS;
+using OpenTabletDriver.Native.MacOS.Input;
 using OpenTabletDriver.Platform.Display;
 using OpenTabletDriver.Platform.Pointer;
 
@@ -12,6 +13,8 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
     public class MacOSAbsolutePointer : MacOSVirtualMouse, IAbsolutePointer
     {
         private Vector2 offset;
+        private Vector2 lastPos;
+        private Vector2 delta;
 
         public MacOSAbsolutePointer(IVirtualScreen virtualScreen)
         {
@@ -22,12 +25,17 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
         public void SetPosition(Vector2 pos)
         {
             var newPos = pos - offset;
+            delta = newPos - lastPos;
+            lastPos = newPos;
+
             QueuePendingPosition(newPos.X, newPos.Y);
         }
 
         protected override void SetPendingPosition(IntPtr mouseEvent, float x, float y)
         {
             CGEventSetLocation(mouseEvent, new CGPoint(x, y));
+            CGEventSetDoubleValueField(mouseEvent, CGEventField.mouseEventDeltaX, delta.X);
+            CGEventSetDoubleValueField(mouseEvent, CGEventField.mouseEventDeltaY, delta.Y);
         }
 
         protected override void ResetPendingPosition(IntPtr mouseEvent)

--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/MacOSAbsolutePointer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/MacOSAbsolutePointer.cs
@@ -13,8 +13,8 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
     public class MacOSAbsolutePointer : MacOSVirtualMouse, IAbsolutePointer
     {
         private Vector2 offset;
-        private Vector2 lastPos;
-        private Vector2 delta;
+        private Vector2? lastPos;
+        private Vector2? delta;
 
         public MacOSAbsolutePointer(IVirtualScreen virtualScreen)
         {
@@ -34,12 +34,17 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
         protected override void SetPendingPosition(IntPtr mouseEvent, float x, float y)
         {
             CGEventSetLocation(mouseEvent, new CGPoint(x, y));
-            CGEventSetDoubleValueField(mouseEvent, CGEventField.mouseEventDeltaX, delta.X);
-            CGEventSetDoubleValueField(mouseEvent, CGEventField.mouseEventDeltaY, delta.Y);
+            if (delta is not null)
+            {
+                CGEventSetDoubleValueField(mouseEvent, CGEventField.mouseEventDeltaX, delta.Value.X);
+                CGEventSetDoubleValueField(mouseEvent, CGEventField.mouseEventDeltaY, delta.Value.Y);
+            }
         }
 
         protected override void ResetPendingPosition(IntPtr mouseEvent)
         {
+            lastPos = null;
+            delta = null;
         }
     }
 }

--- a/OpenTabletDriver.Desktop/Interop/Input/MacOSVirtualMouse.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/MacOSVirtualMouse.cs
@@ -13,8 +13,6 @@ namespace OpenTabletDriver.Desktop.Interop.Input
         private int _prevButtonStates;
         private float? _pendingX;
         private float? _pendingY;
-        private float? _lastX;
-        private float? _lastY;
         private CGMouseButton _lastButton;
         private readonly IntPtr _mouseEvent = CGEventCreate(IntPtr.Zero);
 
@@ -41,16 +39,6 @@ namespace OpenTabletDriver.Desktop.Interop.Input
                 // can send drag here
                 var lastButtonSet = IsButtonSet(_currButtonStates, _lastButton);
                 var cgEventType = ToDragCGEventType(_lastButton, lastButtonSet);
-
-                if (_pendingX.HasValue && _lastX.HasValue && _pendingY.HasValue && _lastY.HasValue)
-                {
-                    // set mouse delta between current and previous mouse position
-                    var deltaX = _pendingX.Value - _lastX.Value;
-                    var deltaY = _pendingY.Value - _lastY.Value;
-                    CGEventSetDoubleValueField(_mouseEvent, CGEventField.mouseEventDeltaX, deltaX);
-                    CGEventSetDoubleValueField(_mouseEvent, CGEventField.mouseEventDeltaY, deltaY);
-                }
-
                 CGEventSetType(_mouseEvent, cgEventType);
                 CGEventPost(CGEventTapLocation.kCGHIDEventTap, _mouseEvent);
             }
@@ -64,10 +52,6 @@ namespace OpenTabletDriver.Desktop.Interop.Input
                 ProcessKeyStates(_currButtonStates, 0);
                 _prevButtonStates = 0;
                 _currButtonStates = 0;
-                _pendingX = null;
-                _pendingY = null;
-                _lastX = null;
-                _lastY = null;
             }
         }
 
@@ -76,8 +60,6 @@ namespace OpenTabletDriver.Desktop.Interop.Input
 
         protected void QueuePendingPosition(float x, float y)
         {
-            _lastX = _pendingX;
-            _lastY = _pendingY;
             _pendingX = x;
             _pendingY = y;
         }
@@ -87,6 +69,8 @@ namespace OpenTabletDriver.Desktop.Interop.Input
             if (_pendingX.HasValue)
             {
                 SetPendingPosition(_mouseEvent, _pendingX.Value, _pendingY.Value);
+                _pendingX = null;
+                _pendingY = null;
                 return true;
             }
 

--- a/OpenTabletDriver.Desktop/Interop/Input/MacOSVirtualMouse.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/MacOSVirtualMouse.cs
@@ -13,6 +13,8 @@ namespace OpenTabletDriver.Desktop.Interop.Input
         private int _prevButtonStates;
         private float? _pendingX;
         private float? _pendingY;
+        private float? _lastX;
+        private float? _lastY;
         private CGMouseButton _lastButton;
         private readonly IntPtr _mouseEvent = CGEventCreate(IntPtr.Zero);
 
@@ -39,6 +41,16 @@ namespace OpenTabletDriver.Desktop.Interop.Input
                 // can send drag here
                 var lastButtonSet = IsButtonSet(_currButtonStates, _lastButton);
                 var cgEventType = ToDragCGEventType(_lastButton, lastButtonSet);
+
+                if (_pendingX.HasValue && _lastX.HasValue && _pendingY.HasValue && _lastY.HasValue)
+                {
+                    // set mouse delta between current and previous mouse position
+                    var deltaX = _pendingX.Value - _lastX.Value;
+                    var deltaY = _pendingY.Value - _lastY.Value;
+                    CGEventSetDoubleValueField(_mouseEvent, CGEventField.mouseEventDeltaX, deltaX);
+                    CGEventSetDoubleValueField(_mouseEvent, CGEventField.mouseEventDeltaY, deltaY);
+                }
+
                 CGEventSetType(_mouseEvent, cgEventType);
                 CGEventPost(CGEventTapLocation.kCGHIDEventTap, _mouseEvent);
             }
@@ -52,6 +64,10 @@ namespace OpenTabletDriver.Desktop.Interop.Input
                 ProcessKeyStates(_currButtonStates, 0);
                 _prevButtonStates = 0;
                 _currButtonStates = 0;
+                _pendingX = null;
+                _pendingY = null;
+                _lastX = null;
+                _lastY = null;
             }
         }
 
@@ -60,6 +76,8 @@ namespace OpenTabletDriver.Desktop.Interop.Input
 
         protected void QueuePendingPosition(float x, float y)
         {
+            _lastX = _pendingX;
+            _lastY = _pendingY;
             _pendingX = x;
             _pendingY = y;
         }
@@ -69,8 +87,6 @@ namespace OpenTabletDriver.Desktop.Interop.Input
             if (_pendingX.HasValue)
             {
                 SetPendingPosition(_mouseEvent, _pendingX.Value, _pendingY.Value);
-                _pendingX = null;
-                _pendingY = null;
                 return true;
             }
 


### PR DESCRIPTION
This PR fixes the issue where pen drag to pan does not work in some apps which requires mouse delta.
Fixes #3048 