### PR TITLE
Add extra string for Kamvas Pro 13 (2.5k)

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 13 (2.5k).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 13 (2.5k).json
@@ -27,7 +27,7 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {
-        "201": "HUION_M210_\\d{6}$"
+        "201": "HUION_M(210|213)_\\d{6}$"
       },
       "InitializationStrings": [
         200


### PR DESCRIPTION
My device was not detected using the existing string, this adds the one that my device has.

Fixes #3069