### PR TITLE
Fix new firmware deco pro gen2

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenTabletGen2Report.cs
+++ b/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenTabletGen2Report.cs
@@ -15,7 +15,7 @@ namespace OpenTabletDriver.Configurations.Parsers.XP_Pen
                 X = Unsafe.ReadUnaligned<ushort>(ref report[2]) | report[10] << 16,
                 Y = Unsafe.ReadUnaligned<ushort>(ref report[4]) | report[11] << 16
             };
-            Pressure = (uint)((Unsafe.ReadUnaligned<ushort>(ref report[6]) - 16384) | (report[13] & 0x01) << 13);
+            Pressure = (uint)((Unsafe.ReadUnaligned<ushort>(ref report[6]) & 0xFFBF) | (report[13] & 0x01) << 13);
             Eraser = report[1].IsBitSet(3);
 
             PenButtons = new bool[]


### PR DESCRIPTION
So... it was not a good idea to use subtraction here. In newer versions of the xp pen firmware they removed the troublesome bit that was being subtracted (`00 40`) and that makes this parser overflow the pressure value.