### PR TITLE
[Backport] Do not include source revision in MSBuild

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,7 @@
     <FrameworkBase>net6.0</FrameworkBase>
     <LangVersion>preview</LangVersion>
     <VersionPrefix>$(VersionBase)</VersionPrefix>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Package Information">


### PR DESCRIPTION
Backports #3124 to `0.6.x`