### PR TITLE
[Backport] Add support for XP-Pen Artist 24 Pro

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 24 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 24 Pro.json
@@ -1,0 +1,41 @@
+{
+  "Name": "XP-Pen Artist 24 Pro",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 526.85,
+      "Height": 296.35,
+      "MaxX": 105370.0,
+      "MaxY": 59270.0
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "Buttons": {
+        "ButtonCount": 2
+      }
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 20
+    },
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 10429,
+      "ProductID": 2349,
+      "InputReportLength": 12,
+      "OutputReportLength": 8,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": [
+        "ArAE"
+      ],
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenAuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenAuxReport.cs
@@ -20,6 +20,16 @@ namespace OpenTabletDriver.Configurations.Parsers.XP_Pen
                 report[index].IsBitSet(7),
                 report[index + 1].IsBitSet(0),
                 report[index + 1].IsBitSet(1),
+                report[index + 1].IsBitSet(2),
+                report[index + 1].IsBitSet(3),
+                report[index + 1].IsBitSet(4),
+                report[index + 1].IsBitSet(5),
+                report[index + 1].IsBitSet(6),
+                report[index + 1].IsBitSet(7),
+                report[index + 2].IsBitSet(0),
+                report[index + 2].IsBitSet(1),
+                report[index + 2].IsBitSet(2),
+                report[index + 2].IsBitSet(3),
             };
         }
 

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -240,6 +240,7 @@
 | XP-Pen Artist 13.3 Pro        |  Missing Features | Wheel is not yet supported.
 | XP-Pen Artist 15.6 Pro        |  Missing Features | Tilt and wheel are not yet supported.
 | XP-Pen Artist 16 Pro          |  Missing Features | Wheel is not yet supported.
+| XP-Pen Artist 24 Pro          |  Missing Features | Wheel is not yet supported.
 | XP-Pen Artist Pro 16TP        |  Missing Features | Touch is not yet supported.
 | XP-Pen Deco 01 V2             |  Missing Features | Tilt is not yet supported.
 | XP-Pen Deco 01 V2 (variant 2) |  Missing Features | Tilt is not yet supported


### PR DESCRIPTION
Backport of #3291, includes the fix from #3335.