### PR TITLE
[Backport] Use basic TabletReportParser on Huion 420

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/420.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/420.json
@@ -23,7 +23,7 @@
       "ProductID": 110,
       "InputReportLength": 8,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {
@@ -39,7 +39,7 @@
       "ProductID": 110,
       "InputReportLength": 8,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {


### PR DESCRIPTION
Backport of #3226.