### PR TITLE
Add tilt to other variants of the Huion H1060P

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/H1060P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H1060P.json
@@ -38,7 +38,7 @@
       "ProductID": 110,
       "InputReportLength": 12,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {
@@ -53,7 +53,7 @@
       "ProductID": 100,
       "InputReportLength": 12,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {


### PR DESCRIPTION
One identifier already has tilt but these don't.