### PR TITLE
Attribute overhaul

### DIFF
--- a/OpenTabletDriver.Analyzers.Tests/Verifiers/FileBasedAnalyzerConfigOptionsProvider.cs
+++ b/OpenTabletDriver.Analyzers.Tests/Verifiers/FileBasedAnalyzerConfigOptionsProvider.cs
@@ -103,7 +103,7 @@ namespace OpenTabletDriver.Analyzers.Tests.Verifiers
             return options;
         }
 
-        [GeneratedRegex(@"^(?<key>(?:\w|_|-|\.)+) = (?<value>(?:\w|_|-|\.)+)$", RegexOptions.Multiline | RegexOptions.NonBacktracking)]
+        [GeneratedRegex(@"^(?<key>(?:\w|_|-|\.)+) = (?<value>(?:\w|_|-|\.)+)\s*$", RegexOptions.Multiline | RegexOptions.NonBacktracking)]
         private static partial Regex ValuePair();
 
         private class CustomAnalyzerConfigOptions : AnalyzerConfigOptions

--- a/OpenTabletDriver.Analyzers/Emitters/DeviceConfigurationProviderEmitter.cs
+++ b/OpenTabletDriver.Analyzers/Emitters/DeviceConfigurationProviderEmitter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
@@ -84,7 +85,7 @@ namespace OpenTabletDriver.Analyzers.Emitters
                                                                             _tabletConfigurations.Select(t => new TabletConfigurationEmitter(t).Emit()))))))))))
                                         .WithSemicolonToken(
                                             SyntaxFactory.Token(SyntaxKind.SemicolonToken))))))))
-                .NormalizeWhitespace(eol: "\n");
+                .NormalizeWhitespace(eol: Environment.NewLine);
 
             builder.AppendLine(Format(compilationUnit).GetText().ToString());
 

--- a/OpenTabletDriver.Analyzers/Formatters/WhitespaceHumanizer.cs
+++ b/OpenTabletDriver.Analyzers/Formatters/WhitespaceHumanizer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -121,19 +122,19 @@ namespace OpenTabletDriver.Analyzers.Formatters
                 .WithOpenBraceToken(oldInitializer.OpenBraceToken
                     .WithLeadingTrivia(
                         SyntaxFactory.TriviaList(
-                            SyntaxFactory.LineFeed,
+                            SyntaxFactory.EndOfLine(Environment.NewLine),
                             SyntaxFactory.Whitespace(currIndentation))))
                 .WithCloseBraceToken(oldInitializer.CloseBraceToken
                     .WithLeadingTrivia(
                         SyntaxFactory.TriviaList(
-                            SyntaxFactory.LineFeed,
+                            SyntaxFactory.EndOfLine(Environment.NewLine),
                             SyntaxFactory.Whitespace(currIndentation))))
                 .WithExpressions(
                     SyntaxFactory.SeparatedList(
                         oldInitializer.Expressions.Select(e => e
                             .WithLeadingTrivia(
                                 SyntaxFactory.TriviaList(
-                                    SyntaxFactory.LineFeed,
+                                    SyntaxFactory.EndOfLine(Environment.NewLine),
                                     SyntaxFactory.Whitespace(currIndentation + indentation))))));
 
             return newInitializer;

--- a/OpenTabletDriver.Configurations/Configurations/10moon/1060N.json
+++ b/OpenTabletDriver.Configurations/Configurations/10moon/1060N.json
@@ -27,7 +27,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -45,7 +46,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {

--- a/OpenTabletDriver.Configurations/Configurations/Acepen/AP1060.json
+++ b/OpenTabletDriver.Configurations/Configurations/Acepen/AP1060.json
@@ -31,7 +31,8 @@
         "CQIC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Acepen/AP906.json
+++ b/OpenTabletDriver.Configurations/Configurations/Acepen/AP906.json
@@ -31,7 +31,8 @@
         "CQIC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Adesso/Cybertablet K8.json
+++ b/OpenTabletDriver.Configurations/Configurations/Adesso/Cybertablet K8.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Artisul/A1201.json
+++ b/OpenTabletDriver.Configurations/Configurations/Artisul/A1201.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Artisul/AP604.json
+++ b/OpenTabletDriver.Configurations/Configurations/Artisul/AP604.json
@@ -25,7 +25,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Artisul/D16 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Artisul/D16 Pro.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Artisul/M0610 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Artisul/M0610 Pro.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         100
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         100
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/FlooGoo/FMA100.json
+++ b/OpenTabletDriver.Configurations/Configurations/FlooGoo/FMA100.json
@@ -25,7 +25,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/1060 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/1060 Pro.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -61,7 +63,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -76,7 +79,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/GM116HD.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/GM116HD.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/GM156HD.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/GM156HD.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M106K Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M106K Pro.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M106K.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M106K.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M10K Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M10K Pro.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M10K.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M10K.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M1220.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M1220.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M1230.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M1230.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M6.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M6.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M8.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M8.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/PD1161.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/PD1161.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/PD156 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/PD156 Pro.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/PD1560.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/PD1560.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/PD1561.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/PD1561.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/PD2200.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/PD2200.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/S56K.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/S56K.json
@@ -29,7 +29,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -44,7 +45,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -59,7 +61,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/S620.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/S620.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/S630.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/S630.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/S830.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/S830.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Genius/G-Pen 560.json
+++ b/OpenTabletDriver.Configurations/Configurations/Genius/G-Pen 560.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Genius/i405x.json
+++ b/OpenTabletDriver.Configurations/Configurations/Genius/i405x.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Genius/i608x.json
+++ b/OpenTabletDriver.Configurations/Configurations/Genius/i608x.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/1060 Plus.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/1060 Plus.json
@@ -33,7 +33,8 @@
       "InitializationStrings": [
         100,
         123
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/420.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/420.json
@@ -53,6 +53,6 @@
   "AuxiliaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1",
-    "LinuxInterface": "0"
+    "Interface": 0
   }
 }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/420.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/420.json
@@ -30,7 +30,8 @@
       "InitializationStrings": [
         100,
         123
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -47,12 +48,13 @@
       "InitializationStrings": [
         100,
         123
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1",
-    "Interface": 0
+    "Interface": "0"
   }
 }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/G10T.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/G10T.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/G930L.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/G930L.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/GC610.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/GC610.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/GT-156HD V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/GT-156HD V2.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/GT-220 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/GT-220 V2.json
@@ -29,7 +29,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/GT-221 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/GT-221 Pro.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/GT-221.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/GT-221.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H1060P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H1060P.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -61,7 +63,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H1161.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H1161.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H320M.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H320M.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H420.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H420.json
@@ -38,6 +38,6 @@
   "AuxiliaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1",
-    "LinuxInterface": "0"
+    "Interface": 0
   }
 }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H420.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H420.json
@@ -32,12 +32,13 @@
       "InitializationStrings": [
         100,
         123
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1",
-    "Interface": 0
+    "Interface": "0"
   }
 }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H420X.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H420X.json
@@ -29,7 +29,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -44,7 +45,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H430P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H430P.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -61,7 +63,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -76,7 +79,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H580X.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H580X.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H610 Pro V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H610 Pro V2.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -61,7 +63,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H610 Pro V3.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H610 Pro V3.json
@@ -27,7 +27,8 @@
       "DeviceStrings": {
         "121": "^HA60$"
       },
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H610 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H610 Pro.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H610X.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H610X.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H640P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H640P.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -61,7 +63,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -76,7 +79,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H641P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H641P.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H642.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H642.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H690.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H690.json
@@ -32,7 +32,8 @@
       "InitializationStrings": [
         100,
         123
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       "InitializationStrings": [
         100,
         123
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H950P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H950P.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -61,7 +63,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -76,7 +79,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H951P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H951P.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/HC16.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/HC16.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/HS610.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/HS610.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/HS611.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/HS611.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/HS64.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/HS64.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -61,7 +63,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/HS95.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/HS95.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 12.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 12.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 13.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 13.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 16 (2021).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 16 (2021).json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 16.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 16.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 20.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 20.json
@@ -29,7 +29,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 22 Plus.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 22 Plus.json
@@ -29,7 +29,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 22.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 22.json
@@ -29,7 +29,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 24 Plus.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 24 Plus.json
@@ -29,7 +29,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 12.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 12.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 13 (2.5k).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 13 (2.5k).json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 13.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 13.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16 (2.5k).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16 (2.5k).json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16 (4k).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16 (4k).json
@@ -29,7 +29,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16 Plus (4k).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16 Plus (4k).json
@@ -29,7 +29,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 19 (4K).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 19 (4K).json
@@ -29,7 +29,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 20.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 20.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 22 (2019).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 22 (2019).json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 24 (4K).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 24 (4K).json
@@ -29,7 +29,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 24.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 24.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/New 1060 Plus (2048).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/New 1060 Plus (2048).json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         100
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         100
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/New 1060 Plus.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/New 1060 Plus.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Q11K V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Q11K V2.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Q11K.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Q11K.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Q620M.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Q620M.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Q630M.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Q630M.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/RDS-160.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/RDS-160.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/RTE-100.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/RTE-100.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/RTM 500.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/RTM 500.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/RTP-700.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/RTP-700.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/WH1409 V2 (Variant 2).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/WH1409 V2 (Variant 2).json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/WH1409 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/WH1409 V2.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/WH1409.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/WH1409.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/KENTING/K5540.json
+++ b/OpenTabletDriver.Configurations/Configurations/KENTING/K5540.json
@@ -27,7 +27,8 @@
       "DeviceStrings": {},
       "InitializationStrings": [
         100
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Lifetec/LT9570.json
+++ b/OpenTabletDriver.Configurations/Configurations/Lifetec/LT9570.json
@@ -35,7 +35,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Monoprice/10594.json
+++ b/OpenTabletDriver.Configurations/Configurations/Monoprice/10594.json
@@ -33,7 +33,8 @@
       "InitializationStrings": [
         100,
         123
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Monoprice/MP1060-HA60.json
+++ b/OpenTabletDriver.Configurations/Configurations/Monoprice/MP1060-HA60.json
@@ -29,7 +29,8 @@
       "DeviceStrings": {},
       "InitializationStrings": [
         100
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/A609.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/A609.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/A610 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/A610 Pro.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/A610.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/A610.json
@@ -32,7 +32,8 @@
       "InitializationStrings": [
         100,
         123
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/A640 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/A640 V2.json
@@ -29,7 +29,8 @@
         "ArAEAAAAAAA="
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/A640.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/A640.json
@@ -27,7 +27,8 @@
       "DeviceStrings": {},
       "InitializationStrings": [
         100
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Intangbo M.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Intangbo M.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1155,
@@ -42,7 +43,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Intangbo S.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Intangbo S.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1155,
@@ -42,7 +43,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos M.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos M.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1155,
@@ -42,7 +43,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N4.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N4.json
@@ -27,7 +27,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N7.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N7.json
@@ -27,7 +27,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1155,
@@ -40,7 +41,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N7B.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N7B.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos S.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos S.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1155,
@@ -42,7 +43,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/RobotPen/T9A.json
+++ b/OpenTabletDriver.Configurations/Configurations/RobotPen/T9A.json
@@ -27,7 +27,8 @@
         "qhAC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Trust/Flex Design Tablet.json
+++ b/OpenTabletDriver.Configurations/Configurations/Trust/Flex Design Tablet.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Turcom/TS-6580.json
+++ b/OpenTabletDriver.Configurations/Configurations/Turcom/TS-6580.json
@@ -30,7 +30,8 @@
       },
       "InitializationStrings": [
         100
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         100
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/UC-Logic/1060N.json
+++ b/OpenTabletDriver.Configurations/Configurations/UC-Logic/1060N.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         100
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/UC-Logic/1060N.json
+++ b/OpenTabletDriver.Configurations/Configurations/UC-Logic/1060N.json
@@ -39,6 +39,6 @@
   "AuxiliaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1",
-    "MacInterface": "0"
+    "Interface": "0"
   }
 }

--- a/OpenTabletDriver.Configurations/Configurations/UC-Logic/PF1209.json
+++ b/OpenTabletDriver.Configurations/Configurations/UC-Logic/PF1209.json
@@ -29,7 +29,8 @@
       },
       "InitializationStrings": [
         109
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/M708 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/M708 V2.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/M708.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/M708.json
@@ -34,7 +34,8 @@
       "InitializationStrings": [
         100,
         123
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/M808.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/M808.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/M908.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/M908.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/S1060.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/S1060.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/S640.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/S640.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -42,7 +43,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/U1200.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/U1200.json
@@ -27,7 +27,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/U1600.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/U1600.json
@@ -27,7 +27,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A15 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A15 Pro.json
@@ -29,7 +29,8 @@
         "CQEE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 12267,
@@ -42,7 +43,8 @@
         "CQEE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A15 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A15 V2.json
@@ -31,7 +31,8 @@
         "CQMC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A15.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A15.json
@@ -31,7 +31,8 @@
         "CQMC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A30 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A30 V2.json
@@ -31,7 +31,8 @@
         "CQMC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A30.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A30.json
@@ -29,7 +29,8 @@
         "CQEE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A50 (Variant 2).json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A50 (Variant 2).json
@@ -29,7 +29,8 @@
         "CQEE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A50.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A50.json
@@ -29,7 +29,8 @@
         "CQEE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 12267,
@@ -42,7 +43,8 @@
         "CQEE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/S640 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/S640 V2.json
@@ -27,7 +27,8 @@
         "CQEE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/S640.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/S640.json
@@ -27,7 +27,8 @@
         "CQEE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/VK1060.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/VK1060.json
@@ -31,7 +31,8 @@
         "CQMC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/VK1060PRO.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/VK1060PRO.json
@@ -31,7 +31,8 @@
         "CQMC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/VK430 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/VK430 V2.json
@@ -33,7 +33,8 @@
       "DeviceStrings": {
         "23": "^2022/12/9$"
       },
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/VK430.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/VK430.json
@@ -33,7 +33,8 @@
       "DeviceStrings": {
         "23": "^2022/3/21$"
       },
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 12267,
@@ -50,7 +51,8 @@
       "DeviceStrings": {
         "23": "^2022/4/25$"
       },
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/VK640.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/VK640.json
@@ -31,7 +31,8 @@
         "CQMC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/VO1060.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/VO1060.json
@@ -30,7 +30,8 @@
         "CQIC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/ViewSonic/Woodpad PF0730.json
+++ b/OpenTabletDriver.Configurations/Configurations/ViewSonic/Woodpad PF0730.json
@@ -27,7 +27,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/ViewSonic/Woodpad PF1030.json
+++ b/OpenTabletDriver.Configurations/Configurations/ViewSonic/Woodpad PF1030.json
@@ -27,7 +27,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTC-4110WL.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTC-4110WL.json
@@ -27,7 +27,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTC-6110WL.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTC-6110WL.json
@@ -27,7 +27,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-430.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-430.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-440.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-440.json
@@ -29,7 +29,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -53,7 +55,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -66,7 +69,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-450.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-450.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-460.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-460.json
@@ -27,7 +27,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -40,7 +41,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-630.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-630.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-640.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-640.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-650.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-650.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-660.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-660.json
@@ -27,7 +27,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTF-430.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTF-430.json
@@ -27,7 +27,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-300.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-300.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-301.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-301.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-460.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-460.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -55,7 +57,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -68,7 +71,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -79,7 +83,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-461.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-461.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -55,7 +57,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -68,7 +71,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-470.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-470.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -55,7 +57,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-480.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-480.json
@@ -34,7 +34,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -47,7 +48,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -60,7 +62,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-490.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-490.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -55,7 +57,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-661.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-661.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -55,7 +57,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -68,7 +71,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-670.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-670.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -55,7 +57,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-680.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-680.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -55,7 +57,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-690.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-690.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -55,7 +57,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-4100.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-4100.json
@@ -27,7 +27,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -38,7 +39,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-4100WL.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-4100WL.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -55,7 +57,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -66,7 +69,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -77,7 +81,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -90,7 +95,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -103,7 +109,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-460.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-460.json
@@ -27,7 +27,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -40,7 +41,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -53,7 +55,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-470.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-470.json
@@ -27,7 +27,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -40,7 +41,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -53,7 +55,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-471.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-471.json
@@ -27,7 +27,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -40,7 +41,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -53,7 +55,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-472.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-472.json
@@ -27,7 +27,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -40,7 +41,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-480.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-480.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -55,7 +57,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-490.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-490.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -55,7 +57,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-6100.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-6100.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-6100WL.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-6100WL.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-671.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-671.json
@@ -27,7 +27,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -40,7 +41,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -53,7 +55,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-672.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-672.json
@@ -27,7 +27,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -40,7 +41,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-680.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-680.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -55,7 +57,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-690.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-690.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -55,7 +57,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTC-133.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTC-133.json
@@ -27,7 +27,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -40,7 +41,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTH-1320.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTH-1320.json
@@ -27,7 +27,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-1300.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-1300.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-1660.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-1660.json
@@ -27,7 +27,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -40,7 +41,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTZ-1200W.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTZ-1200W.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/ET-0405-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/ET-0405-U.json
@@ -27,7 +27,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -40,7 +41,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/ET-0405A-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/ET-0405A-U.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/FT-0405-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/FT-0405-U.json
@@ -27,7 +27,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -40,7 +41,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/GD-0405-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/GD-0405-U.json
@@ -27,7 +27,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -40,7 +41,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/GD-0608-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/GD-0608-U.json
@@ -27,7 +27,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -40,7 +41,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/GD-0912-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/GD-0912-U.json
@@ -27,7 +27,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -40,7 +41,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/GD-1212-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/GD-1212-U.json
@@ -27,7 +27,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -40,7 +41,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/GD-1218-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/GD-1218-U.json
@@ -27,7 +27,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -40,7 +41,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/MTE-450.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/MTE-450.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-450.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-450.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -55,7 +57,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-451.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-451.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -55,7 +57,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-460.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-460.json
@@ -31,7 +31,8 @@
       "DeviceStrings": {},
       "InitializationStrings": [
         0
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       "DeviceStrings": {},
       "InitializationStrings": [
         0
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -57,7 +59,8 @@
       "DeviceStrings": {},
       "InitializationStrings": [
         0
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -70,7 +73,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-650.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-650.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -55,7 +57,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-651.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-651.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -55,7 +57,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-660.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-660.json
@@ -27,7 +27,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -38,7 +39,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -51,7 +53,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-850.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-850.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -55,7 +57,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-851.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-851.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -55,7 +57,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-860.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-860.json
@@ -27,7 +27,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -38,7 +39,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -51,7 +53,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-1240.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-1240.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-440.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-440.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-450.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-450.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-540WL.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-540WL.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-640.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-640.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-650.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-650.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-840.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-840.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTU-600U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTU-600U.json
@@ -27,7 +27,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-1230.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-1230.json
@@ -32,7 +32,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -46,7 +47,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-1231W.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-1231W.json
@@ -32,7 +32,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -46,7 +47,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-430.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-430.json
@@ -32,7 +32,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -46,7 +47,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-431W.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-431W.json
@@ -32,7 +32,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -46,7 +47,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-630.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-630.json
@@ -32,7 +32,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -46,7 +47,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-631W.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-631W.json
@@ -32,7 +32,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -46,7 +47,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-930.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-930.json
@@ -32,7 +32,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -46,7 +47,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/XD-0405-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/XD-0405-U.json
@@ -28,7 +28,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/XD-0608-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/XD-0608-U.json
@@ -28,7 +28,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/XD-0912-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/XD-0912-U.json
@@ -28,7 +28,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/XD-1212-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/XD-1212-U.json
@@ -28,7 +28,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/XD-1218-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/XD-1218-U.json
@@ -28,7 +28,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Waltop/Slim Tablet.json
+++ b/OpenTabletDriver.Configurations/Configurations/Waltop/Slim Tablet.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XENX/P1-640.json
+++ b/OpenTabletDriver.Configurations/Configurations/XENX/P1-640.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XENX/P3-1060.json
+++ b/OpenTabletDriver.Configurations/Configurations/XENX/P3-1060.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XENX/X1-640.json
+++ b/OpenTabletDriver.Configurations/Configurations/XENX/X1-640.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 10 (2nd Gen).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 10 (2nd Gen).json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12 (2nd Gen).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12 (2nd Gen).json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12 Pro.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 13 (2nd Gen).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 13 (2nd Gen).json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 13.3 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 13.3 Pro.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 13.3.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 13.3.json
@@ -29,7 +29,8 @@
         "ArAC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -44,7 +45,8 @@
       "DeviceStrings": {},
       "InitializationStrings": [
         4
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "Attributes": {

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 15.6 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 15.6 Pro.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 15.6.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 15.6.json
@@ -29,7 +29,8 @@
         "ArAC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -42,7 +43,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [
@@ -57,7 +59,8 @@
       "DeviceStrings": {},
       "InitializationStrings": [
         4
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "Attributes": {

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16 (2nd Gen).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16 (2nd Gen).json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16 Pro.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16.json
@@ -30,7 +30,8 @@
       "InitializationStrings": [
         100,
         123
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16.json
@@ -36,6 +36,7 @@
   ],
   "AuxiliaryDeviceIdentifiers": [],
   "Attributes": {
-    "libinputoverride": "1"
+    "libinputoverride": "1",
+    "Interface": "0"
   }
 }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 22 (2nd Gen).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 22 (2nd Gen).json
@@ -27,7 +27,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 22HD.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 22HD.json
@@ -27,7 +27,8 @@
       "DeviceStrings": {},
       "InitializationStrings": [
         100
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 24 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 24 Pro.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist Pro 16 (Gen2).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist Pro 16 (Gen2).json
@@ -27,7 +27,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist Pro 16TP.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist Pro 16TP.json
@@ -27,7 +27,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/CT1060.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/CT1060.json
@@ -27,7 +27,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/CT430.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/CT430.json
@@ -27,7 +27,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -40,7 +41,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/CT640.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/CT640.json
@@ -27,7 +27,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -40,7 +41,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01 V2 (Variant 2).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01 V2 (Variant 2).json
@@ -31,7 +31,8 @@
       "DeviceStrings": {
         "4": "UG902_BPG1002"
       },
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -47,7 +48,8 @@
         "4": "UG901_BPU1002",
         "5": "2020-10-23_Release3"
       },
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01 V2.json
@@ -32,7 +32,8 @@
         "4": "UG901_BPU1002",
         "5": "^(?!2020-10-23_Release3$).*$"
       },
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -47,7 +48,8 @@
       "DeviceStrings": {
         "4": "UG901_BPU1002"
       },
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01.json
@@ -29,7 +29,8 @@
         "ArAC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 02.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 02.json
@@ -29,7 +29,8 @@
         "ArAC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 03.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 03.json
@@ -29,7 +29,8 @@
         "ArAC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco L.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco L.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco M.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco M.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro LW Gen2.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro LW Gen2.json
@@ -27,7 +27,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro Medium.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro Medium.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro SW.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro SW.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro Small.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro Small.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro XLW Gen2.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro XLW Gen2.json
@@ -27,7 +27,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco mini4.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco mini4.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -42,7 +43,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco mini7.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco mini7.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -42,7 +43,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -55,7 +57,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -68,7 +71,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Innovator 16.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Innovator 16.json
@@ -29,7 +29,8 @@
         "ArEE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 03 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 03 Pro.json
@@ -29,7 +29,8 @@
         "ArAC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 03.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 03.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -42,7 +43,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -55,7 +57,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 05 V3.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 05 V3.json
@@ -29,7 +29,8 @@
         "ArAC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 06.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 06.json
@@ -29,7 +29,8 @@
         "ArAC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 06C.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 06C.json
@@ -29,7 +29,8 @@
         "ArAC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G430.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G430.json
@@ -29,7 +29,8 @@
       "DeviceStrings": {
         "2": "TABLET G3 4x3"
       },
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -44,7 +45,8 @@
       },
       "InitializationStrings": [
         100
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G430S V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G430S V2.json
@@ -27,7 +27,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G430S.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G430S.json
@@ -29,7 +29,8 @@
       "DeviceStrings": {
         "2": "G430S"
       },
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G540 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G540 Pro.json
@@ -27,7 +27,8 @@
         "ArAC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G540.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G540.json
@@ -29,7 +29,8 @@
       "DeviceStrings": {
         "2": "TABLET G3 5x4"
       },
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640 (Variant 2).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640 (Variant 2).json
@@ -27,7 +27,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640.json
@@ -30,7 +30,8 @@
       "InitializationStrings": [
         100,
         110
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640S.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640S.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -42,7 +43,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -55,7 +57,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G960.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G960.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G960S Plus.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G960S Plus.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G960S.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G960S.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -42,7 +43,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XenceLabs/Pen Tablet Medium.json
+++ b/OpenTabletDriver.Configurations/Configurations/XenceLabs/Pen Tablet Medium.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -42,7 +43,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XenceLabs/Pen Tablet Small.json
+++ b/OpenTabletDriver.Configurations/Configurations/XenceLabs/Pen Tablet Small.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxiliaryDeviceIdentifiers": [],

--- a/OpenTabletDriver/Devices/HidSharpBackend/Extensions.cs
+++ b/OpenTabletDriver/Devices/HidSharpBackend/Extensions.cs
@@ -35,10 +35,11 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
         ) => TryGet(source, predicate, out var value) ? value! : fallback;
 
         // - HID_REPORTS (report_id:usage_page:usage_id, ...)
-        public static void ExtractHidUsages(this ReportDescriptor reportDescriptor, Dictionary<string, string> deviceAttributes)
+        public static void ExtractHidUsages(Dictionary<string, string> deviceAttributes, Func<ReportDescriptor> reportDescriptorFunc)
         {
             try
             {
+                var reportDescriptor = reportDescriptorFunc();
                 var usages = new List<(byte, uint)>();
                 foreach (var inputReport in reportDescriptor.InputReports)
                 {

--- a/OpenTabletDriver/Devices/HidSharpBackend/Extensions.cs
+++ b/OpenTabletDriver/Devices/HidSharpBackend/Extensions.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using HidSharp.Reports;
+using OpenTabletDriver.Interop;
 
 namespace OpenTabletDriver.Devices.HidSharpBackend
 {
@@ -27,5 +33,48 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
             Func<TSource, TValue> predicate,
             TValue fallback
         ) => TryGet(source, predicate, out var value) ? value! : fallback;
+
+        // - HID_REPORTS (report_id:usage_page:usage_id, ...)
+        public static void ExtractHidUsages(this ReportDescriptor reportDescriptor, Dictionary<string, string> deviceAttributes)
+        {
+            try
+            {
+                var usages = new List<(byte, uint)>();
+                foreach (var inputReport in reportDescriptor.InputReports)
+                {
+                    var reportId = inputReport.ReportID;
+                    usages.AddRange(inputReport.DeviceItem.Usages.GetAllValues().Select(x => (reportId, x)));
+                }
+
+                var hidReportsBuilder = new StringBuilder();
+                var enumerator = usages.GetEnumerator();
+                if (enumerator.MoveNext())
+                {
+                    var reportId = enumerator.Current.Item1;
+                    var extendedUsage = enumerator.Current.Item2;
+                    appendHidReport(hidReportsBuilder, reportId, extendedUsage);
+                    while (enumerator.MoveNext())
+                    {
+                        hidReportsBuilder.Append(", ");
+                        reportId = enumerator.Current.Item1;
+                        extendedUsage = enumerator.Current.Item2;
+                        appendHidReport(hidReportsBuilder, reportId, extendedUsage);
+                    }
+
+                    static void appendHidReport(StringBuilder stringBuilder, byte reportId, uint extendedUsage)
+                    {
+                        var usagePage = (extendedUsage & 0xffff0000) >> 16;
+                        var usageId = extendedUsage & 0x0000ffff;
+                        stringBuilder.Append($"{reportId:X2}:{usagePage:X4}:{usageId:X4}");
+                    }
+                }
+
+                deviceAttributes.Add("HID_REPORTS", hidReportsBuilder.ToString());
+            }
+            catch
+            {
+                deviceAttributes.Add("HID_REPORTS_NON_RECONSTRUCTABLE", "true");
+            }
+        }
     }
 }

--- a/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpoint.cs
+++ b/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpoint.cs
@@ -105,7 +105,6 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
         private void GetDeviceAttributesWindows(Dictionary<string, string> deviceAttributes)
         {
             GetInterfaceNumberFromPath(deviceAttributes, DevicePath, @"&mi_(?<interface>\d+)");
-
         }
 
         private void GetDeviceAttributesLinux(Dictionary<string, string> deviceAttributes)

--- a/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpoint.cs
+++ b/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpoint.cs
@@ -105,6 +105,7 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
         private void GetDeviceAttributesWindows(Dictionary<string, string> deviceAttributes)
         {
             GetInterfaceNumberFromPath(deviceAttributes, DevicePath, @"&mi_(?<interface>\d+)");
+
         }
 
         private void GetDeviceAttributesLinux(Dictionary<string, string> deviceAttributes)
@@ -114,6 +115,7 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
 
         private void GetDeviceAttributesMacOS(Dictionary<string, string> deviceAttributes)
         {
+            GetInterfaceNumberFromPath(deviceAttributes, DevicePath, @"IOUSBHostInterface@(?<interface>\d+)");
         }
 
         private static void GetInterfaceNumberFromPath(Dictionary<string, string> attributes, string path, string regex)

--- a/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpoint.cs
+++ b/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpoint.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using HidSharp;
@@ -27,12 +28,12 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
         public string? SerialNumber => _device.SafeGet(d => d.GetSerialNumber(), null);
         public string DevicePath => _device.SafeGet(d => d.DevicePath, "Invalid Device Path");
         public bool CanOpen => _device.SafeGet(d => d.CanOpen, false);
-        public IDictionary<string, string>? DeviceAttributes => GetDeviceAttributes(DevicePath, _device.GetReportDescriptor());
+        public IDictionary<string, string>? DeviceAttributes => GetDeviceAttributes(DevicePath, () => _device.GetReportDescriptor());
 
         public IDeviceEndpointStream? Open() => _device.TryOpen(out var stream) ? new HidSharpEndpointStream(stream) : null;
         public string GetDeviceString(byte index) => _device.GetDeviceString(index);
 
-        private IDictionary<string, string>? GetDeviceAttributes(string devicePath, ReportDescriptor reportDescriptor)
+        private static IDictionary<string, string>? GetDeviceAttributes(string devicePath, Func<ReportDescriptor> reportDescriptorFunc)
         {
             var deviceAttributes = new Dictionary<string, string>();
 
@@ -50,7 +51,7 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
                     break;
             }
 
-            reportDescriptor.ExtractHidUsages(deviceAttributes);
+            Extensions.ExtractHidUsages(deviceAttributes, reportDescriptorFunc);
 
             return deviceAttributes;
         }

--- a/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpoint.cs
+++ b/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpoint.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 using HidSharp;
 using HidSharp.Reports;
@@ -30,91 +27,47 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
         public string? SerialNumber => _device.SafeGet(d => d.GetSerialNumber(), null);
         public string DevicePath => _device.SafeGet(d => d.DevicePath, "Invalid Device Path");
         public bool CanOpen => _device.SafeGet(d => d.CanOpen, false);
-        public IDictionary<string, string>? DeviceAttributes => GetDeviceAttributes();
+        public IDictionary<string, string>? DeviceAttributes => GetDeviceAttributes(DevicePath, _device.GetReportDescriptor());
 
         public IDeviceEndpointStream? Open() => _device.TryOpen(out var stream) ? new HidSharpEndpointStream(stream) : null;
         public string GetDeviceString(byte index) => _device.GetDeviceString(index);
 
-        // - HID_REPORTS (report_id:usage_page:usage_id, ...)
-        // - USB_INTERFACE_NUMBER
-        private IDictionary<string, string>? GetDeviceAttributes()
+        private IDictionary<string, string>? GetDeviceAttributes(string devicePath, ReportDescriptor reportDescriptor)
         {
             var deviceAttributes = new Dictionary<string, string>();
+
+            // - USB_INTERFACE_NUMBER
             switch (SystemInterop.CurrentPlatform)
             {
                 case SystemPlatform.Windows:
-                    GetDeviceAttributesWindows(deviceAttributes);
+                    GetDeviceAttributesWindows(devicePath, deviceAttributes);
                     break;
                 case SystemPlatform.Linux:
-                    GetDeviceAttributesLinux(deviceAttributes);
+                    GetDeviceAttributesLinux(devicePath, deviceAttributes);
                     break;
                 case SystemPlatform.MacOS:
-                    GetDeviceAttributesMacOS(deviceAttributes);
+                    GetDeviceAttributesMacOS(devicePath, deviceAttributes);
                     break;
             }
 
-            try
-            {
-                ExtractHidUsages(deviceAttributes);
-            }
-            catch
-            {
-                deviceAttributes.Add("HID_REPORT_DESCRIPTOR_NON_RECONSTRUCTABLE", "true");
-            }
+            reportDescriptor.ExtractHidUsages(deviceAttributes);
 
             return deviceAttributes;
         }
 
-        private void ExtractHidUsages(Dictionary<string, string> deviceAttributes)
+        private static void GetDeviceAttributesWindows(string devicePath, Dictionary<string, string> deviceAttributes)
         {
-            var reportDescriptor = _device.GetReportDescriptor();
-
-            List<(byte, uint)> usages = new List<(byte, uint)>();
-            foreach (var inputReport in reportDescriptor.InputReports)
-            {
-                var reportId = inputReport.ReportID;
-                usages.AddRange(inputReport.DeviceItem.Usages.GetAllValues().Select(x => (reportId, x)));
-            }
-
-            var hidReportsBuilder = new StringBuilder();
-            var enumerator = usages.GetEnumerator();
-            if (enumerator.MoveNext())
-            {
-                var reportId = enumerator.Current.Item1;
-                var extendedUsage = enumerator.Current.Item2;
-                appendHidReport(hidReportsBuilder, reportId, extendedUsage);
-                while (enumerator.MoveNext())
-                {
-                    hidReportsBuilder.Append(", ");
-                    reportId = enumerator.Current.Item1;
-                    extendedUsage = enumerator.Current.Item2;
-                    appendHidReport(hidReportsBuilder, reportId, extendedUsage);
-                }
-
-                static void appendHidReport(StringBuilder stringBuilder, byte reportId, uint extendedUsage)
-                {
-                    var usagePage = (extendedUsage & 0xffff0000) >> 16;
-                    var usageId = extendedUsage & 0x0000ffff;
-                    stringBuilder.Append($"{reportId:X2}:{usagePage:X4}:{usageId:X4}");
-                }
-            }
-
-            deviceAttributes.Add("HID_REPORTS", hidReportsBuilder.ToString());
+            GetInterfaceNumberFromPath(deviceAttributes, devicePath, @"&mi_(?<interface>\d+)");
         }
 
-        private void GetDeviceAttributesWindows(Dictionary<string, string> deviceAttributes)
+        private static void GetDeviceAttributesLinux(string devicePath, Dictionary<string, string> deviceAttributes)
         {
-            GetInterfaceNumberFromPath(deviceAttributes, DevicePath, @"&mi_(?<interface>\d+)");
+            GetInterfaceNumberFromPath(deviceAttributes, devicePath, @"^.*\/.*?:.*?\.(?<interface>.+)\/.*?\/hidraw\/hidraw\d+$");
         }
 
-        private void GetDeviceAttributesLinux(Dictionary<string, string> deviceAttributes)
+        private static void GetDeviceAttributesMacOS(string devicePath, Dictionary<string, string> deviceAttributes)
         {
-            GetInterfaceNumberFromPath(deviceAttributes, DevicePath, @"^.*\/.*?:.*?\.(?<interface>.+)\/.*?\/hidraw\/hidraw\d+$");
-        }
-
-        private void GetDeviceAttributesMacOS(Dictionary<string, string> deviceAttributes)
-        {
-            GetInterfaceNumberFromPath(deviceAttributes, DevicePath, @"IOUSBHostInterface@(?<interface>\d+)");
+            GetInterfaceNumberFromPath(deviceAttributes, devicePath, @"IOUSBHostInterface@(?<interface>\d+)");
         }
 
         private static void GetInterfaceNumberFromPath(Dictionary<string, string> attributes, string path, string regex)

--- a/OpenTabletDriver/Devices/WinUSB/WinUSBInterface.cs
+++ b/OpenTabletDriver/Devices/WinUSB/WinUSBInterface.cs
@@ -3,6 +3,8 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
+using HidSharp.Reports;
+using OpenTabletDriver.Devices.HidSharpBackend;
 using OpenTabletDriver.Native.Windows;
 using OpenTabletDriver.Native.Windows.USB;
 using static OpenTabletDriver.Native.Windows.Windows;
@@ -77,12 +79,34 @@ namespace OpenTabletDriver.Devices.WinUSB
                 SerialNumber = deviceDescriptor.iSerialNumber != 0
                     ? GetDeviceString(deviceDescriptor.iSerialNumber)
                     : "Unknown Serial Number";
+
+                var reportDescriptorBuffer = ArrayPool<byte>.Shared.Rent(256);
+                fixed (void* reportDescriptorPtr = &reportDescriptorBuffer[0])
+                {
+                    var reportDescriptorPacket = SetupPacket.MakeGetDescriptor(
+                        RequestInternalType.Standard,
+                        RequestRecipient.Interface,
+                        DescriptorType.Report, 0,
+                        256
+                    );
+
+                    if (!WinUsb_ControlTransfer(winUsbHandle!, reportDescriptorPacket, reportDescriptorPtr, 256, out var lengthTransferred, null))
+                        throw new IOException("Failed to retrieve report descriptor");
+
+                    byte[] reportDescriptorTrimmed = new byte[lengthTransferred];
+                    Array.Copy(reportDescriptorBuffer, reportDescriptorTrimmed, lengthTransferred);
+
+                    _reportDescriptor = new ReportDescriptor(reportDescriptorTrimmed);
+                    FeatureReportLength = _reportDescriptor.MaxFeatureReportLength;
+                }
+                ArrayPool<byte>.Shared.Return(reportDescriptorBuffer);
             });
         }
 
         private int _referenceCount;
         private SafeFileHandle? _activeFileHandle;
         private SafeWinUsbInterfaceHandle? _activeWinUsbHandle;
+        private ReportDescriptor? _reportDescriptor;
 
         internal int InterfaceNum { private set; get; }
         internal byte? InputPipe { private set; get; }
@@ -96,7 +120,7 @@ namespace OpenTabletDriver.Devices.WinUSB
 
         public int OutputReportLength { private set; get; }
 
-        public int FeatureReportLength => 0; // requires parsing report descriptor to determine feature report length
+        public int FeatureReportLength { private set; get; }
 
         public string? Manufacturer { private set; get; }
 
@@ -110,7 +134,7 @@ namespace OpenTabletDriver.Devices.WinUSB
 
         public bool CanOpen => true;
 
-        public IDictionary<string, string>? DeviceAttributes { get; }
+        public IDictionary<string, string>? DeviceAttributes => GetDeviceAttributes();
 
         public unsafe string? GetDeviceString(byte index)
         {
@@ -210,7 +234,7 @@ namespace OpenTabletDriver.Devices.WinUSB
                 ["USB_INTERFACE_NUMBER"] = InterfaceNum.ToString()
             };
 
-            // cannot extract HID_REPORTS from WinUSB for now
+            _reportDescriptor!.ExtractHidUsages(deviceAttributes);
 
             return deviceAttributes;
         }

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -262,7 +262,7 @@ namespace OpenTabletDriver
             return true;
         }
 
-        private static bool DeviceMatchesAttribute(IDeviceEndpoint device, Dictionary<string, string> identifier_attributes,  Dictionary<string, string> config_attributes)
+        private static bool DeviceMatchesAttribute(IDeviceEndpoint device, Dictionary<string, string> identifier_attributes, Dictionary<string, string> config_attributes)
         {
             // The name of the attribute which is used to enforce a device interface whitelist.
             var interfaceKey = "Interface";

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -9,6 +9,7 @@ using System.Text.RegularExpressions;
 using JetBrains.Annotations;
 using OpenTabletDriver.Components;
 using OpenTabletDriver.Devices;
+using OpenTabletDriver.Devices.HidSharpBackend;
 using OpenTabletDriver.Interop;
 using OpenTabletDriver.Tablet;
 
@@ -271,7 +272,8 @@ namespace OpenTabletDriver
             // Windows only configuration attribute.
             if (SystemInterop.CurrentPlatform == SystemPlatform.Windows)
             {
-                if (attributes.TryGetValue("WinUsage", out var winUsage)
+                if (device is HidSharpEndpoint
+                    && attributes.TryGetValue("WinUsage", out var winUsage)
                     && !Regex.IsMatch(device.DevicePath, $"&col{winUsage}"))
                 {
                     // If it isn't a match there is no point proceeding.

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -302,7 +302,6 @@ namespace OpenTabletDriver
                     {
                         return required_interface == usb_interface;
                     }
-
                 }
             }
 

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -225,7 +225,7 @@ namespace OpenTabletDriver
                     (identifier.InputReportLength == null || identifier.InputReportLength == device.InputReportLength) &&
                     (identifier.OutputReportLength == null || identifier.OutputReportLength == device.OutputReportLength) &&
                     DeviceMatchesStrings(device, identifier.DeviceStrings) &&
-                    DeviceMatchesAttribute(device, configuration.Attributes);
+                    DeviceMatchesAttribute(device, identifier.Attributes, configuration.Attributes);
 
                 if (match)
                 {
@@ -262,11 +262,21 @@ namespace OpenTabletDriver
             return true;
         }
 
-        private static bool DeviceMatchesAttribute(IDeviceEndpoint device, Dictionary<string, string> attributes)
+        private static bool DeviceMatchesAttribute(IDeviceEndpoint device, Dictionary<string, string> identifier_attributes,  Dictionary<string, string> config_attributes)
         {
             // The name of the attribute which is used to enforce a device interface whitelist.
             var interfaceKey = "Interface";
             var devName = device.DevicePath;
+
+            Dictionary<string, string> attributes = new(identifier_attributes);
+
+            foreach (var kvp in config_attributes)
+            {
+                if (!attributes.ContainsKey(kvp.Key))
+                {
+                    attributes.Add(kvp.Key, kvp.Value);
+                }
+            }
 
             switch (SystemInterop.CurrentPlatform)
             {

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -264,27 +264,28 @@ namespace OpenTabletDriver
 
         private static bool DeviceMatchesAttribute(IDeviceEndpoint device, Dictionary<string, string> attributes)
         {
+            // The name of the attribute which is used to enforce a device interface whitelist.
+            var interfaceKey = "Interface";
+            var devName = device.DevicePath;
+
             switch (SystemInterop.CurrentPlatform)
             {
                 case SystemPlatform.Windows:
                 {
-                    var devName = device.DevicePath;
-                    var interfaceMatches = !attributes.ContainsKey("WinInterface") || Regex.IsMatch(devName, $"&mi_{attributes["WinInterface"]}");
+                    var interfaceMatches = !attributes.ContainsKey(interfaceKey) || Regex.IsMatch(devName, $"&mi_{attributes[interfaceKey]}");
                     var keyMatches = !attributes.ContainsKey("WinUsage") || Regex.IsMatch(devName, $"&col{attributes["WinUsage"]}");
 
                     return interfaceMatches && keyMatches;
                 }
                 case SystemPlatform.MacOS:
                 {
-                    var devName = device.DevicePath;
-                    bool interfaceMatches = !attributes.ContainsKey("MacInterface") || Regex.IsMatch(devName, $"IOUSBHostInterface@{attributes["MacInterface"]}");
+                    bool interfaceMatches = !attributes.ContainsKey(interfaceKey) || Regex.IsMatch(devName, $"IOUSBHostInterface@{attributes[interfaceKey]}");
                     return interfaceMatches;
                 }
                 case SystemPlatform.Linux:
                 {
-                    var devName = device.DevicePath;
                     var match = Regex.Match(devName, @"^.*\/.*?:.*?\.(?<interface>.+)\/.*?\/hidraw\/hidraw\d+$");
-                    bool interfaceMatches = !attributes.ContainsKey("LinuxInterface") || match.Groups["interface"].Value == attributes["LinuxInterface"];
+                    bool interfaceMatches = !attributes.ContainsKey(interfaceKey) || match.Groups["interface"].Value == attributes[interfaceKey];
 
                     return interfaceMatches;
                 }

--- a/OpenTabletDriver/InputDeviceEndpoint.cs
+++ b/OpenTabletDriver/InputDeviceEndpoint.cs
@@ -15,7 +15,6 @@ namespace OpenTabletDriver
     [PublicAPI]
     public sealed class InputDeviceEndpoint : IDisposable
     {
-
         private readonly uint _featureInitDelayMs;
         private const string DELAY_ATTRIBUTE_KEY_NAME = "FeatureInitDelayMs";
         private InputDeviceState _state;
@@ -38,8 +37,6 @@ namespace OpenTabletDriver
                 if (!uint.TryParse(delayStr, out _featureInitDelayMs))
                     Log.Write("Device", $"Could not parse '{delayStr}' from attribute {DELAY_ATTRIBUTE_KEY_NAME}", LogLevel.Warning);
         }
-
-
 
         /// <summary>
         /// The tablet configuration referring to this device.
@@ -110,7 +107,6 @@ namespace OpenTabletDriver
 
                 try
                 {
-
                     if (_featureInitDelayMs != 0)
                         Thread.Sleep((int)_featureInitDelayMs);
                     reportStream!.SetFeature(report);

--- a/OpenTabletDriver/Tablet/DeviceIdentifier.cs
+++ b/OpenTabletDriver/Tablet/DeviceIdentifier.cs
@@ -62,18 +62,18 @@ namespace OpenTabletDriver.Tablet
         /// Device strings to match against, used for identification.
         /// </summary>
         [DisplayName("Device Strings")]
-        public Dictionary<byte, string> DeviceStrings { set; get; } = [];
+        public Dictionary<byte, string> DeviceStrings { set; get; } = new Dictionary<byte, string>();
 
         /// <summary>
         /// Device strings to query to initialize device endpoints.
         /// </summary>
         [DisplayName("Initialization Strings")]
-        public List<byte> InitializationStrings { set; get; } = [];
+        public List<byte> InitializationStrings { set; get; } = new List<byte>();
 
         /// <summary>
         /// Other information specific to the tablet configurations identifier that can be used in tools or other applications.
         /// </summary>
         [Required(ErrorMessage = $"Tablet {nameof(Attributes)} must be present")]
-        public Dictionary<string, string> Attributes { set; get; } = [];
+        public Dictionary<string, string> Attributes { set; get; } = new Dictionary<string, string>();
     }
 }

--- a/OpenTabletDriver/Tablet/DeviceIdentifier.cs
+++ b/OpenTabletDriver/Tablet/DeviceIdentifier.cs
@@ -69,5 +69,8 @@ namespace OpenTabletDriver.Tablet
         /// </summary>
         [DisplayName("Initialization Strings")]
         public List<byte> InitializationStrings { set; get; } = new List<byte>();
+
+        [Required(ErrorMessage = $"Tablet {nameof(Attributes)} must be present")]
+        public Dictionary<string, string> Attributes { set; get; } = new Dictionary<string, string>();
     }
 }

--- a/OpenTabletDriver/Tablet/DeviceIdentifier.cs
+++ b/OpenTabletDriver/Tablet/DeviceIdentifier.cs
@@ -62,15 +62,18 @@ namespace OpenTabletDriver.Tablet
         /// Device strings to match against, used for identification.
         /// </summary>
         [DisplayName("Device Strings")]
-        public Dictionary<byte, string> DeviceStrings { set; get; } = new Dictionary<byte, string>();
+        public Dictionary<byte, string> DeviceStrings { set; get; } = [];
 
         /// <summary>
         /// Device strings to query to initialize device endpoints.
         /// </summary>
         [DisplayName("Initialization Strings")]
-        public List<byte> InitializationStrings { set; get; } = new List<byte>();
+        public List<byte> InitializationStrings { set; get; } = [];
 
+        /// <summary>
+        /// Other information specific to the tablet configurations identifier that can be used in tools or other applications.
+        /// </summary>
         [Required(ErrorMessage = $"Tablet {nameof(Attributes)} must be present")]
-        public Dictionary<string, string> Attributes { set; get; } = new Dictionary<string, string>();
+        public Dictionary<string, string> Attributes { set; get; } = [];
     }
 }

--- a/OpenTabletDriver/Tablet/TabletConfiguration.cs
+++ b/OpenTabletDriver/Tablet/TabletConfiguration.cs
@@ -29,19 +29,19 @@ namespace OpenTabletDriver.Tablet
         [Required(ErrorMessage = $"Tablet {nameof(DigitizerIdentifiers)} are required")]
         [DisplayName("Digitizer Identifiers")]
         [MinLength(1, ErrorMessage = "Requires at least 1 identifier")]
-        public List<DeviceIdentifier> DigitizerIdentifiers { set; get; } = new List<DeviceIdentifier>();
+        public List<DeviceIdentifier> DigitizerIdentifiers { set; get; } = [];
 
         /// <summary>
         /// The auxiliary device identifier.
         /// </summary>
         [Required(ErrorMessage = $"Tablet {nameof(AuxiliaryDeviceIdentifiers)} must be present")]
         [DisplayName("Auxiliary Identifiers")]
-        public List<DeviceIdentifier> AuxiliaryDeviceIdentifiers { set; get; } = new List<DeviceIdentifier>();
+        public List<DeviceIdentifier> AuxiliaryDeviceIdentifiers { set; get; } = [];
 
         /// <summary>
         /// Other information about the tablet that can be used in tools or other applications.
         /// </summary>
         [Required(ErrorMessage = $"Tablet {nameof(Attributes)} must be present")]
-        public Dictionary<string, string> Attributes { set; get; } = new Dictionary<string, string>();
+        public Dictionary<string, string> Attributes { set; get; } = [];
     }
 }

--- a/OpenTabletDriver/Tablet/TabletConfiguration.cs
+++ b/OpenTabletDriver/Tablet/TabletConfiguration.cs
@@ -29,19 +29,19 @@ namespace OpenTabletDriver.Tablet
         [Required(ErrorMessage = $"Tablet {nameof(DigitizerIdentifiers)} are required")]
         [DisplayName("Digitizer Identifiers")]
         [MinLength(1, ErrorMessage = "Requires at least 1 identifier")]
-        public List<DeviceIdentifier> DigitizerIdentifiers { set; get; } = [];
+        public List<DeviceIdentifier> DigitizerIdentifiers { set; get; } = new List<DeviceIdentifier>();
 
         /// <summary>
         /// The auxiliary device identifier.
         /// </summary>
         [Required(ErrorMessage = $"Tablet {nameof(AuxiliaryDeviceIdentifiers)} must be present")]
         [DisplayName("Auxiliary Identifiers")]
-        public List<DeviceIdentifier> AuxiliaryDeviceIdentifiers { set; get; } = [];
+        public List<DeviceIdentifier> AuxiliaryDeviceIdentifiers { set; get; } = new List<DeviceIdentifier>();
 
         /// <summary>
         /// Other information about the tablet that can be used in tools or other applications.
         /// </summary>
         [Required(ErrorMessage = $"Tablet {nameof(Attributes)} must be present")]
-        public Dictionary<string, string> Attributes { set; get; } = [];
+        public Dictionary<string, string> Attributes { set; get; } = new Dictionary<string, string>();
     }
 }


### PR DESCRIPTION
Supersedes #3243.
Fixes #2438.

TODO:
- [x] Add attribute to force specific interface on Linux & unify attributes to "Interface".
- [x] Restore `FeatureInitDelayMs` attribute.
- [x] Add support for specific identifiers via `DigitizerIdentifiers`.
- [x] Document changes in the codebase.
- [x] Fix tests.

I have something I'm not the most sure on right now, should a method be implemented somewhere to get the combined attributes? Right now it has absolutely no demand and its not complex logic to begin with, and use for combined attributes only are required in one spot, so its not like any code duplication will happen if we don't implement one.

At this time I'm not going to add support for FeatureInitDelayMs or libinputoverride in specific device identifiers, this is not needed and just increases complexity, but implementing the above would amend that. But considering the usage of delay (only intuos3 and on ALL tablets regardless of identifier) there is absolutely no need to implement support into the identifiers too.


Reminder to submit a pull request for web once this is merged.
