### PR TITLE
Rename V2 to (Variant 2), fix VEIKK voila naming, fix A50 support status

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A50 (Variant 2).json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A50 (Variant 2).json
@@ -1,30 +1,32 @@
 {
-  "Name": "XP-Pen Star G640 V2",
+  "Name": "VEIKK A50 (Variant 2)",
   "Specifications": {
     "Digitizer": {
-      "Width": 160,
-      "Height": 100,
-      "MaxX": 15999,
-      "MaxY": 9999
+      "Width": 254,
+      "Height": 152.4,
+      "MaxX": 50800,
+      "MaxY": 30480
     },
     "Pen": {
       "MaxPressure": 8191,
       "ButtonCount": 2
     },
-    "AuxiliaryButtons": null,
+    "AuxiliaryButtons": {
+      "ButtonCount": 4
+    },
     "MouseButtons": null,
     "Touch": null
   },
   "DigitizerIdentifiers": [
     {
-      "VendorID": 10429,
-      "ProductID": 2324,
-      "InputReportLength": 12,
-      "OutputReportLength": 12,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
+      "VendorID": 12267,
+      "ProductID": 3,
+      "InputReportLength": 13,
+      "OutputReportLength": 9,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": [
-        "ArAE"
+        "CQEE"
       ],
       "DeviceStrings": {},
       "InitializationStrings": []

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/VO1060.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/VO1060.json
@@ -1,5 +1,5 @@
 {
-  "Name": "VEIKK Viola (VO1060)",
+  "Name": "VEIKK Voila (VO1060)",
   "Specifications": {
     "Digitizer": {
       "Width": 254,

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01 V2 (Variant 2).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01 V2 (Variant 2).json
@@ -1,5 +1,5 @@
 {
-  "Name": "XP-Pen Deco 01 V2 (variant 2)",
+  "Name": "XP-Pen Deco 01 V2 (Variant 2)",
   "Specifications": {
     "Digitizer": {
       "Width": 254,

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640 (Variant 2).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640 (Variant 2).json
@@ -1,32 +1,30 @@
 {
-  "Name": "VEIKK A50 V2",
+  "Name": "XP-Pen Star G640 (Variant 2)",
   "Specifications": {
     "Digitizer": {
-      "Width": 254,
-      "Height": 152.4,
-      "MaxX": 50800,
-      "MaxY": 30480
+      "Width": 160,
+      "Height": 100,
+      "MaxX": 15999,
+      "MaxY": 9999
     },
     "Pen": {
       "MaxPressure": 8191,
       "ButtonCount": 2
     },
-    "AuxiliaryButtons": {
-      "ButtonCount": 4
-    },
+    "AuxiliaryButtons": null,
     "MouseButtons": null,
     "Touch": null
   },
   "DigitizerIdentifiers": [
     {
-      "VendorID": 12267,
-      "ProductID": 3,
-      "InputReportLength": 13,
-      "OutputReportLength": 9,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkReportParser",
+      "VendorID": 10429,
+      "ProductID": 2324,
+      "InputReportLength": 12,
+      "OutputReportLength": 12,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
       "FeatureInitReport": null,
       "OutputInitReport": [
-        "CQEE"
+        "ArAE"
       ],
       "DeviceStrings": {},
       "InitializationStrings": []

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -152,7 +152,7 @@
 | XP-Pen Star G540              |     Supported     |
 | XP-Pen Star G540 Pro          |     Supported     |
 | XP-Pen Star G640              |     Supported     |
-| XP-Pen Star G640 V2           |     Supported     |
+| XP-Pen Star G640 (Variant 2)  |     Supported     |
 | XP-Pen Star G640S             |     Supported     |
 | XP-Pen Star G960              |     Supported     |
 | XP-Pen Star G960S             |     Supported     |
@@ -222,8 +222,8 @@
 | VEIKK A30                     |  Missing Features | Touchpad is not yet supported.
 | VEIKK A30 V2                  |  Missing Features | Touchpad is not yet supported.
 | VEIKK A50                     |  Missing Features | Touchpad is not yet supported.
-| VEIKK A50 V2                  |  Missing Features | Touchpad is not yet supported.
 | VEIKK Viola (VO1060)          |  Missing Features | Wheel is not yet supported.
+| VEIKK A50 (Variant 2)         |  Missing Features | Touchpad is not yet supported.
 | VEIKK VK1060PRO               |  Missing Features | Wheels not yet supported.
 | Wacom CTE-450                 |  Missing Features | Wheel is not yet supported.
 | Wacom CTE-650                 |  Missing Features | Wheel is not yet supported.
@@ -266,7 +266,7 @@
 | XP-Pen Artist 24 Pro          |  Missing Features | Wheel is not yet supported.
 | XP-Pen Artist Pro 16TP        |  Missing Features | Touch is not yet supported.
 | XP-Pen Deco 01 V2             |  Missing Features | Tilt is not yet supported.
-| XP-Pen Deco 01 V2 (variant 2) |  Missing Features | Tilt is not yet supported
+| XP-Pen Deco 01 V2 (Variant 2) |  Missing Features | Tilt is not yet supported
 | XP-Pen Deco 02                |  Missing Features | Wheel is not yet supported.
 | XP-Pen Deco 03                |  Missing Features | Wheel is not yet supported.
 | XP-Pen Deco Pro Medium        |  Missing Features | Tilt and wheel are not yet supported.

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -222,8 +222,8 @@
 | VEIKK A30                     |  Missing Features | Touchpad is not yet supported.
 | VEIKK A30 V2                  |  Missing Features | Touchpad is not yet supported.
 | VEIKK A50                     |  Missing Features | Touchpad is not yet supported.
-| VEIKK Viola (VO1060)          |  Missing Features | Wheel is not yet supported.
 | VEIKK A50 (Variant 2)         |  Missing Features | Touchpad is not yet supported.
+| VEIKK Voila (VO1060)          |  Missing Features | Wheel is not yet supported.
 | VEIKK VK1060PRO               |  Missing Features | Wheels not yet supported.
 | Wacom CTE-450                 |  Missing Features | Wheel is not yet supported.
 | Wacom CTE-650                 |  Missing Features | Wheel is not yet supported.

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -69,7 +69,6 @@
 | UGEE U1600                    |     Supported     |
 | VEIKK A15                     |     Supported     |
 | VEIKK A15 V2                  |     Supported     |
-| VEIKK A50                     |     Supported     |
 | VEIKK S640                    |     Supported     |
 | VEIKK S640 V2                 |     Supported     |
 | VEIKK VK1060                  |     Supported     |
@@ -222,6 +221,7 @@
 | VEIKK A15 Pro                 |  Missing Features | Wheel is not yet supported.
 | VEIKK A30                     |  Missing Features | Touchpad is not yet supported.
 | VEIKK A30 V2                  |  Missing Features | Touchpad is not yet supported.
+| VEIKK A50                     |  Missing Features | Touchpad is not yet supported.
 | VEIKK A50 V2                  |  Missing Features | Touchpad is not yet supported.
 | VEIKK Viola (VO1060)          |  Missing Features | Wheel is not yet supported.
 | VEIKK VK1060PRO               |  Missing Features | Wheels not yet supported.


### PR DESCRIPTION
Went through and checked which tablets we name `V2` without them being officially named `V2` and changed them to `(Variant 2)`.

Also noticed VEIKK Voila is named wrong and A50 should be in missing features.