### PR TITLE
Remove dist macro in RPM release

### DIFF
--- a/eng/linux/RedHat/package.sh
+++ b/eng/linux/RedHat/package.sh
@@ -19,7 +19,7 @@ echo "Generating ${OTD_LNAME}.spec..."
 cat << EOF > "${output}/SPECS/${OTD_LNAME}.spec"
 Name: ${OTD_LNAME}
 Version: ${OTD_VERSION}
-Release: ${PKG_VER}%{?dist}
+Release: ${PKG_VER}
 Summary: A ${OTD_DESC}
 
 Source0: ${OTD_LNAME}-${OTD_VERSION}.tar.gz


### PR DESCRIPTION
It may give users an impression that our RPM package only supports Fedora, so I think it's better to remove it.