### PR TITLE
Add support for XP-Pen Star G640 variant

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640.json
@@ -26,6 +26,16 @@
         100,
         110
       ]
+    },
+    {
+      "VendorID": 10429,
+      "ProductID": 2324,
+      "InputReportLength": 14,
+      "OutputReportLength": 14,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
+      "OutputInitReport": [
+        "ArAE"
+      ]
     }
   ],
   "Attributes": {


### PR DESCRIPTION
Verification: https://canary.discord.com/channels/615607687467761684/615611007951306863/1310314074621612155
A Diagnostic: https://canary.discord.com/channels/615607687467761684/615611007951306863/1307482987943690411

It has the G640 V2 PID but has V1 specs, not sure if it has the V2 smoothing or anything, I'm interested it knowing if XP-Pen is just shipping these with new firmware updates or what.

