### PR TITLE
Fix LinuxTimer units

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Timer/LinuxTimer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Timer/LinuxTimer.cs
@@ -39,8 +39,8 @@ namespace OpenTabletDriver.Desktop.Interop.Timer
 
                     _timerFD = timerFD;
 
-                    long seconds = (long)Interval;
-                    long nseconds = (long)((Interval - seconds) * 1000.0 * 1000.0 * 1000.0);
+                    long seconds = (long)(Interval / 1000.0f);
+                    long nseconds = (long)((Interval - seconds * 1000) * 1000.0 * 1000.0);
 
                     _timerSpec = new ITimerSpec
                     {

--- a/OpenTabletDriver/ITimer.cs
+++ b/OpenTabletDriver/ITimer.cs
@@ -25,7 +25,7 @@ namespace OpenTabletDriver
         bool Enabled { get; }
 
         /// <summary>
-        /// The timer's interval for invoking <see cref="Elapsed"/>
+        /// The timer's interval for invoking <see cref="Elapsed"/> in milliseconds.
         /// </summary>
         float Interval { set; get; }
 


### PR DESCRIPTION
I messed it up... I thought `Interval` was in seconds, but it was actually in milliseconds.

I can blame lack of documentation, but I should have read it more thoroughly...