### PR TITLE
Add support for Fansjoy S2

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Fansjoy/FJ-S2.json
+++ b/OpenTabletDriver.Configurations/Configurations/Fansjoy/FJ-S2.json
@@ -2,8 +2,8 @@
   "Name": "Fansjoy FJ-S2",
   "Specifications": {
     "Digitizer": {
-      "Width": 115,
-      "Height": 72,
+      "Width": 160,
+      "Height": 100,
       "MaxX": 10500,
       "MaxY": 16800
     },

--- a/OpenTabletDriver.Configurations/Configurations/Fansjoy/FJ-S2.json
+++ b/OpenTabletDriver.Configurations/Configurations/Fansjoy/FJ-S2.json
@@ -1,0 +1,38 @@
+{
+  "Name": "Fansjoy FJ-S2",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 115,
+      "Height": 72,
+      "MaxX": 10500,
+      "MaxY": 16800
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 4
+    },
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 11648,
+      "ProductID": 12307,
+      "InputReportLength": 14,
+      "OutputReportLength": 0,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Fansjoy.FansjoyReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {},
+      "InitializationStrings": [],
+      "Attributes": {}
+    }
+  ],
+  "AuxiliaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Fansjoy/FansjoyAuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Fansjoy/FansjoyAuxReport.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Numerics;
 using OpenTabletDriver.Tablet;
 
 namespace OpenTabletDriver.Configurations.Parsers.Fansjoy

--- a/OpenTabletDriver.Configurations/Parsers/Fansjoy/FansjoyAuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Fansjoy/FansjoyAuxReport.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Numerics;
+using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Fansjoy
+{
+    public struct FansjoyAuxReport : IAuxReport
+    {
+        public FansjoyAuxReport(byte[] report)
+        {
+            Raw = report;
+
+            AuxButtons = new bool[]
+            {
+                report[2] == 0x05,
+                report[3] == 0x19,
+                report[4] == 0x08,
+                report[5] == 0x0b
+            };
+        }
+
+        public bool[] AuxButtons { set; get; }
+        public byte[] Raw { set; get; }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Fansjoy/FansjoyReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Fansjoy/FansjoyReportParser.cs
@@ -1,0 +1,29 @@
+
+using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Fansjoy
+{
+    public class FansjoyReportParser : IReportParser<IDeviceReport>
+    {
+        private const byte PEN_REPORT_LENGTH = 12;
+
+        public IDeviceReport Parse(byte[] report)
+        {
+            if (report.Length == PEN_REPORT_LENGTH)
+            {
+                if (report[1].IsBitSet(5))
+                {
+                    return new FansjoyTabletReport(report);
+                }
+                else
+                {
+                    return null!; // returning null makes OTD ignore this report
+                }
+            }
+            else // report.Length is 14 for aux buttons
+            {
+                return new FansjoyAuxReport(report);
+            }
+        }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Fansjoy/FansjoyReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Fansjoy/FansjoyReportParser.cs
@@ -14,15 +14,11 @@ namespace OpenTabletDriver.Configurations.Parsers.Fansjoy
                 {
                     return new FansjoyTabletReport(report);
                 }
-                else
-                {
-                    return new OutOfRangeReport(report);
-                }
+                return new OutOfRangeReport(report);
             }
-            else // report.Length is 14 for aux buttons
-            {
-                return new FansjoyAuxReport(report);
-            }
+
+            // report.Length is 14 for aux buttons
+            return new FansjoyAuxReport(report);
         }
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Fansjoy/FansjoyReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Fansjoy/FansjoyReportParser.cs
@@ -1,4 +1,3 @@
-
 using OpenTabletDriver.Tablet;
 
 namespace OpenTabletDriver.Configurations.Parsers.Fansjoy
@@ -17,7 +16,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Fansjoy
                 }
                 else
                 {
-                    return null!; // returning null makes OTD ignore this report
+                    return new OutOfRangeReport(report);
                 }
             }
             else // report.Length is 14 for aux buttons

--- a/OpenTabletDriver.Configurations/Parsers/Fansjoy/FansjoyTabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Fansjoy/FansjoyTabletReport.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Numerics;
+using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Fansjoy
+{
+    public struct FansjoyTabletReport : ITabletReport
+    {
+        public FansjoyTabletReport(byte[] report)
+        {
+            Raw = report;
+
+            Position = new Vector2
+            {
+                X = (report[5] << 8 | report[4]),
+                Y = 16800 - (report[3] << 8 | report[2])
+            };
+
+            Pressure = (uint)(report[7] << 8 | report [6]);
+
+            PenButtons = new bool[]
+            {
+                report[1].IsBitSet(2),
+                report[1].IsBitSet(1)
+            };
+        }
+
+        public byte[] Raw { get; set; }
+        public Vector2 Position { set; get; }
+        public uint Pressure { get; set; }
+        public bool[] PenButtons { set; get; }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Fansjoy/FansjoyTabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Fansjoy/FansjoyTabletReport.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Numerics;
 using OpenTabletDriver.Tablet;
 

--- a/OpenTabletDriver.Configurations/Parsers/Fansjoy/FansjoyTabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Fansjoy/FansjoyTabletReport.cs
@@ -24,9 +24,9 @@ namespace OpenTabletDriver.Configurations.Parsers.Fansjoy
             };
         }
 
-        public byte[] Raw { get; set; }
+        public byte[] Raw { set; get; }
         public Vector2 Position { set; get; }
-        public uint Pressure { get; set; }
+        public uint Pressure { set; get; }
         public bool[] PenButtons { set; get; }
     }
 }


### PR DESCRIPTION
For #3435
Note:
There is a function to change orientation by pressing the 1st and 4th button simultaneously for 6 sec. But this action doesn't sending any report at all.
Orientation can be changed in OTD. So I think there's no need to add that function.