### PR TITLE
[Backport] Add support for filtering detection by interface on Linux

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/420.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/420.json
@@ -54,6 +54,7 @@
   ],
   "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
-    "libinputoverride": "1"
+    "libinputoverride": "1",
+    "LinuxInterface": "0"
   }
 }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H420.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H420.json
@@ -39,6 +39,7 @@
   ],
   "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
-    "libinputoverride": "1"
+    "libinputoverride": "1",
+    "LinuxInterface": "0"
   }
 }

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -206,18 +206,26 @@ namespace OpenTabletDriver
                 case PluginPlatform.Windows:
                 {
                     var devName = device.DevicePath;
-
-                    bool interfaceMatches = attributes.ContainsKey("WinInterface") ? Regex.IsMatch(devName, $"&mi_{attributes["WinInterface"]}") : true;
-                    bool keyMatches = attributes.ContainsKey("WinUsage") ? Regex.IsMatch(devName, $"&col{attributes["WinUsage"]}") : true;
+                    bool interfaceMatches = !attributes.ContainsKey("WinInterface") || Regex.IsMatch(devName, $"&mi_{attributes["WinInterface"]}");
+                    bool keyMatches = !attributes.ContainsKey("WinUsage") || Regex.IsMatch(devName, $"&col{attributes["WinUsage"]}");
 
                     return interfaceMatches && keyMatches;
                 }
                 case PluginPlatform.MacOS:
                 {
                     var devName = device.DevicePath;
-                    bool interfaceMatches = attributes.ContainsKey("MacInterface") ? Regex.IsMatch(devName, $"IOUSBHostInterface@{attributes["MacInterface"]}") : true;
+                    bool interfaceMatches = !attributes.ContainsKey("MacInterface") || Regex.IsMatch(devName, $"IOUSBHostInterface@{attributes["MacInterface"]}");
                     return interfaceMatches;
                 }
+                case PluginPlatform.Linux:
+                {
+                    var devName = device.DevicePath;
+                    var match = Regex.Match(devName, @"^.*\/.*?:.*?\.(?<interface>.+)\/.*?\/hidraw\/hidraw\d+$");
+                    bool interfaceMatches = !attributes.ContainsKey("LinuxInterface") || match.Groups["interface"].Value == attributes["LinuxInterface"];
+
+                    return interfaceMatches;
+                }
+
                 default:
                 {
                     return true;


### PR DESCRIPTION
Backport of #3243.

NOTE: This will likely be superseded, do not merge if #3245 is merged.


Also applies the suggestions to simplify the logic, these are already applied on master so I thought I would mirror the code.