### PR TITLE
Add support for DTU-1031X

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTU-1031X.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTU-1031X.json
@@ -1,0 +1,31 @@
+﻿{
+  "Name": "Wacom DTU-1031X",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 226.72,
+      "Height": 129.28,
+      "MaxX": 22672,
+      "MaxY": 12928
+    },
+    "Pen": {
+      "MaxPressure": 511,
+      "ButtonCount": 1
+    },
+    "AuxiliaryButtons": null,
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 1386,
+      "ProductID": 815,
+      "InputReportLength": 64,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.DTU.DTUReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null
+    }
+  ],
+  "AuxiliaryDeviceIdentifiers": [],
+  "Attributes": {}
+}

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/DTU/DTUReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/DTU/DTUReportParser.cs
@@ -1,0 +1,12 @@
+﻿using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Wacom.DTU
+{
+    public class DTUReportParser : IReportParser<IDeviceReport>
+    {
+        public virtual IDeviceReport Parse(byte[] report)
+        {
+            return new DTUTabletReport(report);
+        }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/DTU/DTUTabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/DTU/DTUTabletReport.cs
@@ -1,0 +1,31 @@
+﻿using System.Numerics;
+using System.Runtime.CompilerServices;
+using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Wacom.DTU
+{
+    public struct DTUTabletReport : ITabletReport
+    {
+        public DTUTabletReport(byte[] report)
+        {
+            Raw = report;
+
+            Position = new Vector2
+            {
+                X = (report[3] << 8) | report[4],
+                Y = (report[5] << 8) | report[6]
+            };
+            Pressure = ((uint)(report[1] & 0x1) << 8 ) | report[2];
+
+            PenButtons = new bool[]
+            {
+            };
+
+        }
+
+        public byte[] Raw { set; get; }
+        public Vector2 Position { set; get; }
+        public uint Pressure { set; get; }
+        public bool[] PenButtons { set; get; }
+    }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -234,6 +234,7 @@
 | Wacom CTL-6100WL              |  Missing Features | Wireless is not yet supported.
 | Wacom DTH-1320                |  Missing Features | Touch is not yet supported.
 | Wacom DTK-1300                |  Missing Features | Center button is not yet supported.
+| Wacom DTU-1031X               |  Missing Features | Pen buttons are not yet supported.
 | Wacom DTZ-1200W               |  Missing Features | Touch bars and top side buttons are not yet supported.
 | Wacom MTE-450                 |  Missing Features | Wheel is not yet supported.
 | Wacom PTH-450                 |  Missing Features | Wheel is not yet supported.


### PR DESCRIPTION
Config file and a new parser for DTU-1031X. Tablet comes with a pen that has no buttons but supports ones with them. I will add support later.