### PR TITLE
Add support for Wacom Cintiq 12WX (DTZ-1200W) 5th and 10th buttons

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTZ-1200W.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTZ-1200W.json
@@ -12,7 +12,7 @@
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {
-      "ButtonCount": 8
+      "ButtonCount": 10
     },
     "MouseButtons": null,
     "Touch": null
@@ -23,7 +23,7 @@
       "ProductID": 198,
       "InputReportLength": 10,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3.Intuos3ReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3.Intuos3ExtraAuxReportParser",
       "FeatureInitReport": [
         "AgI="
       ],

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3ExtraAuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3ExtraAuxReport.cs
@@ -1,0 +1,28 @@
+using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3
+{
+    public struct Intuos3ExtraAuxReport : IAuxReport
+    {
+        public Intuos3ExtraAuxReport(byte[] report)
+        {
+            Raw = report;
+            AuxButtons = new bool[]
+            {
+                report[5].IsBitSet(0),
+                report[5].IsBitSet(1),
+                report[5].IsBitSet(2),
+                report[5].IsBitSet(3),
+                report[5].IsBitSet(4),
+                report[6].IsBitSet(0),
+                report[6].IsBitSet(1),
+                report[6].IsBitSet(2),
+                report[6].IsBitSet(3),
+                report[6].IsBitSet(4),
+            };
+        }
+
+        public bool[] AuxButtons { set; get; }
+        public byte[] Raw { set; get; }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3ExtraAuxReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3ExtraAuxReportParser.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Numerics;
+using OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1;
+using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3
+{
+    public class Intuos3ExtraAuxReportParser : IReportParser<IDeviceReport>
+    {
+        public virtual IDeviceReport Parse(byte[] data)
+        {
+            return data[0] switch
+            {
+                0x02 => GetToolReport(data),
+                0x10 => new IntuosV1TabletReport(data, ref _prevPressure, ref _prevTilt, ref _prevPenButtons),
+                0x03 => new IntuosV1AuxReport(data),
+                0x0C => new Intuos3ExtraAuxReport(data),
+                _ => new DeviceReport(data)
+            };
+        }
+
+        private IDeviceReport GetToolReport(byte[] data)
+        {
+            if (data[1] == 0xEA || data[1] == 0xAA)
+                return new IntuosV1RotationReport(data, ref _prevPressure, ref _prevTilt, ref _prevPenButtons);
+            if ((data[1] & 0xF0) == 0xE0 || (data[1] & 0xF0) == 0xA0)
+                return new IntuosV1TabletReport(data, ref _prevPressure, ref _prevTilt, ref _prevPenButtons);
+            if ((data[1] & 0xF0) == 0xF0 || (data[1] & 0xF0) == 0xB0)
+                return new Intuos3MouseReport(data);
+
+            return new DeviceReport(data);
+        }
+
+        private uint _prevPressure;
+        private Vector2 _prevTilt;
+        private bool[] _prevPenButtons = Array.Empty<bool>();
+    }
+}


### PR DESCRIPTION
Fixes #3222.

Data recordings and anything relevant in within that issue.

A new parser is required to keep ordering of the old buttons, maybe a better way exists so that I don't have to duplicate the whole parser.

The way Intuos3 Aux works *typically* is 4 buttons per side and the byte that the data is different per side, this is why a new parser is needed to not break existing aux.

Alternatively a parser change could be made without creating a new parser but this would mean that the 5th and 10th buttons are the last to be bound instead of them being bound in order, this is not very intuitive and we consider aux buttons not in order to be a quirk. See the TABLETS.md on parblo tablets for example.

