### PR TITLE
Update softprops/action-gh-release to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         run: ./eng/macos/package.sh --package true --output ./dist/macos
 
       - name: Upload all artifacts (Release)
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           name: OpenTabletDriver v${{ github.ref_name }}
@@ -87,7 +87,7 @@ jobs:
         run: ./eng/linux/package.sh --package RedHat --output ./dist/redhat
 
       - name: Upload all artifacts (Release)
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           name: OpenTabletDriver v${{ github.ref_name }}
@@ -121,7 +121,7 @@ jobs:
         run: ./eng/windows/package.ps1
 
       - name: Upload Windows asset (Release)
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           name: OpenTabletDriver v${{ github.ref_name }}


### PR DESCRIPTION
Apparently softprops/action-gh-release v1 has been deprecated for over a year and might not even work on current github actions runners due to enforcing node 20.