### PR TITLE
[Backport] Use INPUT_PROP_POINTER for tablets as suggested by kernel docs

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -20,6 +20,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
             Device = new EvdevDevice("OpenTabletDriver Virtual Artist Tablet");
 
             Device.EnableProperty(InputProperty.INPUT_PROP_DIRECT);
+            Device.EnableProperty(InputProperty.INPUT_PROP_POINTER);
 
             Device.EnableType(EventType.EV_ABS);
 

--- a/OpenTabletDriver.Native/Linux/Evdev/EventType.cs
+++ b/OpenTabletDriver.Native/Linux/Evdev/EventType.cs
@@ -2,6 +2,7 @@ namespace OpenTabletDriver.Native.Linux.Evdev
 {
     public enum InputProperty : uint
     {
+        INPUT_PROP_POINTER = 0x00,
         INPUT_PROP_DIRECT = 0x01,
     }
 


### PR DESCRIPTION
Backports #2941 to `0.6.x`