### PR TITLE
Prevent multiple exception dialogs from opening at once (spamming) (0.6.x)

### DIFF
--- a/OpenTabletDriver.UX/Extensions.cs
+++ b/OpenTabletDriver.UX/Extensions.cs
@@ -12,31 +12,41 @@ namespace OpenTabletDriver.UX
 {
     public static class Extensions
     {
+        private static bool MessageBoxActive = false;
+
         public static void ShowMessageBox(this Exception exception)
         {
+            if (MessageBoxActive)
+                return;
             Application.Instance.Invoke(() =>
             {
                 exception = exception.GetBaseException();
 
                 var dialog = new ExceptionDialog(exception);
+                MessageBoxActive = true;
                 dialog.ShowModal(Application.Instance.MainForm);
+                MessageBoxActive = false;
             });
         }
 
         public static void ShowMessageBox(this CommonErrorData errorData)
         {
+            if (MessageBoxActive)
+                return;
             string message = errorData.Message + Environment.NewLine + errorData.StackTrace;
             Log.Write(
                 errorData.TypeName,
                 message,
                 LogLevel.Error
             );
+            MessageBoxActive = true;
             MessageBox.Show(
                 message,
                 errorData.TypeName,
                 MessageBoxButtons.OK,
                 MessageBoxType.Error
             );
+            MessageBoxActive = false;
         }
 
         public static BindableBinding<TControl, bool> GetEnabledBinding<TControl>(this TControl control) where TControl : Control

--- a/OpenTabletDriver.UX/Extensions.cs
+++ b/OpenTabletDriver.UX/Extensions.cs
@@ -31,14 +31,14 @@ namespace OpenTabletDriver.UX
 
         public static void ShowMessageBox(this CommonErrorData errorData)
         {
-            if (MessageBoxActive)
-                return;
             string message = errorData.Message + Environment.NewLine + errorData.StackTrace;
             Log.Write(
                 errorData.TypeName,
                 message,
                 LogLevel.Error
             );
+            if (MessageBoxActive)
+                return;
             MessageBoxActive = true;
             MessageBox.Show(
                 message,


### PR DESCRIPTION
Uses the **MessageBoxActive** bool to determine if there is an exception dialog already open.

This is to prevent cases where for example, a plugin throws an unhandled exception, or something goes horribly wrong in OpenTabletDriver, and exception windows are constantly shown. Things such as that can cause the system to slow down, and is definitely a problem, since not all windows can be closed quickly, or sometimes, even at all.

Although more than one exception won't be shown, they are logged.
There may be a better way to do this though.