### PR TITLE
Use basic TabletReportParser on Huion 420

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/420.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/420.json
@@ -21,7 +21,7 @@
       "ProductID": 110,
       "InputReportLength": 8,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "ReportParser": "OpenTabletDriver.Tablet.TabletReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {
@@ -37,7 +37,7 @@
       "ProductID": 110,
       "InputReportLength": 8,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "ReportParser": "OpenTabletDriver.Tablet.TabletReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {


### PR DESCRIPTION
The Huion 420 has no need for using the UCLogicReportParser as its only uses that for auxiliary keys, as this tablet has none it should *probably* not be using this in the first place.

The main reason behind doing this is because when pressing the pen buttons it can potentially trigger auxiliary keys that don't exist.

![image](https://github.com/OpenTabletDriver/OpenTabletDriver/assets/22662856/61e34b37-df4f-430c-8d87-9dce33d8a5d2)

Not sure if this is the most optimal solution to begin with but this tablet has no aux functionality and thus doesn't need this parser.
