### PR TITLE
Add support for GaomonM7 and make improvement for GaomonM6、1060pro、M8

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/1060 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/1060 Pro.json
@@ -27,7 +27,7 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {
-        "201": "OEM02_T174_\\d{6}$"
+        "201": "(OEM02_T174|GM001_T213|GM001_T216)_\\d{6}$"
       },
       "InitializationStrings": [
         200

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M7.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M7.json
@@ -1,5 +1,5 @@
 {
-  "Name": "Gaomon M8",
+  "Name": "Gaomon M7",
   "Specifications": {
     "Digitizer": {
       "Width": 258.465,
@@ -12,7 +12,7 @@
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {
-      "ButtonCount": 9
+      "ButtonCount": 13
     },
     "MouseButtons": null,
     "Touch": null
@@ -27,7 +27,7 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {
-        "201": "(GM001_T208|GM001_T201|GM001_T221)_\\d{6}$"
+        "201": "(GM001_T207|GM001_T202|GM001_T220)_\\d{6}$"
       },
       "InitializationStrings": [
         200


### PR DESCRIPTION
1. Add supports for GaomonM7 
2. Make improvement for GaomonM6、1060pro、M8：
Models of the M6 include: OEM02_T183 and GM001_T223;
Models of the M7 include: GM001_T207、GM001_T202、GM001_T220;
Models of the M8 include: GM001_T208、GM001_T201、GM001_T221;
Models of the 1060pro include: OEM02_T174、GM001_T213、GM001_T216;
refered by Gaomon Official information
[2024.6.17export.txt](https://github.com/user-attachments/files/17004662/2024.6.17export.txt)
[DevImg.zip](https://github.com/user-attachments/files/17004667/DevImg.zip)
Closes #3341 