### PR TITLE
Add support for Wacom Cintiq 22HD (DTK-2200)

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-2200.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-2200.json
@@ -1,0 +1,52 @@
+{
+  "Name": "Wacom Cintiq 22HD (DTK2200)",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 479,
+      "Height": 271,
+      "MaxX": 95040,
+      "MaxY": 54260
+    },
+    "Pen": {
+      "MaxPressure": 2048,
+      "Buttons": {
+        "ButtonCount": 2
+      }
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 20
+    },
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 1386,
+      "ProductID": 249,
+      "InputReportLength": 5,
+      "OutputReportLength": 0,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.CintiqV1.CintiqV1ReportParser",
+      "FeatureInitReport": [
+        "AgI="
+      ],
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    },
+    {
+      "VendorID": 1386,
+      "ProductID": 250,
+      "InputReportLength": 10,
+      "OutputReportLength": 0,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.CintiqV1.CintiqV1ReportParser",
+      "FeatureInitReport": [
+        "AgI="
+      ],
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {}
+}

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/CintiqV1/CintiqV1AuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/CintiqV1/CintiqV1AuxReport.cs
@@ -1,0 +1,47 @@
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Wacom.CintiqV1
+{
+    public struct CintiqV1AuxReport : IAuxReport
+    {
+        public CintiqV1AuxReport(byte[] report)
+        {
+            Raw = report;
+
+            // TODO: Handle touch strips.
+            var leftRadialButton = report[5];
+            var leftButtons = report[6];
+            var rightRadialButton = report[7];
+            var rightButtons = report[8];
+            var topButtons = report[9];
+            AuxButtons = new bool[]
+            {
+                leftRadialButton.IsBitSet(0),
+                leftButtons.IsBitSet(0),
+                leftButtons.IsBitSet(1),
+                leftButtons.IsBitSet(2),
+                leftButtons.IsBitSet(3),
+                leftButtons.IsBitSet(4),
+                leftButtons.IsBitSet(5),
+                leftButtons.IsBitSet(6),
+                leftButtons.IsBitSet(7),
+                leftButtons.IsBitSet(8),
+                rightRadialButton.IsBitSet(0),
+                rightButtons.IsBitSet(0),
+                rightButtons.IsBitSet(1),
+                rightButtons.IsBitSet(2),
+                rightButtons.IsBitSet(3),
+                rightButtons.IsBitSet(4),
+                rightButtons.IsBitSet(5),
+                rightButtons.IsBitSet(6),
+                rightButtons.IsBitSet(7),
+                rightButtons.IsBitSet(8),
+                topButtons.IsBitSet(0), // i-button
+                topButtons.IsBitSet(1), // wrench-button
+            };
+        }
+
+        public byte[] Raw { set; get; }
+        public bool[] AuxButtons { set; get; }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/CintiqV1/CintiqV1ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/CintiqV1/CintiqV1ReportParser.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Numerics;
+using OpenTabletDriver.Plugin.Tablet;
+using OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1;
+
+namespace OpenTabletDriver.Configurations.Parsers.Wacom.CintiqV1
+{
+    public class CintiqV1ReportParser : IReportParser<IDeviceReport>
+    {
+        public virtual IDeviceReport Parse(byte[] report)
+        {
+            return report[0] switch
+            {
+                0x02 => GetToolReport(report),
+                0x10 => GetToolReport(report),
+                0x0C => new CintiqV1AuxReport(report),
+                _ => new DeviceReport(report)
+            };
+        }
+
+        private IDeviceReport GetToolReport(byte[] report)
+        {
+            if (report[0] == 0x10 && report[1] == 0x20)
+                return new DeviceReport(report);
+            if (report[1] == 0x80)
+                return new OutOfRangeReport(report);
+            if (report[1].IsBitSet(1) && report[1].IsBitSet(3))
+                return new IntuosV1RotationReport(report, ref _prevPressure, ref _prevTilt, ref _prevPenButtons);
+            if (report[1].IsBitSet(5))
+                return new IntuosV1TabletReport(report, ref _prevPressure, ref _prevTilt, ref _prevPenButtons);
+            else if (report[1] == 0xC2)
+                return new IntuosV1ToolReport(report);
+
+            return new DeviceReport(report);
+        }
+
+        private uint _prevPressure;
+        private Vector2 _prevTilt;
+        private bool[] _prevPenButtons = Array.Empty<bool>();
+    }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -210,6 +210,7 @@
 | Wacom CTL-6100WL              |  Missing Features | Wireless is not yet supported.
 | Wacom DTH-1320                |  Missing Features | Touch is not yet supported.
 | Wacom DTK-1300                |  Missing Features | Center button is not yet supported.
+| Wacom DTK-2200                |  Missing Features | Touch Strips are not yet supported.
 | Wacom DTZ-1200W               |  Missing Features | Touch bars and top side buttons are not yet supported.
 | Wacom MTE-450                 |  Missing Features | Wheel is not yet supported.
 | Wacom PTH-450                 |  Missing Features | Wheel is not yet supported.


### PR DESCRIPTION
Tested on NixOS and a Windows 10 VM. Was only able to get diagnostics from within the Windows VM
[diagnostics.json](https://github.com/OpenTabletDriver/OpenTabletDriver/files/15001041/diagnostics.json)
