### PR TITLE
[Backport] Correct Gaomon M8 internal Name

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M8.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M8.json
@@ -1,5 +1,5 @@
 {
-  "Name": "Gaomon M6",
+  "Name": "Gaomon M8",
   "Specifications": {
     "Digitizer": {
       "Width": 258.465,


### PR DESCRIPTION
Backport of #3467.