### PR TITLE
merge matching identifiers with different strings

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/H1060P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H1060P.json
@@ -27,7 +27,7 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {
-        "201": "HUION_T167_\\d{6}$"
+        "201": "HUION_T(167|205)_\\d{6}$"
       },
       "InitializationStrings": [
         200
@@ -43,21 +43,6 @@
       "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T167_\\d{6}$"
-      },
-      "InitializationStrings": [
-        200
-      ]
-    },
-    {
-      "VendorID": 9580,
-      "ProductID": 109,
-      "InputReportLength": 12,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {
-        "201": "HUION_T205_\\d{6}$"
       },
       "InitializationStrings": [
         200

--- a/OpenTabletDriver.Configurations/Configurations/Huion/HS64.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/HS64.json
@@ -27,22 +27,7 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {
-        "201": "HUION_T193_\\d{6}$"
-      },
-      "InitializationStrings": [
-        200
-      ]
-    },
-    {
-      "VendorID": 9580,
-      "ProductID": 109,
-      "InputReportLength": 12,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {
-        "201": "HUION_T181_\\d{6}$"
+        "201": "HUION_T(181|193)_\\d{6}$"
       },
       "InitializationStrings": [
         200


### PR DESCRIPTION
I hope I didn't accidentally unsupport some tablets! Only targets the Huion directory.

One Huion H1060P variant gains tilt support, this is untested by most likely fine to do. I can do this to the other remaining H1060P identifiers too if this is desirable.