### PR TITLE
Veikk A50 revisit

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A50.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A50.json
@@ -12,7 +12,7 @@
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {
-      "ButtonCount": 4
+      "ButtonCount": 12
     },
     "MouseButtons": null,
     "Touch": null
@@ -22,8 +22,21 @@
       "VendorID": 12267,
       "ProductID": 3,
       "InputReportLength": 9,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.SkipByteTabletReportParser",
+      "OutputReportLength": 9,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkV1ReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": [
+        "CQEE"
+      ],
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    },
+    {
+      "VendorID": 12267,
+      "ProductID": 3,
+      "InputReportLength": 8,
+      "OutputReportLength": 0,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkV1ReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE"
@@ -31,6 +44,7 @@
       "DeviceStrings": {},
       "InitializationStrings": []
     }
+
   ],
   "AuxiliaryDeviceIdentifiers": [],
   "Attributes": {

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A50.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A50.json
@@ -44,7 +44,6 @@
       "DeviceStrings": {},
       "InitializationStrings": []
     }
-
   ],
   "AuxiliaryDeviceIdentifiers": [],
   "Attributes": {

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/S640.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/S640.json
@@ -21,7 +21,7 @@
       "ProductID": 1,
       "InputReportLength": 9,
       "OutputReportLength": 9,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkV2ReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkV1ReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE"

--- a/OpenTabletDriver.Configurations/Parsers/Veikk/VeikkAuxV1Report.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Veikk/VeikkAuxV1Report.cs
@@ -1,0 +1,32 @@
+using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Veikk
+{
+    public struct VeikkAuxV1Report : IAuxReport
+    {
+        public VeikkAuxV1Report(byte[] report)
+        {
+            Raw = report;
+            AuxButtons = new bool[]
+            {
+                // Buttons 4 and 6 could shadow each other in the case of more than one buttons being pressed at once.
+                // Button 6 would take precedence.
+                System.Array.IndexOf(report, (byte)0x3E) > 1,
+                System.Array.IndexOf(report, (byte)0x0C) > 1,
+                System.Array.IndexOf(report, (byte)0x2C) > 1,
+                System.Array.IndexOf(report, (byte)0x19) > 1 && report[1] == 0x00,
+                System.Array.IndexOf(report, (byte)0x06) > 1,
+                System.Array.IndexOf(report, (byte)0x19) > 1 && report[1] == 0x01,
+                System.Array.IndexOf(report, (byte)0x1D) > 1,
+                System.Array.IndexOf(report, (byte)0x16) > 1,
+                System.Array.IndexOf(report, (byte)0x2E) > 1,
+                System.Array.IndexOf(report, (byte)0x2D) > 1,
+                System.Array.IndexOf(report, (byte)0x30) > 1,
+                System.Array.IndexOf(report, (byte)0x2F) > 1,
+            };
+        }
+
+        public byte[] Raw { get; set; }
+        public bool[] AuxButtons { get; set; }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Veikk/VeikkAuxV1Report.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Veikk/VeikkAuxV1Report.cs
@@ -10,25 +10,24 @@ namespace OpenTabletDriver.Configurations.Parsers.Veikk
         {
             switch (buttonId)
             {
-                default : return -1;
-                case 0x3E : return 0;
-                case 0x0C : return 1;
-                case 0x2C : return 2;
+                default: return -1;
+                case 0x3E: return 0;
+                case 0x0C: return 1;
+                case 0x2C: return 2;
                 // Buttons 4 and 6 could shadow each other in the case of more than one buttons being pressed at once.
                 // Button 6 would take precedence.
                 case 0x19:
                 {
-                    if (report1==0x00) return 3;
+                    if (report1 == 0x00) return 3;
                     return 5;
-
                 }
-                case 0x06 : return 4;
-                case 0x1D : return 6;
-                case 0x16 : return 7;
-                case 0x2E : return 8;
-                case 0x2D : return 9;
-                case 0x30 : return 10;
-                case 0x2F : return 11;
+                case 0x06: return 4;
+                case 0x1D: return 6;
+                case 0x16: return 7;
+                case 0x2E: return 8;
+                case 0x2D: return 9;
+                case 0x30: return 10;
+                case 0x2F: return 11;
             }
 
         }

--- a/OpenTabletDriver.Configurations/Parsers/Veikk/VeikkAuxV1Report.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Veikk/VeikkAuxV1Report.cs
@@ -1,29 +1,51 @@
+using System;
+using System.Collections.Generic;
 using OpenTabletDriver.Tablet;
 
 namespace OpenTabletDriver.Configurations.Parsers.Veikk
 {
     public struct VeikkAuxV1Report : IAuxReport
     {
+        private int AuxButtonDict(byte report1, byte buttonId)
+        {
+            switch (buttonId)
+            {
+                default : return -1;
+                case 0x3E : return 0;
+                case 0x0C : return 1;
+                case 0x2C : return 2;
+                // Buttons 4 and 6 could shadow each other in the case of more than one buttons being pressed at once.
+                // Button 6 would take precedence.
+                case 0x19:
+                {
+                    if (report1==0x00) return 3;
+                    return 5;
+
+                }
+                case 0x06 : return 4;
+                case 0x1D : return 6;
+                case 0x16 : return 7;
+                case 0x2E : return 8;
+                case 0x2D : return 9;
+                case 0x30 : return 10;
+                case 0x2F : return 11;
+            }
+
+        }
+
         public VeikkAuxV1Report(byte[] report)
         {
             Raw = report;
-            AuxButtons = new bool[]
+            AuxButtons = new bool[12];
+            for (var i = 2; i < report.Length; i++)
             {
-                // Buttons 4 and 6 could shadow each other in the case of more than one buttons being pressed at once.
-                // Button 6 would take precedence.
-                System.Array.IndexOf(report, (byte)0x3E) > 1,
-                System.Array.IndexOf(report, (byte)0x0C) > 1,
-                System.Array.IndexOf(report, (byte)0x2C) > 1,
-                System.Array.IndexOf(report, (byte)0x19) > 1 && report[1] == 0x00,
-                System.Array.IndexOf(report, (byte)0x06) > 1,
-                System.Array.IndexOf(report, (byte)0x19) > 1 && report[1] == 0x01,
-                System.Array.IndexOf(report, (byte)0x1D) > 1,
-                System.Array.IndexOf(report, (byte)0x16) > 1,
-                System.Array.IndexOf(report, (byte)0x2E) > 1,
-                System.Array.IndexOf(report, (byte)0x2D) > 1,
-                System.Array.IndexOf(report, (byte)0x30) > 1,
-                System.Array.IndexOf(report, (byte)0x2F) > 1,
-            };
+                var buttonId = AuxButtonDict(report[1], report[i]);
+                if (buttonId >= 0)
+                {
+                    AuxButtons[buttonId] = true;
+                }
+
+            }
         }
 
         public byte[] Raw { get; set; }

--- a/OpenTabletDriver.Configurations/Parsers/Veikk/VeikkV1ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Veikk/VeikkV1ReportParser.cs
@@ -2,13 +2,16 @@ using OpenTabletDriver.Tablet;
 
 namespace OpenTabletDriver.Configurations.Parsers.Veikk
 {
-    public class VeikkV2ReportParser : IReportParser<IDeviceReport>
+    public class VeikkV1ReportParser : IReportParser<IDeviceReport>
     {
         public IDeviceReport Parse(byte[] report)
         {
+            if (report[0] == 0x03)
+                return new VeikkAuxV1Report(report);
+
             return (report[1], report[2]) switch
             {
-                (0x41, byte x) when (x & 0xF0) == 0xA0 => new TabletReport(report[1..]),
+                (0x41, _ ) when (report[2] & 0xF0) == 0xA0 => new TabletReport(report[1..]),
                 (0x41, 0xC0) => new OutOfRangeReport(report),
                 _ => new DeviceReport(report)
             };

--- a/OpenTabletDriver.Configurations/Parsers/Veikk/VeikkV1ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Veikk/VeikkV1ReportParser.cs
@@ -11,7 +11,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Veikk
 
             return (report[1], report[2]) switch
             {
-                (0x41, _ ) when (report[2] & 0xF0) == 0xA0 => new TabletReport(report[1..]),
+                (0x41, byte x) when (x & 0xF0) == 0xA0 => new TabletReport(report[1..]),
                 (0x41, 0xC0) => new OutOfRangeReport(report),
                 _ => new DeviceReport(report)
             };

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -62,6 +62,7 @@
 | UGTABLET M708 V2              |     Supported     |
 | VEIKK A15                     |     Supported     |
 | VEIKK A15 V2                  |     Supported     |
+| VEIKK A50                     |     Supported     |
 | VEIKK S640                    |     Supported     |
 | VEIKK S640 V2                 |     Supported     |
 | VEIKK VK1060                  |     Supported     |
@@ -199,7 +200,6 @@
 | VEIKK A15 Pro                 |  Missing Features | Wheel is not yet supported.
 | VEIKK A30                     |  Missing Features | Touchpad is not yet supported.
 | VEIKK A30 V2                  |  Missing Features | Touchpad is not yet supported.
-| VEIKK A50                     |  Missing Features | Touchpad is not yet supported.
 | VEIKK A50 V2                  |  Missing Features | Touchpad is not yet supported.
 | VEIKK Viola (VO1060)          |  Missing Features | Wheel is not yet supported.
 | VEIKK VK1060PRO               |  Missing Features | Wheels not yet supported.


### PR DESCRIPTION
Added support for aux buttons to one of the existing Veikk parsers and shifted the A50 to use it instead. 

Also corrected a confusing naming convention. The V2 parser wasn't actually being used for any V2 tablets. I relabel it V1 because I think it's an older protocol.

I suspect that the other "skip byte tablets" that remain can also be migrated to this parser, but I don't want to touch them without confirmation that it would work correctly.