### PR TITLE
Add support for Parblo A640

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Parblo/A640.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/A640.json
@@ -1,0 +1,37 @@
+{
+  "Name": "Parblo A640",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 155,
+      "Height": 93,
+      "MaxX": 29616,
+      "MaxY": 17170
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": null,
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 21827,
+      "ProductID": 97,
+      "InputReportLength": 10,
+      "OutputReportLength": 0,
+      "ReportParser": "OpenTabletDriver.Tablet.TabletReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": [
+        100
+      ]
+    }
+  ],
+  "AuxiliaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -192,6 +192,7 @@
 | Lifetec LT9570                |  Missing Features | Aux buttons and tilt is not yet supported.
 | Monoprice MP1060-HA60         |  Missing Features | Tablet buttons are not yet supported. Windows: Requires Zadig's WinUSB to be installed on interface 0
 | Parblo A610 Pro               |  Missing Features | Wheel is not yet supported.
+| Parblo A640                   |  Missing Features | Aux buttons are not yet supported.
 | Parblo Intangbo M             |  Missing Features | Wheel is not yet supported.
 | Parblo Intangbo S             |  Missing Features | Wheel is not yet supported.
 | UGEE EX08                     |  Missing Features | Tilt is not yet supported. Uses the same configuration as the XP-Pen Deco 01 V2.


### PR DESCRIPTION
Fixes #3128.

This tablet doesn't have a listing anymore because Parblo pulled it presumably because they don't want to support this tablet either.

verification: https://canary.discord.com/channels/615607687467761684/1185199717743865908/1190311364191858848
diagnostic: https://canary.discord.com/channels/615607687467761684/1185199717743865908/1190270418188243014
strings: https://canary.discord.com/channels/615607687467761684/1185199717743865908/1190291812502478879

A lot of things to note here.
- The lpi is weird, the user had to measured the active area of the tablet and this is as accurate we are getting.
- Tablet buttons do not work due to usage of the basic TabletReportParser. The tablet also doesn't change anything on the report, but this may change if we init on string 123, but there is no point doing this as the parser doesn't support it anyway, so not really worth trying at this time.
- Throwing init on string 100 or `ArAE` causes the tablet to revert to 7999 limits on both x and y axis.
- This tablet is otherwise cursed so I'm not sure anything can really be improved with this configuration.



Unrelated things to note:
- Why is the A640 **V2** configuration using a wrong size? Calculating the size with the lpi and coordinates leads to a value much closer to the actual tablet size measured by this user, and what the parblo support page says.
