### PR TITLE
Add UGEE S1060

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/UGEE/S1060.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/S1060.json
@@ -28,11 +28,11 @@
       "OutputInitReport": [
         "ArAE"
       ],
-      "DeviceStrings": { },
-      "InitializationStrings": [ ]
+      "DeviceStrings": {},
+      "InitializationStrings": []
     }
   ],
-  "AuxiliaryDeviceIdentifiers": [ ],
+  "AuxiliaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/S1060.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/S1060.json
@@ -1,0 +1,39 @@
+{
+  "Name": "UGEE S1060",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 254,
+      "Height": 160,
+      "MaxX": 50800,
+      "MaxY": 32000
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 12
+    },
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 10429,
+      "ProductID": 2360,
+      "InputReportLength": 12,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": [
+        "ArAE"
+      ],
+      "DeviceStrings": { },
+      "InitializationStrings": [ ]
+    }
+  ],
+  "AuxiliaryDeviceIdentifiers": [ ],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenAuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenAuxReport.cs
@@ -20,6 +20,8 @@ namespace OpenTabletDriver.Configurations.Parsers.XP_Pen
                 report[index].IsBitSet(7),
                 report[index + 1].IsBitSet(0),
                 report[index + 1].IsBitSet(1),
+                report[index + 1].IsBitSet(2),
+                report[index + 1].IsBitSet(3),
             };
         }
 

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -56,6 +56,7 @@
 | UC-Logic 1060N                |     Supported     |
 | UC-Logic PF1209               |     Supported     |
 | UGEE S640                     |     Supported     |
+| UGEE S1060                    |     Supported     |
 | UGEE U1200                    |     Supported     |
 | UGEE U1600                    |     Supported     |
 | UGTABLET M708 V2              |     Supported     |


### PR DESCRIPTION
Adds support for the UGEE S1060. Had to add 2 extra aux buttons since this tablet has 12 but the code only parsed 10 of them.

Related issue: #3053

<details><summary>diagnostics</summary>

```json
{
  "App Version": "OpenTabletDriver v0.6.4.0",
  "Build Date": "02/10/2024",
  "Operating System": {
    "Name": "NixOS",
    "Version": "24.05 (Uakari)",
    "Attributes": {
      "BUILD_ID": "24.05.20240207.f8e2ebd",
      "ID": "nixos",
      "PRETTY_NAME": "NixOS 24.05 (Uakari)",
      "VERSION_CODENAME": "uakari",
      "VERSION_ID": "24.05",
      "KERNEL_VERSION": "6.1.77"
    }
  },
  "Environment Variables": {
    "USER": "kip",
    "TEMP": null,
    "TMP": null,
    "TMPDIR": null,
    "DISPLAY": ":0",
    "WAYLAND_DISPLAY": "wayland-0",
    "PWD": "/home/kip",
    "PATH": "/nix/store/hsssk3gp60r9xxaq2kpgp3nd10zilidq-dotnet-runtime-6.0.26/bin:/run/wrappers/bin:/home/kip/.nix-profile/bin:/nix/profile/bin:/home/kip/.local/state/nix/profile/bin:/etc/profiles/per-user/kip/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin"
  },
  "HID Devices": [
    {
      "DevicePath": "/sys/devices/pci0000:00/0000:00:14.0/usb1/1-4/1-4:1.1/0003:28BD:0938.0002/hidraw/hidraw1",
      "Manufacturer": "UGTABLET",
      "ProductName": "UGEE S1060",
      "SerialNumber": "000000",
      "FriendlyName": "UGEE S1060",
      "VendorID": 10429,
      "ProductID": 2360,
      "InputReportLength": 10,
      "OutputReportLength": 0,
      "FeatureReportLength": 0,
      "CanOpen": true,
      "DeviceAttributes": {
        "USB_INTERFACE_NUMBER": "1",
        "HID_REPORTS": "07:000D:0002"
      }
    },
    {
      "DevicePath": "/sys/devices/pci0000:00/0000:00:14.0/usb1/1-4/1-4:1.2/0003:28BD:0938.0003/hidraw/hidraw2",
      "Manufacturer": "UGTABLET",
      "ProductName": "UGEE S1060",
      "SerialNumber": "000000",
      "FriendlyName": "UGEE S1060",
      "VendorID": 10429,
      "ProductID": 2360,
      "InputReportLength": 12,
      "OutputReportLength": 20,
      "FeatureReportLength": 0,
      "CanOpen": true,
      "DeviceAttributes": {
        "USB_INTERFACE_NUMBER": "2",
        "HID_REPORTS": "02:FF0A:0001"
      }
    },
    {
      "DevicePath": "/sys/devices/pci0000:00/0000:00:14.0/usb1/1-4/1-4:1.0/0003:28BD:0938.0001/hidraw/hidraw0",
      "Manufacturer": "UGTABLET",
      "ProductName": "UGEE S1060",
      "SerialNumber": "000000",
      "FriendlyName": "UGEE S1060",
      "VendorID": 10429,
      "ProductID": 2360,
      "InputReportLength": 8,
      "OutputReportLength": 0,
      "FeatureReportLength": 0,
      "CanOpen": true,
      "DeviceAttributes": {
        "USB_INTERFACE_NUMBER": "0",
        "HID_REPORTS": "09:0001:0002, 01:0001:0002, 06:0001:0006"
      }
    }
  ],
  "Console Log": [
    {
      "Time": "2024-02-10T21:03:53.5569682+01:00",
      "Group": "Detect",
      "Message": "Searching for tablets...",
      "StackTrace": null,
      "Level": 1,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5703355+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet '10moon 1060N'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5715188+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Acepen AP 1060'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5715487+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Adesso Cybertablet K8'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5717645+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Artisul A1201'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5718085+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Artisul AP604'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5718254+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Artisul M0610 Pro'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.571836+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'FlooGoo FMA100'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5718441+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Gaomon 1060 Pro'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5718689+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Gaomon GM116HD'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5718827+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Gaomon GM156HD'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.571892+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Gaomon M106K Pro'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5719156+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Gaomon M106K'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5719372+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Gaomon M10K Pro'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5719484+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Gaomon M10K'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5719582+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Gaomon M1220'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5719654+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Gaomon M1230'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5719799+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Gaomon M6'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5719913+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Gaomon PD1161'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5720043+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Gaomon PD156 Pro'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5720127+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Gaomon PD1560'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5720216+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Gaomon PD1561'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5720293+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Gaomon PD2200'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5720433+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Gaomon S56K'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5720573+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Gaomon S620'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5720749+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Gaomon S630'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5720837+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Gaomon S830'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5720922+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Genius G-Pen 560'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5721046+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Genius i405x'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5721136+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Genius i608x'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5721215+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion 420'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5721357+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion G10T'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5721441+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion G930L'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5721525+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion GC610'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5721808+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion GT-220 V2'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5721907+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion GT-221 Pro'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5721986+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion GT-221'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5722208+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion H1060P'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5722368+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion H1161'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5722532+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion H320M'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5722641+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion H420'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5722727+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion H420X'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5722895+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion H430P'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5723148+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion H580X'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5723234+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion H610 Pro V2'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.572341+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion H610 Pro V3'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5723505+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion H610 Pro'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5723613+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion H610X'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5723765+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion H640P'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5723978+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion H641P'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5724081+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion H642'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.572416+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion H690'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5724303+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion H950P'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5724437+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion HC16'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5724702+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion HS610'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5724821+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion HS611'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5724976+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion HS64'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5725066+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion HS95'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5725153+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion Kamvas 12'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5725225+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion Kamvas 13'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5725361+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion Kamvas 16 (2021)'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5725446+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion Kamvas 16'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5725533+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion Kamvas 20'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5725613+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion Kamvas 22 Plus'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5725749+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion Kamvas 22'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5725832+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion Kamvas 24 Plus'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5725911+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion Kamvas Pro 12'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5726043+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion Kamvas Pro 13 (2.5k)'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5726121+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion Kamvas Pro 13'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5726233+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion Kamvas Pro 16 (2.5k)'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5726387+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion Kamvas Pro 16'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5726878+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion Kamvas Pro 20'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5727191+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion Kamvas Pro 24 (4K)'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5727448+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion Kamvas Pro 24'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5727567+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion New 1060 Plus (2048)'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5727722+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion New 1060 Plus'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5727841+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion Q11K V2'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.572792+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion Q11K'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5728195+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion Q620M'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5728305+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion Q630M'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5728382+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion RDS-160'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5728577+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion RTE-100'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5728664+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion RTM-500'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5728917+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion WH1409 V2'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5729042+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Huion WH1409'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5729127+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'KENTING K5540'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5729198+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'LifeTec LT9570'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5729284+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Monoprice 10594'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5729398+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Monoprice MP1060-HA60'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5729488+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Parblo A609'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5729564+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Parblo A610 Pro'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5729652+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Parblo A640 V2'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5729773+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Parblo Intangbo M'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5729898+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Parblo Intangbo S'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5730067+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Parblo Ninos M'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5730177+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Parblo Ninos N4'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5730264+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Parblo Ninos N7'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5730411+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Parblo Ninos S'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5730618+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'RobotPen T9A'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5730713+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'UC-Logic 1060N'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5730792+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'UC-Logic PF1209'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.5730879+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'UGEE S1060'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.756635+01:00",
      "Group": "Device",
      "Message": "Initializing device 'UGEE S1060' /sys/devices/pci0000:00/0000:00:14.0/usb1/1-4/1-4:1.2/0003:28BD:0938.0003/hidraw/hidraw2",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7567176+01:00",
      "Group": "Device",
      "Message": "Using report parser type 'OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7629603+01:00",
      "Group": "Device",
      "Message": "Set device output: 02-B0-04",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.763213+01:00",
      "Group": "Detect",
      "Message": "Found tablet 'UGEE S1060'",
      "StackTrace": null,
      "Level": 1,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7646444+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'UGEE S640'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7646977+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'UGEE U1200'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7647091+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'UGEE U1600'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7647231+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'UGTABLET M708 V2'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7647455+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'UGTABLET M708'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7647747+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'VEIKK A15 Pro'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7647899+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'VEIKK A15 V2'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7647988+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'VEIKK A15'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7648066+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'VEIKK A30 V2'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7648144+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'VEIKK A30'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7648278+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'VEIKK A50 V2'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7648367+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'VEIKK A50'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7648445+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'VEIKK S640 V2'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7648519+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'VEIKK S640'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7648644+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'VEIKK VK1060'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7648727+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'VEIKK VK1060PRO'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7648802+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'VEIKK VK430 V2'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7648922+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'VEIKK VK430'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7649003+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'VEIKK VK640'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.764908+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'VEIKK Viola (VO1060)'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7649161+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'ViewSonic Woodpad PF0730'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7649284+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTC-4110WL'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7649366+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTC-6110WL'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7649442+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTE-430'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7649584+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTE-440'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7649713+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTE-450'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7649832+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTE-460'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7649932+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTE-630'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7650034+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTE-640'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7650181+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTE-650'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7650256+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTE-660'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.765051+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTF-430'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7650604+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTH-301'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.765068+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTH-460'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7650917+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTH-461'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7651131+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTH-470'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7651242+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTH-480'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7651345+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTH-490'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7651488+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTH-661'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7651681+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTH-670'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7651785+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTH-680'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7652064+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTH-690'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.765218+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTL-4100'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7652341+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTL-4100WL'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.765261+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTL-460'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7652711+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTL-470'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7652851+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTL-471'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7652953+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTL-472'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7653097+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTL-480'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7653203+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTL-490'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7653349+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTL-6100'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7653429+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTL-6100WL'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7653527+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTL-671'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7653671+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTL-672'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7653779+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTL-680'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7653923+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom CTL-690'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.765403+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom DTC-133'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7654192+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom DTH-1320'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7654271+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom Cintiq 13HD (DTK-1300)'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.765435+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom Cintiq 16 (DTK1660)'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7654496+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom Cintiq 12WX (DTZ-1200W)'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7654576+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom ET-0405-U'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7654676+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom ET-0405A-U'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7654935+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom FT-0405-U'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7655051+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom GD-0405-U'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7655198+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom GD-0608-U'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.76553+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom GD-0912-U'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7655447+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom GD-1212-U'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7655553+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom GD-1218-U'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7655699+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom MTE-450'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7655805+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom PTH-450'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7655945+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom PTH-451'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.765605+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom PTH-460'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7656151+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom PTH-650'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7656449+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom PTH-651'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7656617+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom PTH-660'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7656782+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom PTH-850'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7656885+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom PTH-851'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7657033+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom PTH-860'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7657139+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom PTK-1240'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7657282+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom PTK-440'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7657386+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom PTK-450'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7657526+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom PTK-540WL'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7657699+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom PTK-640'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7657974+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom PTK-650'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7658103+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom PTK-840'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7658206+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom PTU-600U'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7658321+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom PTZ-1230'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7658419+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom PTZ-1231W'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7658558+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom PTZ-430'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7658667+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom PTZ-431W'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7658778+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom PTZ-630'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7658841+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom PTZ-631W'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7658899+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom PTZ-930'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7658986+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom XD-0405-U'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7659045+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom XD-0608-U'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7659226+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom XD-0912-U'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7659293+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom XD-1212-U'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7659383+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Wacom XD-1218-U'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7659444+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'Waltop Slim Tablet 5.8\"'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7659488+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XenceLabs Pen Tablet Medium'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7659569+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XenceLabs Pen Tablet Small'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.765962+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XENX P1-640'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7659666+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XENX P3-1060'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7659799+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XENX X1-640'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7659846+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Artist 10 (2nd Gen)'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7659891+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Artist 12 (2nd Gen)'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7659934+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Artist 12 Pro'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7660011+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Artist 12'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7660059+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Artist 13 (2nd Gen)'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7660104+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Artist 13.3 Pro'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7660179+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Artist 13.3'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7660228+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Artist 15.6 Pro'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7660271+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Artist 15.6'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7660422+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Artist 16 (2nd Gen)'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.766048+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Artist 16 Pro'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7660526+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Artist 22HD'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.766057+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Artist Pro 16TP'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7660656+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen CT1060'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7660705+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen CT430'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7660763+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen CT640'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7660851+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Deco 01 V2 (variant 2)'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7660911+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Deco 01 V2'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7661+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Deco 01'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7661046+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Deco 02'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7661093+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Deco 03'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7661168+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Deco L'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7661215+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Deco M'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.766126+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Deco mini4'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7661303+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Deco mini7'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7661461+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Deco Pro Medium'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7661546+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Deco Pro Small'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7661597+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Deco Pro SW'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.766164+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Innovator 16'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7661685+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Star 03'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7661795+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Star 05 V3'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7661844+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Star 06'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7661935+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Star 06C'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7661987+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Star G430'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7662046+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Star G430S V2'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7662122+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Star G430S'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7662169+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Star G540 Pro'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7662213+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Star G540'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7662254+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Star G640 V2'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.766233+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Star G640'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7662377+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Star G640S'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.766252+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Star G960'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7662591+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Star G960S Plus'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.7662639+01:00",
      "Group": "Detect",
      "Message": "Searching for tablet 'XP-Pen Star G960S'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.8148744+01:00",
      "Group": "Evdev",
      "Message": "Successfully initialized virtual pressure sensitive tablet. (code NONE)",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.8190172+01:00",
      "Group": "UGEE S1060",
      "Message": "Output mode: Artist Mode",
      "StackTrace": null,
      "Level": 1,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.8211296+01:00",
      "Group": "UGEE S1060",
      "Message": "Display area: [1920x1080@<960.00006, 540.00006>:0°],",
      "StackTrace": null,
      "Level": 1,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.8212251+01:00",
      "Group": "UGEE S1060",
      "Message": "Tablet area: [254x142.875@<127, 80>:0°],",
      "StackTrace": null,
      "Level": 1,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.8212888+01:00",
      "Group": "UGEE S1060",
      "Message": "Clipping: Enabled",
      "StackTrace": null,
      "Level": 1,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.8213327+01:00",
      "Group": "UGEE S1060",
      "Message": "Ignoring reports outside area: Disabled",
      "StackTrace": null,
      "Level": 1,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.8307684+01:00",
      "Group": "Evdev",
      "Message": "Successfully initialized virtual keyboard. (code NONE)",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.8374766+01:00",
      "Group": "UGEE S1060",
      "Message": "Express Key Bindings: Key Binding: A, OpenTabletDriver.Desktop.Binding.LinuxArtistMode.LinuxArtistModeButtonBinding, Mouse Button Binding: Backward, Multi-Key Binding: abc, , , , , , , , ",
      "StackTrace": null,
      "Level": 1,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:53.8430696+01:00",
      "Group": "Settings",
      "Message": "Driver is enabled.",
      "StackTrace": null,
      "Level": 1,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:03:59.6099042+01:00",
      "Group": "IPC",
      "Message": "Connected to a client.",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2024-02-10T21:04:00.3310889+01:00",
      "Group": "Settings",
      "Message": "Presets have been refreshed. Loaded 0 presets.",
      "StackTrace": null,
      "Level": 1,
      "Notification": false
    }
  ]
}
```

</details>