### PR TITLE
Fix UC-Logic 1060N configuration

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/UC-Logic/1060N.json
+++ b/OpenTabletDriver.Configurations/Configurations/UC-Logic/1060N.json
@@ -8,7 +8,7 @@
       "MaxY": 30480
     },
     "Pen": {
-      "MaxPressure": 8191,
+      "MaxPressure": 2047,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {
@@ -20,6 +20,7 @@
       "VendorID": 21827,
       "ProductID": 129,
       "InputReportLength": 8,
+      "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
       "OutputInitReport": [
         "ArAC"

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -144,7 +144,7 @@
 | XP-Pen Deco mini7             |     Supported     |
 | XP-Pen Deco Pro LW Gen2       |     Supported     |
 | XP-Pen Deco Pro XLW Gen2      |     Supported     |
-| XP-Pen Star 03                |     Supported     |
+| XP-Pen Star 03                |     Supported     | Older variants may use the same configuration as the UC-Logic 1060N.
 | XP-Pen Star 03 Pro            |     Supported     |
 | XP-Pen Star 05 V3             |     Supported     |
 | XP-Pen Star G430S             |     Supported     |


### PR DESCRIPTION
Fixes #3237.

I don't think we had concrete evidence of this configuration working to begin with.

No verification was ever done on pressure and considering the age of this tablet I'm guessing it was plain wrong to begin with, so I've corrected the value to 2047. See #1037 for the original implementation.

Somewhere between the original pull request mentioned above and now the `OutputReportLength` was set to null, which is wrong because multiple interfaces have the `InputReportLength` of 8, which at a minimum breaks support for Linux and possibly MacOS.

Edit: looking into this further, this reverts changes from #1721, but without reverting this it introduces RNG into weather or not the tablet wants to work, but no logs were provided there, so I'm not sure what the actual approach should be here.

Edit2: looking into this further, they are forcing their tablet to use interface 0, which I don't believe is right? I've seen 2 tablets using the exact same configuration with the exact same device strings, unless this is a different variant i don't see why its using interface 0 and instead of interface 2, and why it needs null instead of 8.

Regardless using null is not always a brilliant idea....