### PR TITLE
Turcom TS-6580 compatibility config. 

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Turcom/TS-6580.json
+++ b/OpenTabletDriver.Configurations/Configurations/Turcom/TS-6580.json
@@ -1,0 +1,56 @@
+{
+  "Name": "Turcom TS-6580",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 203.2,
+      "Height": 127,
+      "MaxX": 32000,
+      "MaxY": 20000
+    },
+    "Pen": {
+      "MaxPressure": 2047,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": null,
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 9580,
+      "ProductID": 110,
+      "InputReportLength": 8,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Tablet.TabletReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "6": "Huion",
+        "121": "M508"
+      },
+      "InitializationStrings": [
+        100
+      ]
+    },
+    {
+      "VendorID": 9580,
+      "ProductID": 110,
+      "InputReportLength": 16,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Tablet.TabletReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "6": "Huion",
+        "121": "M508"
+      },
+      "InitializationStrings": [
+        100
+      ]
+    }
+  ],
+  "AuxiliaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -176,6 +176,7 @@
 | Parblo Ninos M                |    Has Quirks     | Aux buttons are not in order.
 | Parblo Ninos S                |    Has Quirks     | Aux buttons are not in order.
 | Trust Flex Design Tablet      |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed
+| Turcom TS-6580                |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0
 | UGEE M708                     |    Has Quirks     | Windows: Might need Zadig's WinUSB to be installed on interface 0
 | Wacom PTU-600U                |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed
 | XP-Pen Artist 16              |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0


### PR DESCRIPTION
Adding config file for Turcom TS-6580. Full functionality tested in Windows 11 on OTD 0.7.x. 
Confirmed data via Huion driver USB packet capture. (USB addr in pcap is 3.10)
[ts-6580-diag.txt](https://github.com/user-attachments/files/16741961/ts-6580-diag.txt)
[ts-6580_huion-driver-cap.pcap.tar.gz](https://github.com/user-attachments/files/16741967/ts-6580_huion-driver-cap.pcap.tar.gz)
