### PR TITLE
Add support for Parblo A610

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Parblo/A610.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/A610.json
@@ -1,9 +1,9 @@
 {
-  "Name": "UGEE M708",
+  "Name": "Parblo A610",
   "Specifications": {
     "Digitizer": {
-      "Width": 200,
-      "Height": 120,
+      "Width": 254,
+      "Height": 152.4,
       "MaxX": 40000,
       "MaxY": 24000
     },
@@ -27,9 +27,7 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {
-        "4": "F401-20111028",
-        "5": "UC-LOIC",
-        "6": "TABLET 1060"
+        "201": "F401-HK708-STD"
       },
       "InitializationStrings": [
         100,

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -74,7 +74,7 @@
 | VEIKK VK430                   |     Supported     |
 | VEIKK VK640                   |     Supported     |
 | ViewSonic WoodPad PF0730      |     Supported     |
-| ViewSonic Woodpad PF1030      |     Supported     | 
+| ViewSonic Woodpad PF1030      |     Supported     |
 | Wacom CTC-4110WL              |     Supported     |
 | Wacom CTC-6110WL              |     Supported     |
 | Wacom CTE-430                 |     Supported     |
@@ -169,6 +169,7 @@
 | Huion New 1060 Plus (2048)    |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 1
 | Huion osu! Tablet             |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0
 | KENTING K5540                 |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed
+| Parblo A610                   |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0
 | Parblo Ninos M                |    Has Quirks     | Aux buttons are not in order.
 | Parblo Ninos S                |    Has Quirks     | Aux buttons are not in order.
 | UGEE M708                     |    Has Quirks     | Windows: Might need Zadig's WinUSB to be installed on interface 0


### PR DESCRIPTION
Identical hardware to the UGEE M708.

With this PR comes a change that may unintentionally "remove" support tablets with the same PID and VID due to previously their being no string filter on the M708. I have added the string from when this tablet was originally supported back in #1904 and you can follow discord link to find the strings.

We have at least 3 different tablets with this PID and VID now so its important that they are all gated properly.

Because this requires WinUSB it will be a good idea once #3245 is merged for it to be locked to interface 0 for the sake of Linux and MacOS.

Will not be backported at this time due to the merge of the UGTABLET and UGEE folders and diverging `master` and `0.6.x`. Will be backported post #3372.