### PR TITLE
[0.6.x] Update flake.lock, shell.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720957393,
-        "narHash": "sha256-oedh2RwpjEa+TNxhg5Je9Ch6d3W1NKi7DbRO1ziHemA=",
+        "lastModified": 1732014248,
+        "narHash": "sha256-y/MEyuJ5oBWrWAic/14LaIr/u5E0wRVzyYsouYY3W6w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "693bc46d169f5af9c992095736e82c3488bf7dbb",
+        "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
         "type": "github"
       },
       "original": {

--- a/shell.nix
+++ b/shell.nix
@@ -17,7 +17,6 @@ in pkgs.mkShell {
     # dev
     gnused
     gnugrep
-    nixFlakes
     jq
   ];
 


### PR DESCRIPTION
This has been neglected for a while, nixpkgs has had a release since the last update