### PR TITLE
Fix issue with Wacom tablet auxiliary buttons not staying pressed.

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Wacom64bAuxReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Wacom64bAuxReportParser.cs
@@ -1,5 +1,7 @@
+
 ﻿using OpenTabletDriver.Plugin.Tablet;
 using OpenTabletDriver.Plugin.Tablet.Touch;
+
 
 namespace OpenTabletDriver.Configurations.Parsers.Wacom
 {
@@ -7,9 +9,11 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom
     {
         public virtual IDeviceReport Parse(byte[] data)
         {
-            return new WacomTouchReport(data, ref prevTouches);
-        }
 
-        private TouchPoint[] prevTouches;
+            return new WacomTouchReport(data, ref _prevTouches, ref _auxButtons);
+        }
+        private bool[] _auxButtons;
+        private TouchPoint[] _prevTouches;
+
     }
 }


### PR DESCRIPTION
Fix issue with Wacom tablet auxiliary buttons not staying pressed. This commit ensures that when auxiliary buttons assigned to special keys are physically held down, they remain pressed in the driver.


Corrige el problema con los botones auxiliares de la tableta Wacom que no se mantenían presionados. Este commit asegura que cuando los botones auxiliares asignados a teclas especiales están físicamente presionados, se mantienen presionados en el controlador.