### PR TITLE
Add support for the UGEE M808

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/UGEE/M708 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/M708 V2.json
@@ -1,0 +1,39 @@
+{
+  "Name": "UGEE M708 V2",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 253.96,
+      "Height": 152.305,
+      "MaxX": 50792,
+      "MaxY": 30461
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 8
+    },
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 10429,
+      "ProductID": 2340,
+      "InputReportLength": 10,
+      "OutputReportLength": 10,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": [
+        "ArAE"
+      ],
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }
+  ],
+  "AuxiliaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/M708.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/M708.json
@@ -1,5 +1,5 @@
 {
-  "Name": "UGTABLET M708",
+  "Name": "UGEE M708",
   "Specifications": {
     "Digitizer": {
       "Width": 200,

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/M808.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/M808.json
@@ -1,11 +1,11 @@
 {
-  "Name": "UGTABLET M708 V2",
+  "Name": "UGEE M808",
   "Specifications": {
     "Digitizer": {
-      "Width": 253.96,
-      "Height": 152.305,
-      "MaxX": 50792,
-      "MaxY": 30461
+      "Width": 254,
+      "Height": 158.75,
+      "MaxX": 50800,
+      "MaxY": 31750
     },
     "Pen": {
       "MaxPressure": 8191,
@@ -20,9 +20,9 @@
   "DigitizerIdentifiers": [
     {
       "VendorID": 10429,
-      "ProductID": 2340,
-      "InputReportLength": 10,
-      "OutputReportLength": 10,
+      "ProductID": 10499,
+      "InputReportLength": 12,
+      "OutputReportLength": 20,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": [

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -55,10 +55,11 @@
 | RobotPen T9A                  |     Supported     |
 | UC-Logic 1060N                |     Supported     |
 | UC-Logic PF1209               |     Supported     |
+| UGEE M708 V2                  |     Supported     |
+| UGEE M808                     |     Supported     |
 | UGEE S640                     |     Supported     |
 | UGEE U1200                    |     Supported     |
 | UGEE U1600                    |     Supported     |
-| UGTABLET M708 V2              |     Supported     |
 | VEIKK A15                     |     Supported     |
 | VEIKK A15 V2                  |     Supported     |
 | VEIKK S640                    |     Supported     |
@@ -159,7 +160,7 @@
 | KENTING K5540                 |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed
 | Parblo Ninos M                |    Has Quirks     | Aux buttons are not in order.
 | Parblo Ninos S                |    Has Quirks     | Aux buttons are not in order.
-| UGTABLET M708                 |    Has Quirks     | Windows: Might need Zadig's WinUSB to be installed on interface 0
+| UGEE M708                     |    Has Quirks     | Windows: Might need Zadig's WinUSB to be installed on interface 0
 | Wacom PTU-600U                |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed
 | XP-Pen Artist 22HD            |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0
 | XP-Pen Star G430              |    Has Quirks     | Windows: Might need Zadig's WinUSB to be installed on interface 1


### PR DESCRIPTION
Also moves the remaining UGEE tablets from UGTABLET, these don't belong here, never did to begin with. They are all sold under UGEE, no idea why they started getting put here.

If those changes need to be moved to a different pull request I can do that.

Diagnostic: https://canary.discord.com/channels/615607687467761684/1204006679872806943/1204014996560810065
Verification: https://canary.discord.com/channels/615607687467761684/1204006679872806943/1204014074048942090