### PR TITLE
Fix ET-0405-U parser

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/ET-0405-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/ET-0405-U.json
@@ -21,7 +21,7 @@
       "ProductID": 16,
       "InputReportLength": 8,
       "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Tablet.TabletReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
       "FeatureInitReport": [
         "AgI="
       ],


### PR DESCRIPTION
Tested by me. Fixes an issue where the out of range report is parsed as a normal report and sends a report with 55k pressure also sticking the mouse button down since this is the last report sent.