### PR TITLE
[0.6.x] Add XP-Pen Star G430S 200LPI variant

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G430S.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G430S.json
@@ -33,6 +33,20 @@
       },
       "InitializationStrings": [],
       "Attributes": {}
+    },
+    {
+      "VendorID": 10429,
+      "ProductID": 2323,
+      "InputReportLength": 14,
+      "OutputReportLength": 14,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": [
+        "ArAE"
+      ],
+      "DeviceStrings": {},
+      "InitializationStrings": [],
+      "Attributes": {}
     }
   ],
   "AuxilaryDeviceIdentifiers": [],


### PR DESCRIPTION
[Discord context](https://discord.com/channels/615607687467761684/645408221322018837/1304482929489084466)

Partially verified - was tested with user on G430S V2 config, but tablet debugger showed V1 dimensions