### PR TITLE
Update repository locations & fix English

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Required packages (some packages may be pre-installed for your distribution):
 - GTK+3
 
 Run `./eng/linux/package.sh`. If a "package" build is desired,
-there are official support for the following packaging formats:
+there is official support for the following packaging formats:
 
 | Package Format | Command |
 | --- | --- |
@@ -108,9 +108,7 @@ and fill out the template with relevant information. We welcome both bug
 reports, as well as new tablets to add support for. In many cases adding support
 for a new tablet is quite easy.
 
-For issues and PRs related to OpenTabletDriver's packaging, please see the repository [here](https://github.com/OpenTabletDriver/OpenTabletDriver.Packaging).
-
-For issues and PRs related to OpenTabletDriver's [web page](https://opentabletdriver.net), see the repository [here](https://github.com/OpenTabletDriver/OpenTabletDriver.Web).
+For issues and PRs related to OpenTabletDriver's [web page](https://opentabletdriver.net), see the repository [here](https://github.com/OpenTabletDriver/opentabletdriver.github.io).
 
 ### Supporting a new tablet
 

--- a/docs/README_ES.md
+++ b/docs/README_ES.md
@@ -100,9 +100,7 @@ Si desea contribuir a OpenTabletDriver, revise en el [rastreador de propuestas](
 
 Si tiene algún problema o sugerencia, [abra un ticket de propuesta](https://github.com/OpenTabletDriver/OpenTabletDriver/issues/new/choose) y rellene la plantilla con la información pertinente. Agradecemos tanto los informes de errores, como las nuevas tabletas a las que añadir compatibilidad. En muchos casos, añadir compatibilidad a una nueva tableta es bastante fácil.
 
-Para propuestas y solicitudes de extracción relacionados con el empaquetado de OpenTabletDriver, por favor, vea el repositorio de [aquí](https://github.com/OpenTabletDriver/OpenTabletDriver.Packaging).
-
-Para propuestas y solicitudes de extracción relacionados con la página web de OpenTabletDriver, vea el repositorio de [aquí](https://github.com/OpenTabletDriver/OpenTabletDriver.Web).
+Para propuestas y solicitudes de extracción relacionados con la página web de OpenTabletDriver, vea el repositorio de [aquí](https://github.com/OpenTabletDriver/opentabletdriver.github.io).
 
 ### Soporte para una nueva tableta
 

--- a/docs/README_PTBR.md
+++ b/docs/README_PTBR.md
@@ -103,9 +103,8 @@ Se você deseja contribuir para o OpenTabletDriver, confira a aba de [problemas]
 Se você tiver algum problema ou sugestão, [relate um problema](https://github.com/OpenTabletDriver/OpenTabletDriver/issues/new/choose) e preencha o template com informações relevantes.
 Somos gratos aos relatos de bugs quanto aos pedidos de novos tablets para adicionar suporte. Em alguns casos, adicionar um novo tablet pode ser fácil.
 
-Para issues (problemas) e PRs relacionados aos pacotes do OpenTabletDriver, por favor veja neste repositório [aqui](https://github.com/OpenTabletDriver/OpenTabletDriver.Packaging).
 
-Para issues e PRs relacionados ao site do OpenTabletDriver [página web](https://opentabletdriver.net), veja este repositório [aqui](https://github.com/OpenTabletDriver/OpenTabletDriver.Web).
+Para issues e PRs relacionados ao site do OpenTabletDriver [página web](https://opentabletdriver.net), veja este repositório [aqui](https://github.com/OpenTabletDriver/opentabletdriver.github.io).
 
 ### Adicionando suporte a um novo tablet
 


### PR DESCRIPTION
notable points here involve removing references to the packaging repo and updating the references to our website source code, it was still pointing at the old repository.

This does shed light to the fact that the translated documentation isn't maintained that well, some sections are not included entirely.