### PR TITLE
Add support for variant of Huion H610X

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/H610X.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H610X.json
@@ -27,7 +27,7 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {
-        "201": "HUION_T212_\\d{6}$"
+        "201": "HUION_(T212|T229)_\\d{6}$"
       },
       "InitializationStrings": [
         200


### PR DESCRIPTION
My new Huion H610X had a different device string than the pattern specified in the config file: `HUION_T229_220720`

Attached is a diagnostics file with the tablet detected and working.

[diagnostic-h610x.json](https://github.com/OpenTabletDriver/OpenTabletDriver/files/15139030/diagnostic-h610x.json)
