### PR TITLE
Write logs to filesystem in real-time

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -321,10 +321,10 @@ namespace OpenTabletDriver.Daemon
             string group = dev.Configuration.Name;
 
             var elements = from store in profile.Filters
-                where store.Enable
-                let filter = _pluginFactory.Construct<IDevicePipelineElement>(store, dev)
-                where filter != null
-                select filter;
+                           where store.Enable
+                           let filter = _pluginFactory.Construct<IDevicePipelineElement>(store, dev)
+                           where filter != null
+                           select filter;
 
             outputMode.Elements = elements.Append(bindingHandler).ToList();
 
@@ -451,7 +451,7 @@ namespace OpenTabletDriver.Daemon
         {
             var baseType = _pluginManager.ExportedTypes.First(t => t.GetPath() == typeName);
             var matchingTypes = from type in _pluginFactory.GetMatchingTypes(baseType)
-                select ActivatorUtilities.CreateInstance<TypeProxy>(_serviceProvider, type);
+                                select ActivatorUtilities.CreateInstance<TypeProxy>(_serviceProvider, type);
             return Task.FromResult(matchingTypes);
         }
 

--- a/OpenTabletDriver.Daemon/LogFile.cs
+++ b/OpenTabletDriver.Daemon/LogFile.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using OpenTabletDriver.Logging;
+using SysDirectory = System.IO.Directory;
+
+namespace OpenTabletDriver.Daemon
+{
+    public sealed class LogFile : IDisposable
+    {
+        private const int MAX_LOG_FILES = 20;
+        private readonly string _fileName;
+        private readonly FileStream _stream;
+        private readonly StreamWriter _writer;
+        private readonly Channel<LogMessage> _channel = Channel.CreateUnbounded<LogMessage>();
+        private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+        private bool _disposed = false;
+
+        public string Directory { get; }
+
+        public LogFile(string logDirectory)
+        {
+            Directory = logDirectory;
+            PrepareDirectory(logDirectory);
+
+            int? i = null;
+            var currentDate = DateTime.Now;
+            string? logFile;
+
+            while (File.Exists(logFile = GetFileName(Directory, currentDate, i)))
+                i = (i + 1) ?? 1;
+
+            _fileName = logFile;
+            _stream = File.Open(_fileName, FileMode.CreateNew, FileAccess.Write, FileShare.ReadWrite);
+            _writer = new StreamWriter(_stream);
+
+            Task.Factory.StartNew(async () =>
+            {
+                var token = _cts.Token;
+                var writer = _writer;
+                await writer.WriteLineAsync("[");
+                await foreach (var logMessage in _channel.Reader.ReadAllAsync(token))
+                {
+                    if (token.IsCancellationRequested)
+                        break;
+
+                    var log = JsonConvert.SerializeObject(logMessage, Formatting.Indented) + ",";
+                    await writer.WriteLineAsync(log);
+                    await writer.FlushAsync();
+                }
+                await writer.WriteLineAsync("]");
+            }, _cts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+        }
+
+        public void Write(LogMessage message)
+        {
+            while (!_channel.Writer.TryWrite(message)) ;
+        }
+
+        public IEnumerable<LogMessage> Read()
+        {
+            using var file = File.Open(_fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(file);
+            using var jsonReader = new JsonTextReader(reader);
+
+            while (jsonReader.Read())
+            {
+                if (jsonReader.TokenType == JsonToken.StartObject)
+                {
+                    LogMessage? logMessage = null;
+                    try
+                    {
+                        logMessage = JsonConvert.DeserializeObject<LogMessage>(JObject.Load(jsonReader).ToString());
+                    }
+                    catch
+                    {
+                        // ignored
+                    }
+
+                    if (logMessage != null)
+                        yield return logMessage;
+                }
+            }
+        }
+
+        private static string GetFileName(string directory, DateTime date, int? index = null)
+        {
+            var fileName = date.ToUniversalTime().ToString("u").Replace(":", "_");
+            if (index.HasValue)
+                fileName += $"-{index.Value}";
+            fileName += ".log.json";
+            return Path.Combine(directory, fileName);
+        }
+
+        private static void PrepareDirectory(string directory)
+        {
+            if (!SysDirectory.Exists(directory))
+                SysDirectory.CreateDirectory(directory);
+
+            var files = SysDirectory.GetFiles(directory, "*.log.json");
+            if (files.Length < MAX_LOG_FILES)
+                return;
+
+            Array.Sort(files);
+
+            for (var i = 0; i <= files.Length - MAX_LOG_FILES; i++)
+            {
+                try
+                {
+                    File.Delete(files[i]);
+                }
+                catch
+                {
+                    // ignored
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            _cts.Cancel();
+            _writer.Flush();
+            _writer.Dispose();
+            _stream.Dispose();
+        }
+
+        ~LogFile()
+        {
+            Dispose();
+        }
+    }
+}

--- a/OpenTabletDriver.Desktop/Diagnostics/DiagnosticInfo.cs
+++ b/OpenTabletDriver.Desktop/Diagnostics/DiagnosticInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using OpenTabletDriver.Attributes;

--- a/OpenTabletDriver.Desktop/Interop/AppInfo/AppInfo.cs
+++ b/OpenTabletDriver.Desktop/Interop/AppInfo/AppInfo.cs
@@ -13,6 +13,7 @@ namespace OpenTabletDriver.Desktop.Interop.AppInfo
             _settingsFile,
             _pluginDirectory,
             _presetDirectory,
+            _logDirectory,
             _temporaryDirectory,
             _cacheDirectory,
             _backupDirectory,
@@ -52,6 +53,12 @@ namespace OpenTabletDriver.Desktop.Interop.AppInfo
         {
             set => _presetDirectory = value;
             get => _presetDirectory ?? GetDefaultPresetDirectory();
+        }
+
+        public string LogDirectory
+        {
+            set => _logDirectory = value;
+            get => _logDirectory ?? GetDefaultLogDirectory();
         }
 
         public string TemporaryDirectory
@@ -112,6 +119,7 @@ namespace OpenTabletDriver.Desktop.Interop.AppInfo
         private string GetDefaultSettingsFile() => Path.Join(AppDataDirectory, "settings.json");
         private string GetDefaultPluginDirectory() => Path.Join(AppDataDirectory, "Plugins");
         private string GetDefaultPresetDirectory() => Path.Join(AppDataDirectory, "Presets");
+        private string GetDefaultLogDirectory() => Path.Join(AppDataDirectory, "Logs");
         private string GetDefaultTemporaryDirectory() => Path.Join(AppDataDirectory, "Temp");
         private string GetDefaultCacheDirectory() => Path.Join(AppDataDirectory, "Cache");
         private string GetDefaultBackupDirectory() => Path.Join(AppDataDirectory, "Backup");

--- a/OpenTabletDriver.Desktop/Interop/AppInfo/IAppInfo.cs
+++ b/OpenTabletDriver.Desktop/Interop/AppInfo/IAppInfo.cs
@@ -8,6 +8,7 @@ namespace OpenTabletDriver.Desktop.Interop.AppInfo
         string BinaryDirectory { set; get; }
         string PluginDirectory { set; get; }
         string PresetDirectory { set; get; }
+        string LogDirectory { set; get; }
         string TemporaryDirectory { set; get; }
         string CacheDirectory { set; get; }
         string BackupDirectory { set; get; }

--- a/OpenTabletDriver.Desktop/Json/Converters/Implementations/SerializableAppInfo.cs
+++ b/OpenTabletDriver.Desktop/Json/Converters/Implementations/SerializableAppInfo.cs
@@ -9,6 +9,7 @@ namespace OpenTabletDriver.Desktop.Json.Converters.Implementations
         public string BinaryDirectory { get; set; } = string.Empty;
         public string PluginDirectory { get; set; } = string.Empty;
         public string PresetDirectory { get; set; } = string.Empty;
+        public string LogDirectory { get; set; } = string.Empty;
         public string TemporaryDirectory { get; set; } = string.Empty;
         public string CacheDirectory { get; set; } = string.Empty;
         public string BackupDirectory { get; set; } = string.Empty;

--- a/OpenTabletDriver/Logging/LogMessage.cs
+++ b/OpenTabletDriver/Logging/LogMessage.cs
@@ -27,7 +27,7 @@ namespace OpenTabletDriver.Logging
         /// <summary>
         /// The time in which a log message was created.
         /// </summary>
-        public DateTime Time { private set; get; } = DateTime.Now;
+        public DateTime Time { set; get; } = DateTime.Now;
 
         /// <summary>
         /// The group in which the log message belongs to.


### PR DESCRIPTION
Moves storage of logs to a file instead of in-memory. Reduces memory usage for long-term use.

Location: `<OTD_AppData>/Logs/*.log.json`

Things to note:

- Logging to file is done asynchronously via channel.
- `daemon.log` is gone.
- Maximum number of logs stored is 20.
- Diagnostics have no functional changes.
- The resulting log will almost always be an incomplete json array. The parser we use ignores this but is something to take care of when using other tools.

Example log:
```json
[
--- snip ---
{
  "Time": "2023-12-10T22:18:16.624045+08:00",
  "Group": "XP-Pen Star G640S",
  "Message": "Output mode: Absolute Mode",
  "StackTrace": null,
  "Level": 1,
  "Notification": false
},
{
  "Time": "2023-12-10T22:18:16.6575207+08:00",
  "Group": "MouseBinding",
  "Message": "Button: Left",
  "StackTrace": null,
  "Level": 0,
  "Notification": false
},
{
  "Time": "2023-12-10T22:18:16.6706812+08:00",
  "Group": "Settings",
  "Message": "Driver is enabled.",
  "StackTrace": null,
  "Level": 1,
  "Notification": false
},
```
