### PR TITLE
Remove auxiliary buttons field for tablets that do not have auxiliary keys

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 22 Plus.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 22 Plus.json
@@ -11,9 +11,7 @@
       "MaxPressure": 8191,
       "ButtonCount": 2
     },
-    "AuxiliaryButtons": {
-      "ButtonCount": 0
-    },
+    "AuxiliaryButtons": null,
     "MouseButtons": null,
     "Touch": null
   },

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 22.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 22.json
@@ -11,9 +11,7 @@
       "MaxPressure": 8191,
       "ButtonCount": 2
     },
-    "AuxiliaryButtons": {
-      "ButtonCount": 0
-    },
+    "AuxiliaryButtons": null,
     "MouseButtons": null,
     "Touch": null
   },

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 24 Plus.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 24 Plus.json
@@ -11,9 +11,7 @@
       "MaxPressure": 8191,
       "ButtonCount": 2
     },
-    "AuxiliaryButtons": {
-      "ButtonCount": 0
-    },
+    "AuxiliaryButtons": null,
     "MouseButtons": null,
     "Touch": null
   },

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N4.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N4.json
@@ -11,9 +11,7 @@
       "MaxPressure": 8191,
       "ButtonCount": 0
     },
-    "AuxiliaryButtons": {
-      "ButtonCount": 0
-    },
+    "AuxiliaryButtons": null,
     "MouseButtons": null,
     "Touch": null
   },


### PR DESCRIPTION
Having this set to 0 can confuse users because the auxiliary settings tab will appear despite a lack of buttons, setting this to null hides this part of the UI completely, removing possible confusion.