### PR TITLE
Add support for XP-Pen Star 03 Pro

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 03 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 03 Pro.json
@@ -1,0 +1,39 @@
+{
+  "Name": "XP-Pen Star 03 Pro",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 254,
+      "Height": 152.4,
+      "MaxX": 50800,
+      "MaxY": 30480
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 8
+    },
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 10429,
+      "ProductID": 119,
+      "InputReportLength": 8,
+      "OutputReportLength": 8,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": [
+        "ArAC"
+      ],
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }
+  ],
+  "AuxiliaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -134,6 +134,7 @@
 | XP-Pen Deco mini4             |     Supported     |
 | XP-Pen Deco mini7             |     Supported     |
 | XP-Pen Star 03                |     Supported     |
+| XP-Pen Star 03 Pro            |     Supported     |
 | XP-Pen Star 05 V3             |     Supported     |
 | XP-Pen Star G430S             |     Supported     |
 | XP-Pen Star G540              |     Supported     |


### PR DESCRIPTION
Diagnostics: [diagnostics.json](https://github.com/OpenTabletDriver/OpenTabletDriver/files/15355992/diagnostics.json)
Specifications source: [here](https://dgtizers.com/xppen-star-03-pro)
GNU/Linux screenshot (on Wayland): ![image](https://github.com/OpenTabletDriver/OpenTabletDriver/assets/45771313/29604ac0-da41-4ab2-86b1-9c3145824d71)
I couldn't test on Windows since I don't have a Windows machine.

Closes #3319.
