### PR TITLE
Add support for UGEE M908

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/UGEE/M908.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/M908.json
@@ -1,0 +1,39 @@
+{
+  "Name": "UGEE M908",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 254,
+      "Height": 158.75,
+      "MaxX": 50800,
+      "MaxY": 31750
+    },
+    "Pen": {
+      "MaxPressure": 16383,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 8
+    },
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 10429,
+      "ProductID": 10498,
+      "InputReportLength": 12,
+      "OutputReportLength": 20,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": [
+        "ArAE"
+      ],
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }
+  ],
+  "AuxiliaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -196,6 +196,7 @@
 | Parblo Intangbo M             |  Missing Features | Wheel is not yet supported.
 | Parblo Intangbo S             |  Missing Features | Wheel is not yet supported.
 | UGEE EX08                     |  Missing Features | Tilt is not yet supported. Uses the same configuration as the XP-Pen Deco 01 V2.
+| UGEE M908                     |  Missing Features | Wheel is not yet supported.
 | VEIKK A15 Pro                 |  Missing Features | Wheel is not yet supported.
 | VEIKK A30                     |  Missing Features | Touchpad is not yet supported.
 | VEIKK A30 V2                  |  Missing Features | Touchpad is not yet supported.


### PR DESCRIPTION
Verification: https://canary.discord.com/channels/615607687467761684/1230540609815711794/1232757889161236581
Diagnostic: https://canary.discord.com/channels/615607687467761684/1230540609815711794/1232393576835584100

Not going under the UGTABLET folder because the UGTABLET folder should not exist. See #3199.

Fixes #3286.