### PR TITLE
Add support for Acepen AP906

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Acepen/AP1060.json
+++ b/OpenTabletDriver.Configurations/Configurations/Acepen/AP1060.json
@@ -1,0 +1,39 @@
+{
+  "Name": "Acepen AP1060",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 254,
+      "Height": 152.4,
+      "MaxX": 50800,
+      "MaxY": 30480
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 8
+    },
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 21827,
+      "ProductID": 130,
+      "InputReportLength": 11,
+      "OutputReportLength": 9,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Acepen.AcepenReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": [
+        "CQrhSgAAbD0A",
+        "CQEE",
+        "CQIC"
+      ],
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }
+  ],
+  "AuxiliaryDeviceIdentifiers": [],
+  "Attributes": {}
+}

--- a/OpenTabletDriver.Configurations/Configurations/Acepen/AP906.json
+++ b/OpenTabletDriver.Configurations/Configurations/Acepen/AP906.json
@@ -1,11 +1,11 @@
 {
-  "Name": "Acepen AP 1060",
+  "Name": "Acepen AP906",
   "Specifications": {
     "Digitizer": {
-      "Width": 254,
-      "Height": 152.4,
-      "MaxX": 50800,
-      "MaxY": 30480
+      "Width": 229.87,
+      "Height": 142.24,
+      "MaxX": 45974,
+      "MaxY": 28448
     },
     "Pen": {
       "MaxPressure": 8191,
@@ -20,7 +20,7 @@
   "DigitizerIdentifiers": [
     {
       "VendorID": 21827,
-      "ProductID": 130,
+      "ProductID": 145,
       "InputReportLength": 11,
       "OutputReportLength": 9,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Acepen.AcepenReportParser",

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -1,6 +1,7 @@
 | Tablet                        |      Status       | Notes |
 | ---------------------------   | :---------------: | ----- |
-| Acepen AP 1060                |     Supported     |
+| Acepen AP906                  |     Supported     |
+| Acepen AP1060                 |     Supported     |
 | Adesso Cybertablet K8         |     Supported     |
 | Gaomon 1060 Pro               |     Supported     |
 | Gaomon GM116HD                |     Supported     |


### PR DESCRIPTION
This commit also fixes the name on the AP1060, as the model name doesn't contain that space.

verification: https://canary.discord.com/channels/615607687467761684/1186132031097274478/1188537323147776110