### PR TITLE
Add the "Lords Mobile" edition of the H950P

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/H950P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H950P.json
@@ -20,6 +20,21 @@
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
+      "ProductID": 100,
+      "InputReportLength": 12,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "201": "HUION_T(22d)_\\d{6}$"
+      },
+      "InitializationStrings": [
+        200
+      ]
+    },
+    {
+      "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
       "OutputReportLength": null,

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H950P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H950P.json
@@ -27,7 +27,7 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {
-        "201": "HUION_T(22d)_\\d{6}$"
+        "201": "HUION_T22d_\\d{6}$"
       },
       "InitializationStrings": [
         200


### PR DESCRIPTION
The "Lords Mobile" edition of the H950P has a different ProductID than the standard H950P. Adding this identifier allows the "Lords" version to function the same as the standard H950P.

Looking for feedback as well about whether or not this is appropriate as an addition to the current H950P.json or if it should be its own file. As it stands, the model number on the back states the tablet is an "H950P" with the only difference I noticed is the ProductID.

**Diagnostics:**
https://github.com/user-attachments/files/16515015/H950P_Lords.txt

**String Dump:**
https://github.com/user-attachments/files/16514947/H950P_Lords.txt

**Verification:**
I have successfully used the tablet in Krita and mapped functions to all pen buttons and auxiliary buttons on the tablet.