### PR TITLE
Add StartupWMClass

### DIFF
--- a/eng/linux/lib.sh
+++ b/eng/linux/lib.sh
@@ -66,5 +66,6 @@ Terminal=false
 Type=Application
 Categories=Settings;
 StartupNotify=true
+StartupWMClass=OpenTabletDriver.UX
 EOF
 }


### PR DESCRIPTION
For some reason on my desktop the app is not properly associated with the .desktop file, i.e the launched application appears in the dock without an icon. Technically `StartupNotify` should solve that if the app behaves correctly but i guess it didn't.

It doesn't hurt to also explicitly write down the wmclass to guarantee that association.

Following is a screenshot from GNOME's `looking-glass` utility that allows inspecting window details, here i can see the current wmclass and the fact that it's considered untracked, unlike the other application shown in the picture which clearly has its app associated.

![Screenshot from 2024-02-14 16-31-55](https://github.com/OpenTabletDriver/OpenTabletDriver/assets/31079629/21d69a87-d45a-4a51-8567-99d82b81d6dd)
 