### PR TITLE
Update UGEE M808 configuration

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/UGEE/M808 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/M808 V2.json
@@ -1,5 +1,5 @@
 {
-  "Name": "UGEE M808",
+  "Name": "UGEE M808 V2",
   "Specifications": {
     "Digitizer": {
       "Width": 254,
@@ -8,7 +8,7 @@
       "MaxY": 31750
     },
     "Pen": {
-      "MaxPressure": 8191,
+      "MaxPressure": 16383,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {
@@ -26,7 +26,7 @@
         "ArAE"
       ],
       "DeviceStrings": {
-        "5": "^(?!2023-09-21_release001).*$"
+        "5": "2023-09-21_release001"
       },
       "InitializationStrings": [],
       "Attributes": {}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -70,6 +70,7 @@
 | UGEE EX08                          |     Supported     | Uses the same configuration as the XP-Pen Deco 01 V2.
 | UGEE M708 V2                       |     Supported     |
 | UGEE M808                          |     Supported     |
+| UGEE M808 V2                       |     Supported     |
 | UGEE S640                          |     Supported     |
 | UGEE S1060                         |     Supported     |
 | UGEE U1200                         |     Supported     |


### PR DESCRIPTION
UGEE M808 supports 16384 pressure sensitivity level after firmware update.
see https://www.ugee.com/firmware-upgrade/16k


## verification

![maxpressure](https://github.com/user-attachments/assets/0a701e73-eb97-42a1-923d-c2d0741a7a6c)

[diagnostics.txt](https://github.com/user-attachments/files/17598294/diagnostics.txt)