### PR TITLE
Turcom TS-6580 compatibility config. (0.6.x config backport)

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Turcom/TS-6580.json
+++ b/OpenTabletDriver.Configurations/Configurations/Turcom/TS-6580.json
@@ -1,0 +1,58 @@
+{
+  "Name": "Turcom TS-6580",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 203.2,
+      "Height": 127.0,
+      "MaxX": 32000.0,
+      "MaxY": 20000.0
+    },
+    "Pen": {
+      "MaxPressure": 2047,
+      "Buttons": {
+        "ButtonCount": 2
+      }
+    },
+    "AuxiliaryButtons": null,
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 9580,
+      "ProductID": 110,
+      "InputReportLength": 8,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "6": "Huion",
+        "121": "M508"
+      },
+      "InitializationStrings": [
+        100
+      ]
+    },
+    {
+      "VendorID": 9580,
+      "ProductID": 110,
+      "InputReportLength": 16,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "6": "Huion",
+        "121": "M508"
+      },
+      "InitializationStrings": [
+        100
+      ]
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -175,6 +175,7 @@
 | Parblo Ninos M                |    Has Quirks     | Aux buttons are not in order.
 | Parblo Ninos S                |    Has Quirks     | Aux buttons are not in order.
 | Trust Flex Design Tablet      |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed
+| Turcom TS-6580                |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0
 | UGEE M708                     |    Has Quirks     | Windows: Might need Zadig's WinUSB to be installed on interface 0
 | Wacom PTU-600U                |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed
 | XP-Pen Artist 22HD            |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0


### PR DESCRIPTION
Backported config of Turcom TS-6580. Tested in Windows 11 as working. 
[ts-6580_0.6_backport.json](https://github.com/user-attachments/files/16751643/ts-6580_0.6_backport.json)


