### PR TITLE
Add support for variant of Huion HS64.

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/HS64.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/HS64.json
@@ -32,6 +32,21 @@
       "InitializationStrings": [
         200
       ]
+    },
+    {
+      "VendorID": 9580,
+      "ProductID": 110,
+      "InputReportLength": 12,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "201": "HUION_T181_\\d{6}$"
+      },
+      "InitializationStrings": [
+        200
+      ]
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],


### PR DESCRIPTION
Information collected from OpenTabletDriver/OpenTabletDriver#3183. This seems like a rebrand of the HS64 under a different name, but the name is obscure and hard to find any information about, any information about it just links back to the HS64, hence modifying the original configuration.

Fixes #3183.

All verification is on the linked issue.