### PR TITLE
Add support for Trust Flex Design Tablet

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Trust/Flex Design Tablet.json
+++ b/OpenTabletDriver.Configurations/Configurations/Trust/Flex Design Tablet.json
@@ -1,0 +1,39 @@
+{
+  "Name": "Trust Flex Design Tablet",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 153.6,
+      "Height": 115.2,
+      "MaxX": 12288,
+      "MaxY": 9216
+    },
+    "Pen": {
+      "MaxPressure": 1023,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": null,
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 5935,
+      "ProductID": 55,
+      "InputReportLength": 64,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Genius.GeniusReportParserV2",
+      "FeatureInitReport": [
+        "AgQA",
+        "AgIA",
+        "AhAB"
+      ],
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": []
+    }
+  ],
+  "AuxiliaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -74,7 +74,7 @@
 | VEIKK VK430                   |     Supported     |
 | VEIKK VK640                   |     Supported     |
 | ViewSonic WoodPad PF0730      |     Supported     |
-| ViewSonic Woodpad PF1030      |     Supported     | 
+| ViewSonic Woodpad PF1030      |     Supported     |
 | Wacom CTC-4110WL              |     Supported     |
 | Wacom CTC-6110WL              |     Supported     |
 | Wacom CTE-430                 |     Supported     |
@@ -172,6 +172,7 @@
 | KENTING K5540                 |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed
 | Parblo Ninos M                |    Has Quirks     | Aux buttons are not in order.
 | Parblo Ninos S                |    Has Quirks     | Aux buttons are not in order.
+| Trust Flex Design Tablet      |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed
 | UGEE M708                     |    Has Quirks     | Windows: Might need Zadig's WinUSB to be installed on interface 0
 | Wacom PTU-600U                |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed
 | XP-Pen Artist 22HD            |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0


### PR DESCRIPTION
Verification: https://canary.discord.com/channels/615607687467761684/1240317376101093446/1241474209163645000
Diagnostic: https://canary.discord.com/channels/615607687467761684/1240317376101093446/1241485624800972850

There is a quirk with the tablet itself (not a bug in OpenTabletDriver) that prevents pressure from being reported when pen buttons are pressed.

The lpmm of the tablet is around 80~ the specifications on the internet don't seem to agree on the size of the active area of this tablet, so it was measured by hand.