### PR TITLE
[0.6.x] Use AppContext.BaseDirectory in daemon watchdog

### DIFF
--- a/OpenTabletDriver.UX/DaemonWatchdog.cs
+++ b/OpenTabletDriver.UX/DaemonWatchdog.cs
@@ -16,9 +16,9 @@ namespace OpenTabletDriver.UX
         {
             PluginPlatform.Windows => new ProcessStartInfo
             {
-                FileName = Path.Join(Directory.GetCurrentDirectory(), "OpenTabletDriver.Daemon.exe"),
+                FileName = Path.Join(AppContext.BaseDirectory, "OpenTabletDriver.Daemon.exe"),
                 Arguments = "",
-                WorkingDirectory = Directory.GetCurrentDirectory(),
+                WorkingDirectory = AppContext.BaseDirectory,
                 CreateNoWindow = true
             },
             PluginPlatform.MacOS => new ProcessStartInfo
@@ -29,7 +29,7 @@ namespace OpenTabletDriver.UX
             _ => new ProcessStartInfo
             {
                 FileName = "dotnet",
-                Arguments = Path.Join(Directory.GetCurrentDirectory(), "OpenTabletDriver.Daemon.dll")
+                Arguments = Path.Join(AppContext.BaseDirectory, "OpenTabletDriver.Daemon.dll")
             }
         };
 


### PR DESCRIPTION
`Directory.GetCurrentDirectory()` refers to where the application was called from, not the root of the application. This caused issues when calling the GUI from the Start menu.

Not sure if this branch is still in active development or if another release is planned. If the answer to either is no, feel free to close this PR :)