### PR TITLE
Finish transition to .NET 8

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3.2.0
         with:
-          dotnet-version: '6.0'
+          dotnet-version: '8.0'
 
       - name: Linux Publish
         env:
@@ -53,7 +53,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3.2.0
         with:
-          dotnet-version: '6.0'
+          dotnet-version: '8.0'
 
       - name: MacOS Publish
         env:
@@ -80,7 +80,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3.2.0
         with:
-          dotnet-version: '6.0'
+          dotnet-version: '8.0'
 
       - name: Windows Publish
         env:
@@ -110,7 +110,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3.2.0
         with:
-          dotnet-version: '6.0'
+          dotnet-version: '8.0'
 
       - name: Lint Changed Files
         run: |
@@ -127,7 +127,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3.2.0
         with:
-          dotnet-version: '6.0'
+          dotnet-version: '8.0'
 
       - name: Run tests
         run: dotnet test
@@ -142,7 +142,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3.2.0
         with:
-          dotnet-version: '6.0'
+          dotnet-version: '8.0'
 
       - name: Windows
         run: dotnet restore OpenTabletDriver.Windows.slnf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       VERSION_SUFFIX: ${{ github.event.inputs.version_suffix }}
     steps:
       - name: Install required packages
-        run: sudo apt install -y debhelper dotnet-sdk-6.0
+        run: sudo apt install -y debhelper dotnet-sdk-8.0
 
       - name: Checkout OpenTabletDriver Repository
         uses: actions/checkout@v4
@@ -75,7 +75,7 @@ jobs:
         VERSION_SUFFIX: ${{ github.event.inputs.version_suffix }}
     steps:
       - name: Install required packages
-        run: sudo dnf install -y rpm-build systemd-rpm-macros libicu openssl-libs zlib krb5-libs git dotnet-sdk-6.0 tree jq
+        run: sudo dnf install -y rpm-build systemd-rpm-macros libicu openssl-libs zlib krb5-libs git dotnet-sdk-8.0 tree jq
 
       - name: Checkout OpenTabletDriver Repository
         uses: actions/checkout@v4
@@ -115,7 +115,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3.2.0
         with:
-          dotnet-version: '6.0'
+          dotnet-version: '8.0'
 
       - name: Package
         run: ./eng/windows/package.ps1

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,8 +6,8 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "Build Daemon",
-            "cwd": "${workspaceFolder}/OpenTabletDriver.Daemon/bin/Debug/net6.0",
-            "program": "${workspaceFolder}/OpenTabletDriver.Daemon/bin/Debug/net6.0/OpenTabletDriver.Daemon.dll",
+            "cwd": "${workspaceFolder}/OpenTabletDriver.Daemon/bin/Debug/net8.0",
+            "program": "${workspaceFolder}/OpenTabletDriver.Daemon/bin/Debug/net8.0/OpenTabletDriver.Daemon.dll",
             "args": [
               "--config",
               "${workspaceFolder}/bin/Configurations"
@@ -25,16 +25,16 @@
             "console": "internalConsole",
             "stopAtEntry": false,
             "windows": {
-                "cwd": "${workspaceFolder}/OpenTabletDriver.UX.Wpf/bin/Debug/net6.0-windows",
-                "program": "${workspaceFolder}/OpenTabletDriver.UX.Wpf/bin/Debug/net6.0-windows/OpenTabletDriver.UX.Wpf.dll",
+                "cwd": "${workspaceFolder}/OpenTabletDriver.UX.Wpf/bin/Debug/net8.0-windows",
+                "program": "${workspaceFolder}/OpenTabletDriver.UX.Wpf/bin/Debug/net8.0-windows/OpenTabletDriver.UX.Wpf.dll",
             },
             "linux": {
-                "cwd": "${workspaceFolder}/OpenTabletDriver.UX.Gtk/bin/Debug/net6.0/",
-                "program": "${workspaceFolder}/OpenTabletDriver.UX.Gtk/bin/Debug/net6.0/OpenTabletDriver.UX.Gtk.dll",
+                "cwd": "${workspaceFolder}/OpenTabletDriver.UX.Gtk/bin/Debug/net8.0/",
+                "program": "${workspaceFolder}/OpenTabletDriver.UX.Gtk/bin/Debug/net8.0/OpenTabletDriver.UX.Gtk.dll",
             },
             "osx": {
-                "cwd": "${workspaceFolder}/OpenTabletDriver.UX.MacOS/bin/Debug/net6.0/OpenTabletDriver.UX.MacOS.app/Contents/MacOS/",
-                "program": "${workspaceFolder}/OpenTabletDriver.UX.MacOS/bin/Debug/net6.0/OpenTabletDriver.UX.MacOS.app/Contents/MacOS/OpenTabletDriver.UX.MacOS.dll",
+                "cwd": "${workspaceFolder}/OpenTabletDriver.UX.MacOS/bin/Debug/net8.0/OpenTabletDriver.UX.MacOS.app/Contents/MacOS/",
+                "program": "${workspaceFolder}/OpenTabletDriver.UX.MacOS/bin/Debug/net8.0/OpenTabletDriver.UX.MacOS.app/Contents/MacOS/OpenTabletDriver.UX.MacOS.dll",
             }
         },
         {

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The requirements to build OpenTabletDriver are consistent across all platforms. 
 
 ### All platforms
 
-- .NET 6 SDK (can be obtained from [here](https://dotnet.microsoft.com/download/dotnet/6.0) - You want the SDK for your platform, Linux users should install via package manager where possible)
+- .NET 8 SDK (can be obtained from [here](https://dotnet.microsoft.com/download/dotnet/8.0) - You want the SDK for your platform, Linux users should install via package manager where possible)
 
 #### Windows
 


### PR DESCRIPTION
Backports #3387.

Only includes the README change on the main README, no point backporting the translations as they are not in sync anyway.