### PR TITLE
Correct Auxiliary key count for XP-Pen Artist 24 Pro

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 24 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 24 Pro.json
@@ -12,7 +12,7 @@
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {
-      "ButtonCount": 8
+      "ButtonCount": 20
     },
     "MouseButtons": null,
     "Touch": null


### PR DESCRIPTION
Minor fuckup that was missed because of the bulk configuration merge, you can see the mistake in #3291 where the auxiliary keys were supposed to be set to 20.