### PR TITLE
[Backport] Add support for Huion Kamvas Pro 16 Plus (4k)

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16 Plus (4k).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16 Plus (4k).json
@@ -1,0 +1,39 @@
+{
+  "Name": "Huion Kamvas Pro 16 Plus (4k)",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 344.75422,
+      "Height": 193.85432,
+      "MaxX": 68840,
+      "MaxY": 38720
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "Buttons": {
+        "ButtonCount": 2
+      }
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 0
+    },
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 9580,
+      "ProductID": 109,
+      "InputReportLength": 12,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "201": "HUION_M20a_\\d{6}$"
+      },
+      "InitializationStrings": [200]
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {}
+}

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16 Plus (4k).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16 Plus (4k).json
@@ -2,8 +2,8 @@
   "Name": "Huion Kamvas Pro 16 Plus (4k)",
   "Specifications": {
     "Digitizer": {
-      "Width": 344.75422,
-      "Height": 193.85432,
+      "Width": 344.2,
+      "Height": 193.6,
       "MaxX": 68840,
       "MaxY": 38720
     },
@@ -13,9 +13,7 @@
         "ButtonCount": 2
       }
     },
-    "AuxiliaryButtons": {
-      "ButtonCount": 0
-    },
+    "AuxiliaryButtons": null,
     "MouseButtons": null,
     "Touch": null
   },
@@ -31,7 +29,9 @@
       "DeviceStrings": {
         "201": "HUION_M20a_\\d{6}$"
       },
-      "InitializationStrings": [200]
+      "InitializationStrings": [
+        200
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -41,6 +41,7 @@
 | Huion Kamvas Pro 13 (2.5k)    |     Supported     |
 | Huion Kamvas Pro 16 (2.5k)    |     Supported     |
 | Huion Kamvas Pro 16 (4k)      |     Supported     |
+| Huion Kamvas Pro 16 Plus      |     Supported     |
 | Huion Kamvas Pro 24 (4K)      |     Supported     |
 | Huion New 1060 Plus           |     Supported     |
 | Huion Q11K                    |     Supported     |

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -38,10 +38,10 @@
 | Huion Kamvas 22               |     Supported     |
 | Huion Kamvas 22 Plus          |     Supported     |
 | Huion Kamvas 24 Plus          |     Supported     |
-| Huion Kamvas Pro 13 (2.5k)    |     Supported     |
-| Huion Kamvas Pro 16 (2.5k)    |     Supported     |
-| Huion Kamvas Pro 16 (4k)      |     Supported     |
-| Huion Kamvas Pro 16 Plus      |     Supported     |
+| Huion Kamvas Pro 13 (2.5K)    |     Supported     |
+| Huion Kamvas Pro 16 (2.5K)    |     Supported     |
+| Huion Kamvas Pro 16 (4K)      |     Supported     |
+| Huion Kamvas Pro 16 Plus (4K) |     Supported     |
 | Huion Kamvas Pro 24 (4K)      |     Supported     |
 | Huion New 1060 Plus           |     Supported     |
 | Huion Q11K                    |     Supported     |


### PR DESCRIPTION
Backport of #3251.

Name in TABLETS.md was only noticed after merge so a commit to fix that has been included here. The fix for master is #3410.