### PR TITLE
Add Minimal Wheel Support in 0.6.x

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/Huion/HuionAuxReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Huion/HuionAuxReportParser.cs
@@ -1,0 +1,19 @@
+using OpenTabletDriver.Configurations.Parsers.UCLogic;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Huion
+{
+    public class HuionAuxReportParser : IReportParser<IDeviceReport>
+    {
+        public IDeviceReport Parse(byte[] data)
+        {
+            return data[1] switch
+            {
+                0xE0 => new UCLogicAuxReport(data),
+                0xF0 => new HuionWheelReport(data),
+                _ => new TiltTabletReport(data)
+            };
+
+        }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Huion/HuionWheelReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Huion/HuionWheelReport.cs
@@ -1,0 +1,20 @@
+using OpenTabletDriver.Plugin.Tablet.Wheel;
+
+namespace OpenTabletDriver.Configurations.Parsers.Huion;
+
+public class HuionWheelReport : IAbsoluteWheelReport
+{
+    public HuionWheelReport(byte[] data)
+    {
+        Raw = data;
+        var wheelData = data[5];
+
+        if (wheelData == 0)
+            WheelPosition = null;
+        else
+            WheelPosition = wheelData - 1u;
+    }
+
+    public byte[] Raw { get; set; }
+    public uint? WheelPosition { get; set; }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos4/Intuos4AuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos4/Intuos4AuxReport.cs
@@ -1,8 +1,9 @@
 using OpenTabletDriver.Plugin.Tablet;
+using OpenTabletDriver.Plugin.Tablet.Wheel;
 
 namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos4
 {
-    public struct Intuos4AuxReport : IAuxReport
+    public struct Intuos4AuxReport : IAuxReport, IAbsoluteWheelReport
     {
         public Intuos4AuxReport(byte[] report)
         {
@@ -25,9 +26,14 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos4
                 buttonsByte.IsBitSet(6),
                 buttonsByte.IsBitSet(7),
             };
+
+            // Wheel Start at Position zero (0x80) and Provides a value between 0x80 & 0xC7 on PTK 440, 640 & 840
+            if (report[2].IsBitSet(7))
+                WheelPosition = (uint)report[2] - 0x80;
         }
 
         public byte[] Raw { set; get; }
         public bool[] AuxButtons { set; get; }
+        public uint? WheelPosition { set; get; }
     }
 }

--- a/OpenTabletDriver.Plugin/Tablet/TabletSpecifications.cs
+++ b/OpenTabletDriver.Plugin/Tablet/TabletSpecifications.cs
@@ -27,6 +27,11 @@ namespace OpenTabletDriver.Plugin.Tablet
         public ButtonSpecifications MouseButtons { set; get; }
 
         /// <summary>
+        /// Specifications for the wheel.
+        /// </summary>
+        public WheelSpecifications Wheel { get; set; }
+
+        /// <summary>
         /// Specifications for the touch digitizer.
         /// </summary>
         public DigitizerSpecifications Touch { set; get; }

--- a/OpenTabletDriver.Plugin/Tablet/Wheel/IAbsoluteWheel.cs
+++ b/OpenTabletDriver.Plugin/Tablet/Wheel/IAbsoluteWheel.cs
@@ -1,0 +1,13 @@
+namespace OpenTabletDriver.Plugin.Tablet.Wheel
+{
+    /// <summary>
+    /// An auxiliary report containing states of a wheel/ring input.
+    /// </summary>
+    public interface IAbsoluteWheelReport : IDeviceReport
+    {
+        /// <summary>
+        /// The position reading of the wheel, or null to indicate an absence of touch.
+        /// </summary>
+        uint? WheelPosition { get; set; }
+    }
+}

--- a/OpenTabletDriver.Plugin/Tablet/WheelSpecifications.cs
+++ b/OpenTabletDriver.Plugin/Tablet/WheelSpecifications.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel;
+
+namespace OpenTabletDriver.Plugin.Tablet
+{
+    /// <summary>
+    /// Device specifications for a wheel.
+    /// </summary>
+    public class WheelSpecifications
+    {
+        /// <summary>
+        /// The amount of steps making up a whole rotation.
+        /// </summary>
+        [DisplayName("Steps")]
+        public uint StepCount { set; get; }
+
+        /// <summary>
+        /// Does the wheel report relative position (movement) or absolute position
+        /// </summary>
+        [DisplayName("Relative")]
+        public bool IsRelative { get; set; }
+
+        /// <summary>
+        /// Does a increment/positive movement indicate clockwise movement?
+        /// </summary>
+        [DisplayName("Clockwise")]
+        public bool IsClockwise { get; set; }
+
+        /// <summary>
+        /// For absolute wheels, the angle on the unit circle, corresponding to a reading of zero from the sensor
+        /// </summary>
+        public float AngleOfZeroReading { get; set; }
+    }
+}

--- a/OpenTabletDriver.UX/Tools/ReportFormatter.cs
+++ b/OpenTabletDriver.UX/Tools/ReportFormatter.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using OpenTabletDriver.Plugin.Tablet;
 using OpenTabletDriver.Plugin.Tablet.Touch;
+using OpenTabletDriver.Plugin.Tablet.Wheel;
 
 namespace OpenTabletDriver.UX.Tools
 {
@@ -62,6 +63,8 @@ namespace OpenTabletDriver.UX.Tools
                 sb.AppendOneLine(GetStringFormat(tiltReport));
             if (report is ITouchReport touchReport)
                 sb.AppendOneLine(GetStringFormat(touchReport));
+            if(report is IAbsoluteWheelReport absoluteWheelReport)
+                sb.AppendLines(GetStringFormat(absoluteWheelReport));
             if (report is IMouseReport mouseReport)
                 sb.AppendOneLine(GetStringFormat(mouseReport));
             if (report is IToolReport toolReport)
@@ -115,6 +118,11 @@ namespace OpenTabletDriver.UX.Tools
             foreach (var touch in touchReport.Touches)
                 if (touch != null)
                     yield return touch.ToString();
+        }
+
+        private static IEnumerable<string> GetStringFormat(IAbsoluteWheelReport toolReport)
+        {
+            yield return $"Wheel:{toolReport.WheelPosition?.ToString() ?? "Idle"}";
         }
 
         private static IEnumerable<string> GetStringFormat(IMouseReport mouseReport)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ab03de7f-d669-4eaa-ab10-13186c3080d2)

I lied.

I got triggered seeing multiple basically dead PRs targeting master, which is not going to be ready anytime soon, so i took the opportunity to backport #2669.

This should then allow Parsing of the Wheel on PTK 440 to 840 as well as the Huion HS610.
Let me know if you want me to also include the specs for known supported tablets inside configs.
(These maxes can also be acquired via calibration, which i do in my 0.5.x Wheel Addon plugin)

One more question to be asked : PTK x40 tablets have a wheel button, and a concern was made [here](https://github.com/OpenTabletDriver/OpenTabletDriver/pull/2669/files#r1403035242)

Before my PR, the wheel button was already parser in the Intuos4Report, would this be the time to move it out to the `IAbsoluteWheelReport` or a new `IWheelSupport` (that would be used for relative & absolute)

