### PR TITLE
Add pressure parsing workaround to XD-xxxx-U

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/XD-0405-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/XD-0405-U.json
@@ -8,7 +8,7 @@
       "MaxY": 21200
     },
     "Pen": {
-      "MaxPressure": 1023,
+      "MaxPressure": 2046,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": null,

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/XD-0608-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/XD-0608-U.json
@@ -8,7 +8,7 @@
       "MaxY": 32480
     },
     "Pen": {
-      "MaxPressure": 1023,
+      "MaxPressure": 2046,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": null,

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/XD-0912-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/XD-0912-U.json
@@ -8,7 +8,7 @@
       "MaxY": 48120
     },
     "Pen": {
-      "MaxPressure": 1023,
+      "MaxPressure": 2046,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": null,

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/XD-1212-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/XD-1212-U.json
@@ -8,7 +8,7 @@
       "MaxY": 63360
     },
     "Pen": {
-      "MaxPressure": 1023,
+      "MaxPressure": 2046,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": null,

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/XD-1218-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/XD-1218-U.json
@@ -8,7 +8,7 @@
       "MaxY": 63360
     },
     "Pen": {
-      "MaxPressure": 1023,
+      "MaxPressure": 2046,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": null,


### PR DESCRIPTION
Yeah turns out these tablets also require the mangled pressure change because the parsing for these tablets are off, you can see the same requirement in GD, PTZ and others.

Verification: https://canary.discord.com/channels/615607687467761684/615611007951306863/1204509429299413172