### PR TITLE
[Backport] Remove auxiliary buttons field for tablets that do not have auxiliary keys

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 22 Plus.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 22 Plus.json
@@ -13,9 +13,7 @@
         "ButtonCount": 2
       }
     },
-    "AuxiliaryButtons": {
-      "ButtonCount": 0
-    },
+    "AuxiliaryButtons": null,
     "MouseButtons": null,
     "Touch": null
   },

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 22.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 22.json
@@ -13,9 +13,7 @@
         "ButtonCount": 2
       }
     },
-    "AuxiliaryButtons": {
-      "ButtonCount": 0
-    },
+    "AuxiliaryButtons": null,
     "MouseButtons": null,
     "Touch": null
   },

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 24 Plus.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 24 Plus.json
@@ -13,9 +13,7 @@
         "ButtonCount": 2
       }
     },
-    "AuxiliaryButtons": {
-      "ButtonCount": 0
-    },
+    "AuxiliaryButtons": null,
     "MouseButtons": null,
     "Touch": null
   },

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N4.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N4.json
@@ -13,9 +13,7 @@
         "ButtonCount": 0
       }
     },
-    "AuxiliaryButtons": {
-      "ButtonCount": 0
-    },
+    "AuxiliaryButtons": null,
     "MouseButtons": null,
     "Touch": null
   },


### PR DESCRIPTION
backport of #3193 