### PR TITLE
[0.6.x] Add support for touch strips

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-2200.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-2200.json
@@ -15,7 +15,12 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 20
-    }
+    },
+    "TouchStrips": {
+      "Count": 2
+    },
+    "MouseButtons": null,
+    "Touch": null
   },
   "DigitizerIdentifiers": [
     {

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/CintiqV1/CintiqV1ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/CintiqV1/CintiqV1ReportParser.cs
@@ -13,7 +13,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.CintiqV1
             {
                 0x02 => GetToolReport(report),
                 0x10 => GetToolReport(report),
-                0x0C => new CintiqV1AuxReport(report),
+                0x0C => new CintiqV1AuxReport(report, ref _prevLeftStrip, ref _prevRightStrip),
                 _ => new DeviceReport(report)
             };
         }
@@ -37,5 +37,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.CintiqV1
         private uint _prevPressure;
         private Vector2 _prevTilt;
         private bool[] _prevPenButtons = Array.Empty<bool>();
+        private ushort _prevLeftStrip;
+        private ushort _prevRightStrip;
     }
 }

--- a/OpenTabletDriver.Console/Program.Commands.cs
+++ b/OpenTabletDriver.Console/Program.Commands.cs
@@ -152,6 +152,16 @@ namespace OpenTabletDriver.Console
             });
         }
 
+        private static async Task SetTouchStripBinding(string tablet, string name, int index)
+        {
+            await ModifyProfile(tablet, p =>
+            {
+                var binding = AppInfo.PluginManager.ConstructObject<IBinding>(name);
+
+                p.BindingSettings.TouchStrips[index] = new PluginSettingStore(binding);
+            });
+        }
+
         private static async Task SetEnableClipping(string tablet, bool isEnabled)
         {
             await ModifyProfile(tablet, p => p.AbsoluteModeSettings.EnableClipping = isEnabled);
@@ -249,6 +259,7 @@ namespace OpenTabletDriver.Console
             await Out.WriteLineAsync($"Tip Binding: {profile.BindingSettings.TipButton.Format() ?? "None"}@{profile.BindingSettings.TipActivationThreshold}%");
             await Out.WriteLineAsync($"Pen Bindings: {string.Join(", ", profile.BindingSettings.PenButtons.Format())}");
             await Out.WriteLineAsync($"Express Key Bindings: {string.Join(", ", profile.BindingSettings.AuxButtons.Format())}");
+            await Out.WriteLineAsync($"Touch Strips Bindings: {string.Join(", ", profile.BindingSettings.TouchStrips.Format())}");
         }
 
         private static async Task GetMiscSettings(string tablet)

--- a/OpenTabletDriver.Console/Program.cs
+++ b/OpenTabletDriver.Console/Program.cs
@@ -73,6 +73,7 @@ namespace OpenTabletDriver.Console
             CreateCommand<string, string, float>(SetTipBinding, "Sets the current tip binding"),
             CreateCommand<string, string, int>(SetPenBinding, "Sets the current pen button bindings"),
             CreateCommand<string, string, int>(SetAuxBinding, "Sets the current express key bindings"),
+            CreateCommand<string, string, int>(SetTouchStripBinding, "Sets the current touch strip bindings"),
             CreateCommand<string, int>(SetResetTime, "Sets the reset time in milliseconds"),
             CreateCommand<string, bool>(SetEnableClipping, "Sets whether inputs should be limited to the specified areas"),
             CreateCommand<string, bool>(SetEnableAreaLimiting, "Sets whether inputs outside of the tablet area should be ignored"),

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -430,6 +430,12 @@ namespace OpenTabletDriver.Daemon
                 Log.Write(group, $"Express Key Bindings: " + string.Join(", ", bindingHandler.AuxButtons.Select(b => b.Value?.Binding)));
             }
 
+            if (settings.TouchStrips != null && settings.TouchStrips.Any(b => b?.Path != null))
+            {
+                SetBindingHandlerCollectionSettings(bindingServiceProvider, settings.TouchStrips, bindingHandler.TouchStrips, tabletReference);
+                Log.Write(group, $"Touch Strip Bindings: " + string.Join(", ", bindingHandler.TouchStrips.Select(b => b.Value?.Binding)));
+            }
+
             if (settings.MouseButtons != null && settings.MouseButtons.Any(b => b?.Path != null))
             {
                 SetBindingHandlerCollectionSettings(bindingServiceProvider, settings.MouseButtons, bindingHandler.MouseButtons, tabletReference);

--- a/OpenTabletDriver.Desktop/Profiles/BindingSettings.cs
+++ b/OpenTabletDriver.Desktop/Profiles/BindingSettings.cs
@@ -13,6 +13,7 @@ namespace OpenTabletDriver.Desktop.Profiles
         private PluginSettingStore tipButton, eraserButton, mouseScrollUp, mouseScrollDown;
         private PluginSettingStoreCollection penButtons = new PluginSettingStoreCollection(),
             auxButtons = new PluginSettingStoreCollection(),
+            touchStrips = new PluginSettingStoreCollection(),
             mouseButtons = new PluginSettingStoreCollection();
 
         [JsonProperty("TipActivationThreshold")]
@@ -57,6 +58,13 @@ namespace OpenTabletDriver.Desktop.Profiles
             get => this.auxButtons;
         }
 
+        [JsonProperty("TouchStrips")]
+        public PluginSettingStoreCollection TouchStrips
+        {
+            set => this.RaiseAndSetIfChanged(ref this.touchStrips, value);
+            get => this.touchStrips;
+        }
+
         [JsonProperty("MouseButtons")]
         public PluginSettingStoreCollection MouseButtons
         {
@@ -90,7 +98,8 @@ namespace OpenTabletDriver.Desktop.Profiles
                 ),
                 PenButtons = new PluginSettingStoreCollection(),
                 AuxButtons = new PluginSettingStoreCollection(),
-                MouseButtons = new PluginSettingStoreCollection()
+                TouchStrips = new PluginSettingStoreCollection(),
+                MouseButtons = new PluginSettingStoreCollection(),
             };
             bindingSettings.MatchSpecifications(tabletSpecifications);
             return bindingSettings;
@@ -100,10 +109,12 @@ namespace OpenTabletDriver.Desktop.Profiles
         {
             int penButtonCount = (int?)tabletSpecifications.Pen?.Buttons?.ButtonCount ?? 0;
             int auxButtonCount = (int?)tabletSpecifications.AuxiliaryButtons?.ButtonCount ?? 0;
+            int touchStripsCount = (int?)tabletSpecifications.TouchStrips?.Count ?? 0;
             int mouseButtonCount = (int?)tabletSpecifications.MouseButtons?.ButtonCount ?? 0;
 
             PenButtons = PenButtons.SetExpectedCount(penButtonCount);
             AuxButtons = AuxButtons.SetExpectedCount(auxButtonCount);
+            TouchStrips = TouchStrips.SetExpectedCount(touchStripsCount * 2);
             MouseButtons = MouseButtons.SetExpectedCount(mouseButtonCount);
         }
     }

--- a/OpenTabletDriver.Plugin/Tablet/ITouchStripReport.cs
+++ b/OpenTabletDriver.Plugin/Tablet/ITouchStripReport.cs
@@ -1,0 +1,7 @@
+namespace OpenTabletDriver.Plugin.Tablet
+{
+    public interface ITouchStripReport : IDeviceReport
+    {
+        TouchStripDirection[] TouchStripDirections { get; set; }
+    }
+}

--- a/OpenTabletDriver.Plugin/Tablet/TabletSpecifications.cs
+++ b/OpenTabletDriver.Plugin/Tablet/TabletSpecifications.cs
@@ -32,5 +32,10 @@ namespace OpenTabletDriver.Plugin.Tablet
         /// Specifications for the touch digitizer.
         /// </summary>
         public DigitizerSpecifications? Touch { set; get; }
+
+        /// <summary>
+        /// Specifications for the touch strips.
+        /// </summary>
+        public TouchStripSpecifications? TouchStrips { set; get; }
     }
 }

--- a/OpenTabletDriver.Plugin/Tablet/TouchStripDirection.cs
+++ b/OpenTabletDriver.Plugin/Tablet/TouchStripDirection.cs
@@ -1,0 +1,9 @@
+namespace OpenTabletDriver.Plugin.Tablet
+{
+    public enum TouchStripDirection
+    {
+        None,
+        Up,
+        Down,
+    }
+}

--- a/OpenTabletDriver.Plugin/Tablet/TouchStripSpecifications.cs
+++ b/OpenTabletDriver.Plugin/Tablet/TouchStripSpecifications.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace OpenTabletDriver.Plugin.Tablet
+{
+    public class TouchStripSpecifications
+    {
+        /// <summary>
+        /// The amount of touch strips.
+        /// </summary>
+        [Required(ErrorMessage = $"{nameof(Count)} must be defined")]
+        public uint Count { set; get; }
+    }
+}

--- a/OpenTabletDriver.UX/Controls/Bindings/TouchStripBindingEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/TouchStripBindingEditor.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using Eto.Forms;
+using OpenTabletDriver.Desktop.Reflection;
+using OpenTabletDriver.UX.Controls.Generic;
+
+namespace OpenTabletDriver.UX.Controls.Bindings
+{
+    public sealed class TouchStripBindingEditor : BindingEditor
+    {
+        public TouchStripBindingEditor()
+        {
+            this.Content = new Scrollable
+            {
+                Border = BorderType.None,
+                Content = new StackLayout
+                {
+                    HorizontalContentAlignment = HorizontalAlignment.Stretch,
+                    Spacing = 5,
+                    Items =
+                    {
+                        new Group
+                        {
+                            Text = "Touch Strips",
+                            Content = touchStripBindings = new BindingDisplayList
+                            {
+                                Prefix = "Touch Strip Binding"
+                            }
+                        }
+                    }
+                }
+            };
+
+            touchStripBindings.ItemSourceBinding.Bind(SettingsBinding.Child(c => (IList<PluginSettingStore>)c.TouchStrips));
+        }
+
+        private BindingDisplayList touchStripBindings;
+    }
+}

--- a/OpenTabletDriver.UX/Controls/ControlPanel.cs
+++ b/OpenTabletDriver.UX/Controls/ControlPanel.cs
@@ -45,6 +45,11 @@ namespace OpenTabletDriver.UX.Controls
                     },
                     new TabPage
                     {
+                        Text = "Touch Strip Settings",
+                        Content = touchStripBindingEditor = new TouchStripBindingEditor()
+                    },
+                    new TabPage
+                    {
                         Text = "Mouse Settings",
                         Content = mouseBindingEditor = new MouseBindingEditor()
                     },
@@ -75,6 +80,7 @@ namespace OpenTabletDriver.UX.Controls
             outputModeEditor.ProfileBinding.Bind(ProfileBinding);
             penBindingEditor.ProfileBinding.Bind(ProfileBinding);
             auxBindingEditor.ProfileBinding.Bind(ProfileBinding);
+            touchStripBindingEditor.ProfileBinding.Bind(ProfileBinding);
             mouseBindingEditor.ProfileBinding.Bind(ProfileBinding);
             filterEditor.StoreCollectionBinding.Bind(ProfileBinding.Child(p => p.Filters));
             toolEditor.StoreCollectionBinding.Bind(App.Current, a => a.Settings.Tools);
@@ -94,7 +100,7 @@ namespace OpenTabletDriver.UX.Controls
         private Placeholder placeholder;
         private LogView logView;
         private OutputModeEditor outputModeEditor;
-        private BindingEditor penBindingEditor, auxBindingEditor, mouseBindingEditor;
+        private BindingEditor penBindingEditor, auxBindingEditor, mouseBindingEditor, touchStripBindingEditor;
         private PluginSettingStoreCollectionEditor<IPositionedPipelineElement<IDeviceReport>> filterEditor;
         private PluginSettingStoreCollectionEditor<ITool> toolEditor;
 
@@ -129,6 +135,7 @@ namespace OpenTabletDriver.UX.Controls
                 SetPageVisibility(filterEditor, true);
                 SetPageVisibility(penBindingEditor, tablet.Properties.Specifications.Pen != null);
                 SetPageVisibility(auxBindingEditor, tablet.Properties.Specifications.AuxiliaryButtons != null);
+                SetPageVisibility(touchStripBindingEditor, tablet.Properties.Specifications.TouchStrips != null);
                 SetPageVisibility(mouseBindingEditor, tablet.Properties.Specifications.MouseButtons != null);
                 SetPageVisibility(toolEditor, true);
 
@@ -142,6 +149,7 @@ namespace OpenTabletDriver.UX.Controls
                 SetPageVisibility(filterEditor, false);
                 SetPageVisibility(penBindingEditor, false);
                 SetPageVisibility(auxBindingEditor, false);
+                SetPageVisibility(touchStripBindingEditor, false);
                 SetPageVisibility(mouseBindingEditor, false);
                 SetPageVisibility(toolEditor, false);
 

--- a/OpenTabletDriver.UX/Tools/ReportFormatter.cs
+++ b/OpenTabletDriver.UX/Tools/ReportFormatter.cs
@@ -24,6 +24,8 @@ namespace OpenTabletDriver.UX.Tools
                 sb.AppendLines(GetStringFormat(tabletReport));
             if (report is IAuxReport auxReport)
                 sb.AppendLines(GetStringFormat(auxReport));
+            if (report is ITouchStripReport touchStripReport)
+                sb.AppendLines(GetStringFormat(touchStripReport));
             if (report is IEraserReport eraserReport)
                 sb.AppendLines(GetStringFormat(eraserReport));
             if (report is IProximityReport proximityReport)
@@ -54,6 +56,8 @@ namespace OpenTabletDriver.UX.Tools
                 sb.AppendOneLine(GetStringFormat(tabletReport));
             if (report is IAuxReport auxReport)
                 sb.AppendOneLine(GetStringFormat(auxReport));
+            if (report is ITouchStripReport touchStripReport)
+                sb.AppendOneLine(GetStringFormat(touchStripReport));
             if (report is IEraserReport eraserReport)
                 sb.AppendOneLine(GetStringFormat(eraserReport));
             if (report is IProximityReport proximityReport)
@@ -91,6 +95,11 @@ namespace OpenTabletDriver.UX.Tools
         private static IEnumerable<string> GetStringFormat(IAuxReport auxReport)
         {
             yield return $"AuxButtons:[{string.Join(" ", auxReport.AuxButtons)}]";
+        }
+
+        private static IEnumerable<string> GetStringFormat(ITouchStripReport touchStripReport)
+        {
+            yield return $"TouchStripDirections:[{string.Join(" ", touchStripReport.TouchStripDirections)}]";
         }
 
         private static IEnumerable<string> GetStringFormat(IEraserReport eraserReport)

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -109,6 +109,7 @@
 | Wacom CTL-690                 |     Supported     |
 | Wacom DTC-133                 |     Supported     |
 | Wacom DTK-1660                |     Supported     |
+| Wacom DTK-2200                |     Supported     |
 | Wacom ET-0405-U               |     Supported     |
 | Wacom ET-0405A-U              |     Supported     |
 | Wacom FT-0405-U               |     Supported     |
@@ -239,7 +240,6 @@
 | Wacom CTL-6100WL              |  Missing Features | Wireless is not yet supported.
 | Wacom DTH-1320                |  Missing Features | Touch is not yet supported.
 | Wacom DTK-1300                |  Missing Features | Center button is not yet supported.
-| Wacom DTK-2200                |  Missing Features | Touch Strips are not yet supported.
 | Wacom DTZ-1200W               |  Missing Features | Touch bars and top side buttons are not yet supported.
 | Wacom MTE-450                 |  Missing Features | Wheel is not yet supported.
 | Wacom PTH-450                 |  Missing Features | Wheel is not yet supported.


### PR DESCRIPTION
Depends on: https://github.com/OpenTabletDriver/OpenTabletDriver/pull/3285

I think this functionality will overlap closely with touch rings, scroll wheels, wheels/dials/paddles, triggers, or any other 1-dimensional HID, in which case maybe it could be given a more abstract name. `ScrollLikeController`?

This change will make the unit tester complain about every other config because I added a new config parameter "TouchStrips".