### PR TITLE
[0.6.x] Fix Nullable related warnings

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -492,9 +492,9 @@ namespace OpenTabletDriver.Daemon
             }
         }
 
-        public Task<Settings?> GetSettings()
+        public Task<Settings> GetSettings()
         {
-            return Task.FromResult(Settings);
+            return Task.FromResult(Settings!);
         }
 
         public Task<IEnumerable<SerializedDeviceEndpoint>> GetDevices()

--- a/OpenTabletDriver.Desktop/Diagnostics/OSInfo.cs
+++ b/OpenTabletDriver.Desktop/Diagnostics/OSInfo.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using OpenTabletDriver.Interop;
 using OpenTabletDriver.Plugin;
 
+#nullable enable
+
 namespace OpenTabletDriver.Desktop
 {
     public class OSInfo

--- a/OpenTabletDriver.Desktop/Profiles/ProfileCollection.cs
+++ b/OpenTabletDriver.Desktop/Profiles/ProfileCollection.cs
@@ -4,6 +4,8 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using OpenTabletDriver.Plugin.Tablet;
 
+#nullable enable
+
 namespace OpenTabletDriver.Desktop.Profiles
 {
     public class ProfileCollection : ObservableCollection<Profile>

--- a/OpenTabletDriver.Desktop/Updater/IUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/IUpdater.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace OpenTabletDriver.Desktop.Updater
 {
     public interface IUpdater

--- a/OpenTabletDriver.Desktop/Updater/UpdateInfo.cs
+++ b/OpenTabletDriver.Desktop/Updater/UpdateInfo.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace OpenTabletDriver.Desktop.Updater
 {
     public sealed class UpdateInfo


### PR DESCRIPTION
I'm tired of seeing those warnings in my plugins depending on OpenTabletDriver.Desktop.

I think adding Nullable enable to the specific files should be fine.
Also fix nullability of `GetSettings()` in `DriverDaemon` to match the contract.