### PR TITLE
Update templates diagnostic step

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -52,13 +52,12 @@ body:
       label: Diagnostic Information
       description: |
         Export diagnostics through the OpenTabletDriver GUI from menu <kbd>Help</kbd> → <kbd>Export Diagnostics</kbd>.
-        Then, in the text area below, either attach the file\* or paste its contents\*\*.
+        Then, in the text area below, It is much preferred that you attach the file, but you can also or paste its contents\*.
 
-        **If you are not able to export diagnostics** for some reason (i.e., crashes), then **paste a stack trace
-        if you got one**, or just type "N/A" if there's simply nothing else you can contribute.
+        **If you are not able to export diagnostics** for some reason (i.e., crashes), then retrieve logs for your platform following
+        [these](https://opentabletdriver.net/Wiki/Documentation/Logs#daemon-log) instructions, if you cannot retrieve logs or you have nothing else you can contribute here type "N/A".
 
-        \*: You may need to rename the file to have a `.txt` extension for GitHub to allow uploading it.
-        \*\*: If pasting diagnostics, it would be helpful to use a JSON code block, as you can see in the placeholder text below.
+        \*: If pasting diagnostics, it would be helpful to use a JSON code block, as you can see in the placeholder text below.
       placeholder: |
         ```json
         <paste file contents>

--- a/.github/ISSUE_TEMPLATE/support_request.yml
+++ b/.github/ISSUE_TEMPLATE/support_request.yml
@@ -32,13 +32,12 @@ body:
       label: Diagnostic Information
       description: |
         Export diagnostics through the OpenTabletDriver GUI from menu <kbd>Help</kbd> → <kbd>Export Diagnostics</kbd>.
-        Then, in the text area below, either attach the file\* or paste its contents\*\*.
+        Then, in the text area below, It is much preferred that you attach the file, but you can also or paste its contents\*.
 
-        **If you are not able to export diagnostics** for some reason (i.e., crashes), then **paste a stack trace
-        if you got one**, or just type "N/A" if there's simply nothing else you can contribute.
+        **If you are not able to export diagnostics** for some reason (i.e., crashes), then retrieve logs for your platform following
+        [these](https://opentabletdriver.net/Wiki/Documentation/Logs#daemon-log) instructions, if you cannot retrieve logs or you have nothing else you can contribute here type "N/A".
 
-        \*: You may need to rename the file to have a `.txt` extension for GitHub to allow uploading it.
-        \*\*: If pasting diagnostics, it would be helpful to use a JSON code block, as you can see in the placeholder text below.
+        \*: If pasting diagnostics, it would be helpful to use a JSON code block, as you can see in the placeholder text below.
       placeholder: |
         ```json
         <paste file contents>

--- a/.github/ISSUE_TEMPLATE/tablet_configuration.yml
+++ b/.github/ISSUE_TEMPLATE/tablet_configuration.yml
@@ -71,9 +71,8 @@ body:
       label: Diagnostic Information
       description: |
         Export diagnostics through the OpenTabletDriver GUI from menu <kbd>Help</kbd> → <kbd>Export Diagnostics</kbd>.
-        Then, in the text area below, either attach the file\* or paste its contents\*\*.
+        Then, in the text area below, either attach the file or paste its contents\*.
 
-        \*: You may need to rename the file to have a `.txt` extension for GitHub to allow uploading it.
         \*\*: If pasting contents, it would be helpful to use a JSON code block, as you can see in the placeholder text below.
       placeholder: |
         ```json


### PR DESCRIPTION
OpenTabletDriver/opentabletdriver.github.io#152 should be fixed before this is merged, if the link changes that should also be updated on this pull request.

With the update to the logging directory users can now retrieve logs from a crash easier.

GitHub allows uploading of json files without renaming them to txt now.

I have not tested these templates updates yet and I'm bad at English so wording improvements are always welcome.