### PR TITLE
[Backport] Attribute overhaul

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/10moon/1060N.json
+++ b/OpenTabletDriver.Configurations/Configurations/10moon/1060N.json
@@ -29,7 +29,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -47,7 +48,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {

--- a/OpenTabletDriver.Configurations/Configurations/Acepen/AP1060.json
+++ b/OpenTabletDriver.Configurations/Configurations/Acepen/AP1060.json
@@ -33,7 +33,8 @@
         "CQIC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Acepen/AP906.json
+++ b/OpenTabletDriver.Configurations/Configurations/Acepen/AP906.json
@@ -33,7 +33,8 @@
         "CQIC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Adesso/Cybertablet K8.json
+++ b/OpenTabletDriver.Configurations/Configurations/Adesso/Cybertablet K8.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Artisul/A1201.json
+++ b/OpenTabletDriver.Configurations/Configurations/Artisul/A1201.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Artisul/AP604.json
+++ b/OpenTabletDriver.Configurations/Configurations/Artisul/AP604.json
@@ -27,7 +27,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Artisul/D16 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Artisul/D16 Pro.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Artisul/M0610 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Artisul/M0610 Pro.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         100
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         100
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/FlooGoo/FMA100.json
+++ b/OpenTabletDriver.Configurations/Configurations/FlooGoo/FMA100.json
@@ -27,7 +27,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/1060 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/1060 Pro.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -63,7 +65,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -78,7 +81,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/GM116HD.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/GM116HD.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/GM156HD.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/GM156HD.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M106K Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M106K Pro.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M106K.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M106K.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M10K Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M10K Pro.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M10K.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M10K.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M1220.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M1220.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M1230.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M1230.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M6.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M6.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M8.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M8.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/PD1161.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/PD1161.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/PD156 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/PD156 Pro.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/PD1560.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/PD1560.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/PD1561.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/PD1561.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/PD2200.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/PD2200.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/S56K.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/S56K.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -61,7 +63,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/S620.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/S620.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/S630.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/S630.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/S830.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/S830.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Genius/G-Pen 560.json
+++ b/OpenTabletDriver.Configurations/Configurations/Genius/G-Pen 560.json
@@ -33,7 +33,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Genius/i405x.json
+++ b/OpenTabletDriver.Configurations/Configurations/Genius/i405x.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Genius/i608x.json
+++ b/OpenTabletDriver.Configurations/Configurations/Genius/i608x.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/1060 Plus.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/1060 Plus.json
@@ -35,7 +35,8 @@
       "InitializationStrings": [
         100,
         123
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/420.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/420.json
@@ -32,7 +32,8 @@
       "InitializationStrings": [
         100,
         123
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -49,7 +50,8 @@
       "InitializationStrings": [
         100,
         123
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/420.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/420.json
@@ -55,6 +55,6 @@
   "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1",
-    "LinuxInterface": "0"
+    "Interface": "0"
   }
 }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/G10T.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/G10T.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/G930L.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/G930L.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/GC610.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/GC610.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/GT-156HD V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/GT-156HD V2.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/GT-220 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/GT-220 V2.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/GT-221 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/GT-221 Pro.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/GT-221.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/GT-221.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H1060P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H1060P.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -63,7 +65,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H1161.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H1161.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H320M.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H320M.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H420.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H420.json
@@ -34,7 +34,8 @@
       "InitializationStrings": [
         100,
         123
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H420.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H420.json
@@ -40,6 +40,6 @@
   "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1",
-    "LinuxInterface": "0"
+    "Interface": "0"
   }
 }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H420X.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H420X.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H430P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H430P.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -63,7 +65,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -78,7 +81,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H580X.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H580X.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H610 Pro V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H610 Pro V2.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -63,7 +65,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H610 Pro V3.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H610 Pro V3.json
@@ -29,7 +29,8 @@
       "DeviceStrings": {
         "121": "^HA60$"
       },
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H610 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H610 Pro.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H610X.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H610X.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H640P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H640P.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -63,7 +65,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -78,7 +81,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H641P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H641P.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H642.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H642.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H690.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H690.json
@@ -34,7 +34,8 @@
       "InitializationStrings": [
         100,
         123
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -50,7 +51,8 @@
       "InitializationStrings": [
         100,
         123
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H950P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H950P.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -63,7 +65,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -78,7 +81,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H951P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H951P.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/HC16.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/HC16.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/HS610.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/HS610.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/HS611.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/HS611.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
 
   ],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/HS64.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/HS64.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -63,7 +65,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/HS95.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/HS95.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 12.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 12.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 13.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 13.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 16 (2021).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 16 (2021).json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 16.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 16.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 20.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 20.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 22 Plus.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 22 Plus.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 22.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 22.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 24 Plus.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 24 Plus.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 12.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 12.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 13 (2.5k).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 13 (2.5k).json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 13.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 13.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16 (2.5k).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16 (2.5k).json
@@ -33,7 +33,8 @@
         },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,9 +49,10 @@
       },
       "InitializationStrings": [
         200
-      ]
-      }
-    ],
-    "AuxilaryDeviceIdentifiers": [],
-    "Attributes": {}
-  }
+      ],
+      "Attributes": {}
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {}
+}

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16 (2.5k).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16 (2.5k).json
@@ -1,36 +1,36 @@
 {
-    "Name": "Huion Kamvas Pro 16 (2.5k)",
-    "Specifications": {
-      "Digitizer": {
-        "Width": 349.63,
-        "Height": 196.665,
-        "MaxX": 69926.0,
-        "MaxY": 39333.0
-      },
-      "Pen": {
-        "MaxPressure": 8191,
-        "Buttons": {
-          "ButtonCount": 2
-        }
-      },
-      "AuxiliaryButtons": {
-        "ButtonCount": 8
-      },
-      "MouseButtons": null,
-      "Touch": null
+  "Name": "Huion Kamvas Pro 16 (2.5k)",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 349.63,
+      "Height": 196.665,
+      "MaxX": 69926.0,
+      "MaxY": 39333.0
     },
-    "DigitizerIdentifiers": [
-      {
-        "VendorID": 9580,
-        "ProductID": 109,
-        "InputReportLength": 12,
-        "OutputReportLength": null,
-        "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-        "FeatureInitReport": null,
-        "OutputInitReport": null,
-        "DeviceStrings": {
-          "201": "HUION_M214_\\d{6}$"
-        },
+    "Pen": {
+      "MaxPressure": 8191,
+      "Buttons": {
+        "ButtonCount": 2
+      }
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 8
+    },
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 9580,
+      "ProductID": 109,
+      "InputReportLength": 12,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "201": "HUION_M214_\\d{6}$"
+      },
       "InitializationStrings": [
         200
       ],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16 (4k).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16 (4k).json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16 Plus (4k).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16 Plus (4k).json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 19 (4K).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 19 (4K).json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 20.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 20.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 22 (2019).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 22 (2019).json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 24 (4K).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 24 (4K).json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 24.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 24.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/New 1060 Plus (2048).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/New 1060 Plus (2048).json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         100
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         100
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/New 1060 Plus.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/New 1060 Plus.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Q11K V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Q11K V2.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Q11K.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Q11K.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Q620M.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Q620M.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Q630M.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Q630M.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/RDS-160.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/RDS-160.json
@@ -1,44 +1,44 @@
 {
-    "Name": "Huion RDS-160",
-    "Specifications": {
-      "Digitizer": {
-        "Width": 344.2,
-        "Height": 193.6,
-        "MaxX": 68840.0,
-        "MaxY": 38720.0
-      },
-      "Pen": {
-        "MaxPressure": 8191,
-        "Buttons": {
-          "ButtonCount": 2
-        }
-      },
-      "AuxiliaryButtons": {
-        "ButtonCount": 10
-      },
-      "MouseButtons": null,
-      "Touch": null
+  "Name": "Huion RDS-160",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 344.2,
+      "Height": 193.6,
+      "MaxX": 68840.0,
+      "MaxY": 38720.0
     },
-    "DigitizerIdentifiers": [
-      {
-        "VendorID": 9580,
-        "ProductID": 109,
-        "InputReportLength": 12,
-        "OutputReportLength": null,
-        "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-        "FeatureInitReport": null,
-        "OutputInitReport": null,
-        "DeviceStrings": {
-          "201": "HUION_M211_\\d{6}$"
-        },
-        "InitializationStrings": [
-          200
-        ],
-        "Attributes": {}
+    "Pen": {
+      "MaxPressure": 8191,
+      "Buttons": {
+        "ButtonCount": 2
       }
-    ],
-    "AuxilaryDeviceIdentifiers": [],
-    "Attributes": {
-      "libinputoverride": "1"
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 10
+    },
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 9580,
+      "ProductID": 109,
+      "InputReportLength": 12,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "201": "HUION_M211_\\d{6}$"
+      },
+      "InitializationStrings": [
+        200
+      ],
+      "Attributes": {}
     }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
   }
+}

--- a/OpenTabletDriver.Configurations/Configurations/Huion/RDS-160.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/RDS-160.json
@@ -33,7 +33,8 @@
         },
         "InitializationStrings": [
           200
-        ]
+        ],
+        "Attributes": {}
       }
     ],
     "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/RTE-100.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/RTE-100.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/RTM 500.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/RTM 500.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/RTP-700.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/RTP-700.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/WH1409 V2 (Variant 2).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/WH1409 V2 (Variant 2).json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/WH1409 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/WH1409 V2.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Huion/WH1409.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/WH1409.json
@@ -33,7 +33,8 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/KENTING/K5540.json
+++ b/OpenTabletDriver.Configurations/Configurations/KENTING/K5540.json
@@ -29,7 +29,8 @@
       "DeviceStrings": {},
       "InitializationStrings": [
         100
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Lifetec/LT9570.json
+++ b/OpenTabletDriver.Configurations/Configurations/Lifetec/LT9570.json
@@ -37,7 +37,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Monoprice/10594.json
+++ b/OpenTabletDriver.Configurations/Configurations/Monoprice/10594.json
@@ -35,7 +35,8 @@
       "InitializationStrings": [
         100,
         123
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Monoprice/MP1060-HA60.json
+++ b/OpenTabletDriver.Configurations/Configurations/Monoprice/MP1060-HA60.json
@@ -31,7 +31,8 @@
       "DeviceStrings": {},
       "InitializationStrings": [
         100
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/A609.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/A609.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/A610 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/A610 Pro.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/A610.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/A610.json
@@ -34,7 +34,8 @@
       "InitializationStrings": [
         100,
         123
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/A640 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/A640 V2.json
@@ -31,7 +31,8 @@
         "ArAEAAAAAAA="
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/A640.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/A640.json
@@ -29,7 +29,8 @@
       "DeviceStrings": {},
       "InitializationStrings": [
         100
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Intangbo M.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Intangbo M.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1155,
@@ -44,7 +45,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Intangbo S.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Intangbo S.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1155,
@@ -44,7 +45,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos M.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos M.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1155,
@@ -44,7 +45,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N4.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N4.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N7.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N7.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1155,
@@ -42,7 +43,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N7B.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N7B.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos S.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos S.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1155,
@@ -44,7 +45,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/RobotPen/T9A.json
+++ b/OpenTabletDriver.Configurations/Configurations/RobotPen/T9A.json
@@ -29,7 +29,8 @@
         "qhAC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Trust/Flex Design Tablet.json
+++ b/OpenTabletDriver.Configurations/Configurations/Trust/Flex Design Tablet.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Turcom/TS-6580.json
+++ b/OpenTabletDriver.Configurations/Configurations/Turcom/TS-6580.json
@@ -32,7 +32,8 @@
       },
       "InitializationStrings": [
         100
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 9580,
@@ -48,7 +49,8 @@
       },
       "InitializationStrings": [
         100
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/UC-Logic/1060N.json
+++ b/OpenTabletDriver.Configurations/Configurations/UC-Logic/1060N.json
@@ -35,7 +35,8 @@
       },
       "InitializationStrings": [
         100
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/UC-Logic/1060N.json
+++ b/OpenTabletDriver.Configurations/Configurations/UC-Logic/1060N.json
@@ -41,6 +41,6 @@
   "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1",
-    "MacInterface": "0"
+    "Interface": "0"
   }
 }

--- a/OpenTabletDriver.Configurations/Configurations/UC-Logic/PF1209.json
+++ b/OpenTabletDriver.Configurations/Configurations/UC-Logic/PF1209.json
@@ -31,7 +31,8 @@
       },
       "InitializationStrings": [
         109
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/M708 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/M708 V2.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/M708.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/M708.json
@@ -36,7 +36,8 @@
       "InitializationStrings": [
         100,
         123
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/M808.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/M808.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/M908.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/M908.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/S1060.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/S1060.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/S640.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/S640.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -44,7 +45,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/U1200.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/U1200.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/U1600.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/U1600.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A15 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A15 Pro.json
@@ -31,7 +31,8 @@
         "CQEE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 12267,
@@ -44,7 +45,8 @@
         "CQEE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A15 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A15 V2.json
@@ -33,7 +33,8 @@
             "CQMC"
         ],
         "DeviceStrings": {},
-        "InitializationStrings": []
+        "InitializationStrings": [],
+        "Attributes": {}
       }
     ],
     "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A15 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A15 V2.json
@@ -1,44 +1,44 @@
 {
-    "Name": "VEIKK A15 V2",
-    "Specifications": {
-      "Digitizer": {
-        "Width": 254.0,
-        "Height": 152.4,
-        "MaxX": 50800.0,
-        "MaxY": 31750.0
-      },
-      "Pen": {
-        "MaxPressure": 8191,
-        "Buttons": {
-          "ButtonCount": 2
-        }
-      },
-      "AuxiliaryButtons": {
-        "ButtonCount": 12
-      },
-      "MouseButtons": null,
-      "Touch": null
+  "Name": "VEIKK A15 V2",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 254,
+      "Height": 152.4,
+      "MaxX": 50800.0,
+      "MaxY": 31750.0
     },
-    "DigitizerIdentifiers": [
-      {
-        "VendorID": 12267,
-        "ProductID": 4,
-        "InputReportLength": 13,
-        "OutputReportLength": 9,
-        "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkReportParser",
-        "FeatureInitReport": null,
-        "OutputInitReport": [
-            "CQEE",
-            "CQIC",
-            "CQMC"
-        ],
-        "DeviceStrings": {},
-        "InitializationStrings": [],
-        "Attributes": {}
+    "Pen": {
+      "MaxPressure": 8191,
+      "Buttons": {
+        "ButtonCount": 2
       }
-    ],
-    "AuxilaryDeviceIdentifiers": [],
-    "Attributes": {
-      "libinputoverride": "1"
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 12
+    },
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 12267,
+      "ProductID": 4,
+      "InputReportLength": 13,
+      "OutputReportLength": 9,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": [
+        "CQEE",
+        "CQIC",
+        "CQMC"
+      ],
+      "DeviceStrings": {},
+      "InitializationStrings": [],
+      "Attributes": {}
     }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
   }
+}

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A15.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A15.json
@@ -33,7 +33,8 @@
             "CQMC"
         ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A30 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A30 V2.json
@@ -33,7 +33,8 @@
         "CQMC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A30.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A30.json
@@ -31,7 +31,8 @@
         "CQEE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A50 (Variant 2).json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A50 (Variant 2).json
@@ -31,7 +31,8 @@
         "CQEE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A50.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A50.json
@@ -31,7 +31,8 @@
         "CQEE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 12267,
@@ -44,7 +45,8 @@
         "CQEE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/S640 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/S640 V2.json
@@ -29,7 +29,8 @@
         "CQEE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/S640.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/S640.json
@@ -29,7 +29,8 @@
         "CQEE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/VK1060.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/VK1060.json
@@ -33,7 +33,8 @@
         "CQMC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/VK1060PRO.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/VK1060PRO.json
@@ -33,7 +33,8 @@
         "CQMC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/VK430 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/VK430 V2.json
@@ -35,7 +35,8 @@
       "DeviceStrings": {
         "23": "^2022/12/9$"
       },
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/VK430.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/VK430.json
@@ -35,7 +35,8 @@
       "DeviceStrings": {
         "23": "^2022/3/21$"
       },
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 12267,
@@ -52,7 +53,8 @@
       "DeviceStrings": {
         "23": "^2022/4/25$"
       },
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/VK640.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/VK640.json
@@ -33,7 +33,8 @@
         "CQMC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/VO1060.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/VO1060.json
@@ -32,7 +32,8 @@
         "CQIC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/ViewSonic/Woodpad PF0730.json
+++ b/OpenTabletDriver.Configurations/Configurations/ViewSonic/Woodpad PF0730.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/ViewSonic/Woodpad PF1030.json
+++ b/OpenTabletDriver.Configurations/Configurations/ViewSonic/Woodpad PF1030.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTC-4110WL.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTC-4110WL.json
@@ -29,7 +29,8 @@
           ],
         "OutputInitReport": null,
         "DeviceStrings": {},
-        "InitializationStrings": []
+        "InitializationStrings": [],
+        "Attributes": {}
       }
     ],
     "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTC-4110WL.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTC-4110WL.json
@@ -1,38 +1,38 @@
 {
-    "Name": "Wacom CTC-4110WL",
-    "Specifications": {
-      "Digitizer": {
-        "Width": 152.0,
-        "Height": 95.0,
-        "MaxX": 15200.0,
-        "MaxY": 9500.0
-      },
-      "Pen": {
-        "MaxPressure": 4095,
+  "Name": "Wacom CTC-4110WL",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 152.0,
+      "Height": 95.0,
+      "MaxX": 15200.0,
+      "MaxY": 9500.0
+    },
+    "Pen": {
+      "MaxPressure": 4095,
       "Buttons": {
         "ButtonCount": 2
       }
-      },
-      "AuxiliaryButtons": null,
-      "MouseButtons": null,
-      "Touch": null
     },
-    "DigitizerIdentifiers": [
-      {
-        "VendorID": 1329,
-        "ProductID": 256,
-        "InputReportLength": 192,
-        "OutputReportLength": null,
-        "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV3.IntuosV3ReportParser",
-        "FeatureInitReport": [
-            "AgI="
-          ],
-        "OutputInitReport": null,
-        "DeviceStrings": {},
-        "InitializationStrings": [],
-        "Attributes": {}
-      }
-    ],
-    "AuxilaryDeviceIdentifiers": [],
-    "Attributes": {}
-  }
+    "AuxiliaryButtons": null,
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 1329,
+      "ProductID": 256,
+      "InputReportLength": 192,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV3.IntuosV3ReportParser",
+      "FeatureInitReport": [
+        "AgI="
+      ],
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": [],
+      "Attributes": {}
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {}
+}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTC-6110WL.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTC-6110WL.json
@@ -29,7 +29,8 @@
           ],
         "OutputInitReport": null,
         "DeviceStrings": {},
-        "InitializationStrings": []
+        "InitializationStrings": [],
+        "Attributes": {}
       }
     ],
     "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTC-6110WL.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTC-6110WL.json
@@ -1,38 +1,38 @@
 {
-    "Name": "Wacom CTC-6110WL",
-    "Specifications": {
-      "Digitizer": {
-        "Width": 216.0,
-        "Height": 135.0,
-        "MaxX": 21600.0,
-        "MaxY": 13500.0
-      },
-      "Pen": {
-        "MaxPressure": 4095,
+  "Name": "Wacom CTC-6110WL",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 216.0,
+      "Height": 135.0,
+      "MaxX": 21600.0,
+      "MaxY": 13500.0
+    },
+    "Pen": {
+      "MaxPressure": 4095,
       "Buttons": {
         "ButtonCount": 2
       }
-      },
-      "AuxiliaryButtons": null,
-      "MouseButtons": null,
-      "Touch": null
     },
-    "DigitizerIdentifiers": [
-      {
-        "VendorID": 1329,
-        "ProductID": 258,
-        "InputReportLength": 192,
-        "OutputReportLength": null,
-        "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV3.IntuosV3ReportParser",
-        "FeatureInitReport": [
-            "AgI="
-          ],
-        "OutputInitReport": null,
-        "DeviceStrings": {},
-        "InitializationStrings": [],
-        "Attributes": {}
-      }
-    ],
-    "AuxilaryDeviceIdentifiers": [],
-    "Attributes": {}
-  }
+    "AuxiliaryButtons": null,
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 1329,
+      "ProductID": 258,
+      "InputReportLength": 192,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV3.IntuosV3ReportParser",
+      "FeatureInitReport": [
+        "AgI="
+      ],
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": [],
+      "Attributes": {}
+    }
+  ],
+  "AuxilaryDeviceIdentifiers": [],
+  "Attributes": {}
+}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-430.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-430.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-440.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-440.json
@@ -31,7 +31,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -55,7 +57,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -68,7 +71,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-450.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-450.json
@@ -33,7 +33,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-460.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-460.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-630.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-630.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-640.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-640.json
@@ -33,7 +33,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -46,7 +47,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-650.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-650.json
@@ -33,7 +33,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-660.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-660.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTF-430.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTF-430.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-300.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-300.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-301.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-301.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-460.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-460.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -57,7 +59,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -70,7 +73,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -81,7 +85,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-461.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-461.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -57,7 +59,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -70,7 +73,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-470.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-470.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -57,7 +59,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-480.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-480.json
@@ -36,7 +36,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -49,7 +50,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -62,7 +64,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-490.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-490.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -57,7 +59,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-661.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-661.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -57,7 +59,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -70,8 +73,9 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
-    }    
+      "InitializationStrings": [],
+      "Attributes": {}
+    }
   ],
   "AuxilaryDeviceIdentifiers": [],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-670.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-670.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -57,7 +59,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-680.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-680.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -57,7 +59,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-690.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-690.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -57,7 +59,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-4100.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-4100.json
@@ -29,7 +29,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -40,7 +41,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-4100WL.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-4100WL.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -57,7 +59,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -68,7 +71,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -79,7 +83,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -92,7 +97,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -105,7 +111,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-460.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-460.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -55,7 +57,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-470.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-470.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -55,7 +57,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-471.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-471.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -55,7 +57,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-472.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-472.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-480.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-480.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -57,7 +59,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-490.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-490.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -57,7 +59,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-6100.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-6100.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-6100WL.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-6100WL.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-671.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-671.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -55,7 +57,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-672.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-672.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-680.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-680.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -57,7 +59,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-690.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-690.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -57,7 +59,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTC-133.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTC-133.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTH-1320.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTH-1320.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-1300.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-1300.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-1660.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-1660.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-2200.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-2200.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-2200.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-2200.json
@@ -1,11 +1,11 @@
 {
-  "Name": "Wacom Cintiq 22HD (DTK2200)",
+  "Name": "Wacom Cintiq 22HD (DTK-2200)",
   "Specifications": {
     "Digitizer": {
-      "Width": 479,
-      "Height": 271,
-      "MaxX": 95040,
-      "MaxY": 54260
+      "Width": 479.0,
+      "Height": 271.0,
+      "MaxX": 95040.0,
+      "MaxY": 54260.0
     },
     "Pen": {
       "MaxPressure": 2048,

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTZ-1200W.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTZ-1200W.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/ET-0405-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/ET-0405-U.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/ET-0405A-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/ET-0405A-U.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/FT-0405-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/FT-0405-U.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/GD-0405-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/GD-0405-U.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/GD-0608-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/GD-0608-U.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/GD-0912-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/GD-0912-U.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/GD-1212-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/GD-1212-U.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/GD-1218-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/GD-1218-U.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -42,7 +43,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/MTE-450.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/MTE-450.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-450.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-450.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -57,7 +59,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-451.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-451.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -57,7 +59,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-460.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-460.json
@@ -33,7 +33,8 @@
       "DeviceStrings": {},
       "InitializationStrings": [
         0
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -46,7 +47,8 @@
       "DeviceStrings": {},
       "InitializationStrings": [
         0
-      ]
+      ],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -59,7 +61,8 @@
       "DeviceStrings": {},
       "InitializationStrings": [
         0
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -72,7 +75,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-650.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-650.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -57,7 +59,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-651.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-651.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -57,7 +59,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-660.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-660.json
@@ -29,7 +29,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -40,7 +41,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -53,7 +55,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-850.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-850.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -57,7 +59,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-851.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-851.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -57,7 +59,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-860.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-860.json
@@ -29,7 +29,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -40,7 +41,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -53,7 +55,8 @@
       "FeatureInitReport": null,
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "Attributes": {}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-1240.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-1240.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-440.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-440.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-450.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-450.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-540WL.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-540WL.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-640.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-640.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-650.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-650.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-840.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-840.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTU-600U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTU-600U.json
@@ -29,7 +29,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-1230.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-1230.json
@@ -34,7 +34,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -48,7 +49,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-1231W.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-1231W.json
@@ -34,7 +34,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -48,7 +49,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-430.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-430.json
@@ -34,7 +34,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -48,7 +49,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-431W.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-431W.json
@@ -34,7 +34,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -48,7 +49,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-630.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-630.json
@@ -34,7 +34,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -48,7 +49,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-631W.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-631W.json
@@ -34,7 +34,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -48,7 +49,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-930.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-930.json
@@ -34,7 +34,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -48,7 +49,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/XD-0405-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/XD-0405-U.json
@@ -30,7 +30,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/XD-0608-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/XD-0608-U.json
@@ -30,7 +30,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/XD-0912-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/XD-0912-U.json
@@ -30,7 +30,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/XD-1212-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/XD-1212-U.json
@@ -30,7 +30,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/XD-1218-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/XD-1218-U.json
@@ -30,7 +30,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 1386,
@@ -44,7 +45,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/Waltop/Slim Tablet.json
+++ b/OpenTabletDriver.Configurations/Configurations/Waltop/Slim Tablet.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XENX/P1-640.json
+++ b/OpenTabletDriver.Configurations/Configurations/XENX/P1-640.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XENX/P3-1060.json
+++ b/OpenTabletDriver.Configurations/Configurations/XENX/P3-1060.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XENX/X1-640.json
+++ b/OpenTabletDriver.Configurations/Configurations/XENX/X1-640.json
@@ -31,7 +31,8 @@
       ],
       "OutputInitReport": null,
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 10 (2nd Gen).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 10 (2nd Gen).json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12 (2nd Gen).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12 (2nd Gen).json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12 Pro.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 13 (2nd Gen).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 13 (2nd Gen).json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 13.3 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 13.3 Pro.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 13.3.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 13.3.json
@@ -31,7 +31,8 @@
         "ArAC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -46,7 +47,8 @@
       "DeviceStrings": {},
       "InitializationStrings": [
         4
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "Attributes": {

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 15.6 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 15.6 Pro.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 15.6.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 15.6.json
@@ -31,7 +31,8 @@
         "ArAC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -44,7 +45,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -59,7 +61,8 @@
       "DeviceStrings": {},
       "InitializationStrings": [
         4
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "Attributes": {

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16 (2nd Gen).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16 (2nd Gen).json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16 Pro.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16.json
@@ -38,6 +38,7 @@
   ],
   "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
-    "libinputoverride": "1"
+    "libinputoverride": "1",
+    "Interface": "0"
   }
 }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16.json
@@ -32,7 +32,8 @@
       "InitializationStrings": [
         100,
         123
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 22 (2nd Gen).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 22 (2nd Gen).json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 22HD.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 22HD.json
@@ -29,7 +29,8 @@
       "DeviceStrings": {},
       "InitializationStrings": [
         100
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 24 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 24 Pro.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist Pro 16 (Gen2).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist Pro 16 (Gen2).json
@@ -4,13 +4,13 @@
     "Digitizer": {
       "Width": 344.68,
       "Height": 215.42,
-      "MaxX": 68920,
-      "MaxY": 43078
+      "MaxX": 68920.0,
+      "MaxY": 43078.0
     },
     "Pen": {
       "MaxPressure": 16383,
       "Buttons": {
-          "ButtonCount": 2
+        "ButtonCount": 2
       }
     },
     "AuxiliaryButtons": null,
@@ -19,19 +19,19 @@
   },
   "DigitizerIdentifiers": [
     {
-    "VendorID": 10429,
-    "ProductID": 2395,
-    "InputReportLength": 14,
-    "OutputReportLength": 14,
-    "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenGen2ReportParser",
-    "FeatureInitReport": null,
-    "OutputInitReport": [
-      "ArAE"
-    ],
-    "DeviceStrings": {},
-    "InitializationStrings": [],
-    "Attributes": {}
-  }
+      "VendorID": 10429,
+      "ProductID": 2395,
+      "InputReportLength": 14,
+      "OutputReportLength": 14,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenGen2ReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": [
+        "ArAE"
+      ],
+      "DeviceStrings": {},
+      "InitializationStrings": [],
+      "Attributes": {}
+    }
   ],
   "AuxilaryDeviceIdentifiers": [],
   "Attributes": {

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist Pro 16 (Gen2).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist Pro 16 (Gen2).json
@@ -29,7 +29,8 @@
       "ArAE"
     ],
     "DeviceStrings": {},
-    "InitializationStrings": []
+    "InitializationStrings": [],
+    "Attributes": {}
   }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist Pro 16TP.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist Pro 16TP.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/CT1060.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/CT1060.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/CT430.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/CT430.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -42,7 +43,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/CT640.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/CT640.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -42,7 +43,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01 V2 (Variant 2).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01 V2 (Variant 2).json
@@ -33,7 +33,8 @@
       "DeviceStrings": {
         "4": "UG902_BPG1002"
       },
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -49,7 +50,8 @@
         "4": "UG901_BPU1002",
         "5": "2020-10-23_Release3"
       },
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01 V2.json
@@ -34,7 +34,8 @@
         "4": "UG901_BPU1002",
         "5": "^(?!2020-10-23_Release3$).*$"
       },
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -49,7 +50,8 @@
       "DeviceStrings": {
         "4": "UG901_BPU1002"
       },
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01.json
@@ -31,7 +31,8 @@
         "ArAC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 02.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 02.json
@@ -31,7 +31,8 @@
         "ArAC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 03.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 03.json
@@ -31,7 +31,8 @@
         "ArAC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco L.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco L.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco M.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco M.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro LW Gen2.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro LW Gen2.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro Medium.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro Medium.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro SW.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro SW.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro Small.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro Small.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro XLW Gen2.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro XLW Gen2.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco mini4.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco mini4.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -44,7 +45,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco mini7.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco mini7.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -44,7 +45,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -57,7 +59,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -70,7 +73,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Innovator 16.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Innovator 16.json
@@ -31,7 +31,8 @@
         "ArEE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 03 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 03 Pro.json
@@ -31,7 +31,8 @@
         "ArAC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 03.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 03.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -44,7 +45,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -57,7 +59,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 05 V3.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 05 V3.json
@@ -31,7 +31,8 @@
         "ArAC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 06.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 06.json
@@ -31,7 +31,8 @@
         "ArAC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 06C.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 06C.json
@@ -31,7 +31,8 @@
         "ArAC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G430.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G430.json
@@ -31,7 +31,8 @@
       "DeviceStrings": {
         "2": "TABLET G3 4x3"
       },
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -46,7 +47,8 @@
       },
       "InitializationStrings": [
         100
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G430S V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G430S V2.json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G430S.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G430S.json
@@ -31,7 +31,8 @@
       "DeviceStrings": {
         "2": "G430S"
       },
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G540 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G540 Pro.json
@@ -29,7 +29,8 @@
         "ArAC"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G540.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G540.json
@@ -31,7 +31,8 @@
       "DeviceStrings": {
         "2": "TABLET G3 5x4"
       },
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640 (Variant 2).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640 (Variant 2).json
@@ -29,7 +29,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640.json
@@ -32,7 +32,8 @@
       "InitializationStrings": [
         100,
         110
-      ]
+      ],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640S.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640S.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -44,7 +45,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -57,7 +59,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G960.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G960.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G960S Plus.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G960S Plus.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G960S.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G960S.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -44,7 +45,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XenceLabs/Pen Tablet Medium.json
+++ b/OpenTabletDriver.Configurations/Configurations/XenceLabs/Pen Tablet Medium.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     },
     {
       "VendorID": 10429,
@@ -44,7 +45,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Configurations/Configurations/XenceLabs/Pen Tablet Small.json
+++ b/OpenTabletDriver.Configurations/Configurations/XenceLabs/Pen Tablet Small.json
@@ -31,7 +31,8 @@
         "ArAE"
       ],
       "DeviceStrings": {},
-      "InitializationStrings": []
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],

--- a/OpenTabletDriver.Plugin/Tablet/DeviceIdentifier.cs
+++ b/OpenTabletDriver.Plugin/Tablet/DeviceIdentifier.cs
@@ -58,5 +58,7 @@ namespace OpenTabletDriver.Plugin.Tablet
         /// Device strings to query to initialize device endpoints.
         /// </summary>
         public List<byte> InitializationStrings { set; get; } = new List<byte>();
+
+        public Dictionary<string, string> Attributes { set; get; } = new Dictionary<string, string>();
     }
 }

--- a/OpenTabletDriver/Devices/HidSharpBackend/Extensions.cs
+++ b/OpenTabletDriver/Devices/HidSharpBackend/Extensions.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using HidSharp.Reports;
+using OpenTabletDriver.Interop;
+
+namespace OpenTabletDriver.Devices.HidSharpBackend
+{
+    internal static class Extensions
+    {
+        // - HID_REPORTS (report_id:usage_page:usage_id, ...)
+        public static void ExtractHidUsages(Dictionary<string, string> deviceAttributes, Func<ReportDescriptor> reportDescriptorFunc)
+        {
+            try
+            {
+                var reportDescriptor = reportDescriptorFunc();
+                var usages = new List<(byte, uint)>();
+                foreach (var inputReport in reportDescriptor.InputReports)
+                {
+                    var reportId = inputReport.ReportID;
+                    usages.AddRange(inputReport.DeviceItem.Usages.GetAllValues().Select(x => (reportId, x)));
+                }
+
+                var hidReportsBuilder = new StringBuilder();
+                var enumerator = usages.GetEnumerator();
+                if (enumerator.MoveNext())
+                {
+                    var reportId = enumerator.Current.Item1;
+                    var extendedUsage = enumerator.Current.Item2;
+                    appendHidReport(hidReportsBuilder, reportId, extendedUsage);
+                    while (enumerator.MoveNext())
+                    {
+                        hidReportsBuilder.Append(", ");
+                        reportId = enumerator.Current.Item1;
+                        extendedUsage = enumerator.Current.Item2;
+                        appendHidReport(hidReportsBuilder, reportId, extendedUsage);
+                    }
+
+                    static void appendHidReport(StringBuilder stringBuilder, byte reportId, uint extendedUsage)
+                    {
+                        var usagePage = (extendedUsage & 0xffff0000) >> 16;
+                        var usageId = extendedUsage & 0x0000ffff;
+                        stringBuilder.Append($"{reportId:X2}:{usagePage:X4}:{usageId:X4}");
+                    }
+                }
+
+                deviceAttributes.Add("HID_REPORTS", hidReportsBuilder.ToString());
+            }
+            catch
+            {
+                deviceAttributes.Add("HID_REPORTS_NON_RECONSTRUCTABLE", "true");
+            }
+        }
+    }
+}

--- a/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpoint.cs
+++ b/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpoint.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using HidSharp;
+using HidSharp.Reports;
 using OpenTabletDriver.Interop;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Devices;
@@ -30,90 +32,45 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
         public string SerialNumber => device.SafeGet(d => d.GetSerialNumber(), string.Empty);
         public string DevicePath => device.SafeGet(d => d.DevicePath, "Invalid Device Path");
         public bool CanOpen => device.SafeGet(d => d.CanOpen, false);
-        public IDictionary<string, string> DeviceAttributes => GetDeviceAttributes();
+        public IDictionary<string, string> DeviceAttributes => GetDeviceAttributes(DevicePath, () => device.GetReportDescriptor());
 
         public IDeviceEndpointStream Open() => device.TryOpen(out var stream) ? new HidSharpEndpointStream(stream) : null;
         public string GetDeviceString(byte index) => device.GetDeviceString(index);
 
-        // - HID_REPORTS (report_id:usage_page:usage_id, ...)
-        // - USB_INTERFACE_NUMBER
-        private IDictionary<string, string> GetDeviceAttributes()
+        private static IDictionary<string, string> GetDeviceAttributes(string devicePath, Func<ReportDescriptor> reportDescriptorFunc)
         {
             var deviceAttributes = new Dictionary<string, string>();
             switch (SystemInterop.CurrentPlatform)
             {
                 case PluginPlatform.Windows:
-                    GetDeviceAttributesWindows(deviceAttributes);
+                    GetDeviceAttributesWindows(devicePath, deviceAttributes);
                     break;
                 case PluginPlatform.Linux:
-                    GetDeviceAttributesLinux(deviceAttributes);
+                    GetDeviceAttributesLinux(devicePath, deviceAttributes);
                     break;
                 case PluginPlatform.MacOS:
-                    GetDeviceAttributesMacOS(deviceAttributes);
+                    GetDeviceAttributesMacOS(devicePath, deviceAttributes);
                     break;
             }
 
-            try
-            {
-                ExtractHidUsages(deviceAttributes);
-            }
-            catch
-            {
-                deviceAttributes.Add("HID_REPORT_DESCRIPTOR_NON_RECONSTRUCTABLE", "true");
-            }
+            Extensions.ExtractHidUsages(deviceAttributes, reportDescriptorFunc);
 
             return deviceAttributes;
         }
 
-        private void ExtractHidUsages(Dictionary<string, string> deviceAttributes)
+        private static void GetDeviceAttributesWindows(string devicePath, Dictionary<string, string> deviceAttributes)
         {
-            var reportDescriptor = device.GetReportDescriptor();
-
-            List<(byte, uint)> usages = new List<(byte, uint)>();
-            foreach (var inputReport in reportDescriptor.InputReports)
-            {
-                var reportId = inputReport.ReportID;
-                usages.AddRange(inputReport.DeviceItem.Usages.GetAllValues().Select(x => (reportId, x)));
-            }
-
-            var hidReportsBuilder = new StringBuilder();
-            var enumerator = usages.GetEnumerator();
-            if (enumerator.MoveNext())
-            {
-                var reportId = enumerator.Current.Item1;
-                var extendedUsage = enumerator.Current.Item2;
-                appendHidReport(hidReportsBuilder, reportId, extendedUsage);
-                while (enumerator.MoveNext())
-                {
-                    hidReportsBuilder.Append(", ");
-                    reportId = enumerator.Current.Item1;
-                    extendedUsage = enumerator.Current.Item2;
-                    appendHidReport(hidReportsBuilder, reportId, extendedUsage);
-                }
-
-                static void appendHidReport(StringBuilder stringBuilder, byte reportId, uint extendedUsage)
-                {
-                    var usagePage = (extendedUsage & 0xffff0000) >> 16;
-                    var usageId = extendedUsage & 0x0000ffff;
-                    stringBuilder.Append($"{reportId:X2}:{usagePage:X4}:{usageId:X4}");
-                }
-            }
-
-            deviceAttributes.Add("HID_REPORTS", hidReportsBuilder.ToString());
+            GetInterfaceNumberFromPath(deviceAttributes, devicePath, @"&mi_(?<interface>\d+)");
         }
 
-        private void GetDeviceAttributesWindows(Dictionary<string, string> deviceAttributes)
+        private static void GetDeviceAttributesLinux(string devicePath, Dictionary<string, string> deviceAttributes)
         {
-            GetInterfaceNumberFromPath(deviceAttributes, DevicePath, @"&mi_(?<interface>\d+)");
+            GetInterfaceNumberFromPath(deviceAttributes, devicePath, @"^.*\/.*?:.*?\.(?<interface>.+)\/.*?\/hidraw\/hidraw\d+$");
         }
 
-        private void GetDeviceAttributesLinux(Dictionary<string, string> deviceAttributes)
+        private static void GetDeviceAttributesMacOS(string devicePath, Dictionary<string, string> deviceAttributes)
         {
-            GetInterfaceNumberFromPath(deviceAttributes, DevicePath, @"^.*\/.*?:.*?\.(?<interface>.+)\/.*?\/hidraw\/hidraw\d+$");
-        }
-
-        private void GetDeviceAttributesMacOS(Dictionary<string, string> deviceAttributes)
-        {
+            GetInterfaceNumberFromPath(deviceAttributes, devicePath, @"IOUSBHostInterface@(?<interface>\d+)");
         }
 
         private static void GetInterfaceNumberFromPath(Dictionary<string, string> attributes, string path, string regex)

--- a/OpenTabletDriver/Devices/WinUSB/WinUSBInterface.cs
+++ b/OpenTabletDriver/Devices/WinUSB/WinUSBInterface.cs
@@ -3,6 +3,8 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
+using HidSharp.Reports;
+using OpenTabletDriver.Devices.HidSharpBackend;
 using OpenTabletDriver.Native.Windows;
 using OpenTabletDriver.Native.Windows.USB;
 using OpenTabletDriver.Plugin.Devices;
@@ -78,12 +80,41 @@ namespace OpenTabletDriver.Devices.WinUSB
                 SerialNumber = deviceDescriptor.iSerialNumber != 0
                     ? GetDeviceString(deviceDescriptor.iSerialNumber)
                     : "Unknown Serial Number";
+
+                var reportDescriptorBuffer = ArrayPool<byte>.Shared.Rent(256);
+                fixed (void* reportDescriptorPtr = &reportDescriptorBuffer[0])
+                {
+                    var reportDescriptorPacket = SetupPacket.MakeGetDescriptor(
+                        RequestInternalType.Standard,
+                        RequestRecipient.Interface,
+                        DescriptorType.Report, 0,
+                        256
+                    );
+
+                    if (!WinUsb_ControlTransfer(winUsbHandle!, reportDescriptorPacket, reportDescriptorPtr, 256, out var lengthTransferred, null))
+                        throw new IOException("Failed to retrieve report descriptor");
+
+                    _reportDescriptor = new byte[lengthTransferred];
+                    Array.Copy(reportDescriptorBuffer, _reportDescriptor, lengthTransferred);
+
+                    try
+                    {
+                        var reportDescriptor = new ReportDescriptor(_reportDescriptor);
+                        FeatureReportLength = reportDescriptor.MaxFeatureReportLength;
+                    }
+                    catch
+                    {
+                        // Ignore
+                    }
+                }
+                ArrayPool<byte>.Shared.Return(reportDescriptorBuffer);
             });
         }
 
         private int referenceCount;
         private SafeFileHandle activeFileHandle;
         private SafeWinUsbInterfaceHandle activeWinUsbHandle;
+        private byte[] _reportDescriptor;
 
         internal int InterfaceNum { get; private set; }
         internal byte? InputPipe { get; private set; }
@@ -97,7 +128,7 @@ namespace OpenTabletDriver.Devices.WinUSB
 
         public int OutputReportLength { get; private set; }
 
-        public int FeatureReportLength => 0; // requires parsing report descriptor to determine feature report length
+        public int FeatureReportLength { private set; get; }
 
         public string Manufacturer { get; private set; }
 
@@ -111,7 +142,7 @@ namespace OpenTabletDriver.Devices.WinUSB
 
         public bool CanOpen => true;
 
-        public IDictionary<string, string> DeviceAttributes { get; }
+        public IDictionary<string, string> DeviceAttributes => GetDeviceAttributes();
 
         public unsafe string GetDeviceString(byte index)
         {
@@ -211,7 +242,7 @@ namespace OpenTabletDriver.Devices.WinUSB
                 ["USB_INTERFACE_NUMBER"] = InterfaceNum.ToString()
             };
 
-            // cannot extract HID_REPORTS from WinUSB for now
+            HidSharpBackend.Extensions.ExtractHidUsages(deviceAttributes, () => new ReportDescriptor(_reportDescriptor));
 
             return deviceAttributes;
         }

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -201,27 +201,28 @@ namespace OpenTabletDriver
 
         private static bool DeviceMatchesAttribute(IDeviceEndpoint device, Dictionary<string, string> attributes)
         {
+            // The name of the attribute which is used to enforce a device interface whitelist.
+            var interfaceKey = "Interface";
+            var devName = device.DevicePath;
+
             switch (SystemInterop.CurrentPlatform)
             {
                 case PluginPlatform.Windows:
                 {
-                    var devName = device.DevicePath;
-                    bool interfaceMatches = !attributes.ContainsKey("WinInterface") || Regex.IsMatch(devName, $"&mi_{attributes["WinInterface"]}");
-                    bool keyMatches = !attributes.ContainsKey("WinUsage") || Regex.IsMatch(devName, $"&col{attributes["WinUsage"]}");
+                    var interfaceMatches = !attributes.ContainsKey(interfaceKey) || Regex.IsMatch(devName, $"&mi_{attributes[interfaceKey]}");
+                    var keyMatches = !attributes.ContainsKey("WinUsage") || Regex.IsMatch(devName, $"&col{attributes["WinUsage"]}");
 
                     return interfaceMatches && keyMatches;
                 }
                 case PluginPlatform.MacOS:
                 {
-                    var devName = device.DevicePath;
-                    bool interfaceMatches = !attributes.ContainsKey("MacInterface") || Regex.IsMatch(devName, $"IOUSBHostInterface@{attributes["MacInterface"]}");
+                    bool interfaceMatches = !attributes.ContainsKey(interfaceKey) || Regex.IsMatch(devName, $"IOUSBHostInterface@{attributes[interfaceKey]}");
                     return interfaceMatches;
                 }
                 case PluginPlatform.Linux:
                 {
-                    var devName = device.DevicePath;
                     var match = Regex.Match(devName, @"^.*\/.*?:.*?\.(?<interface>.+)\/.*?\/hidraw\/hidraw\d+$");
-                    bool interfaceMatches = !attributes.ContainsKey("LinuxInterface") || match.Groups["interface"].Value == attributes["LinuxInterface"];
+                    bool interfaceMatches = !attributes.ContainsKey(interfaceKey) || match.Groups["interface"].Value == attributes[interfaceKey];
 
                     return interfaceMatches;
                 }


### PR DESCRIPTION
Attempts to backport #3245.

As a consequence of the diverging branches, history had to be killed, I also have not tested the changes on the backport yet.

Additionally, this PR fixes the linting on some of the tablets that had mangled formatting when they were backported.

It also fixes the name from #3285, as this did not have a `-` in the DTK-2200. The DTK-1660 is also like this, but as that config has been in a release already, changing it would "reset" the settings of users all for a minimal formatting change.