### PR TITLE
Linux: Default to Artist Mode

### DIFF
--- a/OpenTabletDriver.Desktop/Profiles/Profile.cs
+++ b/OpenTabletDriver.Desktop/Profiles/Profile.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using OpenTabletDriver.Desktop.Output;
 using OpenTabletDriver.Desktop.Reflection;
+using OpenTabletDriver.Interop;
 using OpenTabletDriver.Platform.Display;
 
 namespace OpenTabletDriver.Desktop.Profiles
@@ -42,6 +43,13 @@ namespace OpenTabletDriver.Desktop.Profiles
             get => _bindings;
         }
 
+        private static Type DefaultOutputModeType =>
+            SystemInterop.CurrentPlatform switch
+            {
+                SystemPlatform.Linux => typeof(LinuxArtistMode),
+                _ => typeof(AbsoluteMode)
+            };
+
         public static Profile GetDefaults(IServiceProvider serviceProvider, InputDevice tablet)
         {
             var screen = serviceProvider.GetRequiredService<IVirtualScreen>();
@@ -50,7 +58,7 @@ namespace OpenTabletDriver.Desktop.Profiles
             return new Profile
             {
                 Tablet = tablet.Configuration.Name,
-                OutputMode = serviceProvider.GetDefaultSettings(typeof(AbsoluteMode), digitizer!, screen),
+                OutputMode = serviceProvider.GetDefaultSettings(DefaultOutputModeType, digitizer!, screen),
                 BindingSettings = BindingSettings.GetDefaults(tablet.Configuration.Specifications)
             };
         }


### PR DESCRIPTION
(port of #3525)

More and more applications are misbehaving when using absolute mode on Linux.

Artist mode has generally been working well, and likely has more intuitive behavior regarding general tablet handling.

Some defects have been noted - notably, default buttons do not make sense.

Port to `master` from `0.6.x` branch

While this fixes https://github.com/OpenTabletDriver/OpenTabletDriver/issues/3496, it should be noted that this PR additionally defaults to Artist Mode on X11.

/e: as is convention with `master`, the changes are untested