### PR TITLE
[Backport] build.sh: Use ${BASH_SOURCE[0]} as root instead of cwd

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,4 +32,4 @@ while [ $# -gt 0 ]; do
 done
 
 # provide defaults, then pass everything else as-is
-. ./eng/linux/package.sh -o "${output}" -c "${config}" "${options[@]}"
+. "$(dirname ${BASH_SOURCE[0]})"/eng/linux/package.sh -o "${output}" -c "${config}" "${options[@]}"


### PR DESCRIPTION
Backports #2951 to `0.6.x`