### PR TITLE
[Backport] Add support for Parblo A640

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Parblo/A640.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/A640.json
@@ -1,0 +1,39 @@
+{
+  "Name": "Parblo A640",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 155,
+      "Height": 93,
+      "MaxX": 29616.0,
+      "MaxY": 17170.0
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "Buttons": {
+        "ButtonCount": 2
+      }
+    },
+    "AuxiliaryButtons": null,
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 21827,
+      "ProductID": 97,
+      "InputReportLength": 10,
+      "OutputReportLength": 0,
+      "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": [
+        100
+      ]
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -192,6 +192,7 @@
 | Lifetec LT9570                |  Missing Features | Aux buttons and tilt is not yet supported.
 | Monoprice MP1060-HA60         |  Missing Features | Tablet buttons are not yet supported. Windows: Requires Zadig's WinUSB to be installed on interface 0
 | Parblo A610 Pro               |  Missing Features | Wheel is not yet supported.
+| Parblo A640                   |  Missing Features | Aux buttons are not yet supported.
 | Parblo Intangbo M             |  Missing Features | Wheel is not yet supported.
 | Parblo Intangbo S             |  Missing Features | Wheel is not yet supported.
 | UGEE EX08                     |  Missing Features | Tilt is not yet supported. Uses the same configuration as the XP-Pen Deco 01 V2.


### PR DESCRIPTION
Backport of #3157.

Opening as draft because its highly likely something will be tweaked with that PR before its actually merged, so leaving as draft until the other is merged so I can confirm the right changes are pulled into 0.6.x.