### PR TITLE
Fix Detection Issue for Huion Kamvas Pro 12 Tablet 

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 12.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 12.json
@@ -42,7 +42,7 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {
-        "201": "HUION_M20j_\\d{6}$"
+        "201": "HUION_M(20j|171)_\\d{6}$"
       },
       "InitializationStrings": [
         200


### PR DESCRIPTION
Hi,

I own a Kamvas Pro 12, and I found out that my tablet is undetected. When I was debugging, I found that my device with ProductID=109 has a DeviceString "HUION_M171_\d{6}$" instead of "HUION_M20j_\d{6}$" as in the configuration. This pull request will fix this bug by adding an additional configuration for this tablet.

PS: It's my first pull request, and my English is not my first language, so please forgive me if I do any mistakes :)