### PR TITLE
[06x] Linux: Default to Artist Mode globally

### DIFF
--- a/OpenTabletDriver.Desktop/Profiles/Profile.cs
+++ b/OpenTabletDriver.Desktop/Profiles/Profile.cs
@@ -1,6 +1,9 @@
+using System;
 using Newtonsoft.Json;
+using OpenTabletDriver.Desktop.Interop;
 using OpenTabletDriver.Desktop.Output;
 using OpenTabletDriver.Desktop.Reflection;
+using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Desktop.Profiles
@@ -56,12 +59,19 @@ namespace OpenTabletDriver.Desktop.Profiles
             get => bindings;
         }
 
+        private static Type DefaultOutputModeType =>
+            DesktopInterop.CurrentPlatform switch
+            {
+                PluginPlatform.Linux => typeof(LinuxArtistMode),
+                _ => typeof(AbsoluteMode)
+            };
+
         public static Profile GetDefaults(TabletReference tablet)
         {
             return new Profile
             {
                 Tablet = tablet.Properties.Name,
-                OutputMode = new PluginSettingStore(typeof(AbsoluteMode)),
+                OutputMode = new PluginSettingStore(DefaultOutputModeType),
                 AbsoluteModeSettings = AbsoluteModeSettings.GetDefaults(tablet.Properties.Specifications.Digitizer),
                 RelativeModeSettings = RelativeModeSettings.GetDefaults(),
                 BindingSettings = BindingSettings.GetDefaults(tablet.Properties.Specifications)


### PR DESCRIPTION
More and more applications are misbehaving when using absolute mode on Linux.

Artist mode has generally been working well, and likely has more intuitive behavior regarding general tablet handling.

While this fixes #3496, it should be noted that this PR additionally defaults to Artist Mode on X11.

Defects I noticed after implementing this, which will likely be solved in a follow-up PR:

- Default buttons do not make sense
  - Pen tip is bound to left mouse button
  - Pen barrel buttons should probably be bound (as pen button 1/2/3)
  - Aux buttons should be bound
    - Would be interesting to gauge what people expect these to be bound to by default