### PR TITLE
[0.6.x] fix: double click in relative mode

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/MacOSAbsolutePointer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/MacOSAbsolutePointer.cs
@@ -40,6 +40,14 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
             }
         }
 
+        protected override void QueuePendingPositionFromSystem()
+        {
+            var eventRef = CGEventCreate(IntPtr.Zero);
+            var pos = CGEventGetLocation(eventRef);
+            CFRelease(eventRef);
+            QueuePendingPosition((float)pos.x, (float)pos.y);
+        }
+
         protected override void ResetPendingPosition(IntPtr mouseEvent)
         {
             _lastPos = null;

--- a/OpenTabletDriver.Desktop/Interop/Input/Relative/MacOSRelativePointer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Relative/MacOSRelativePointer.cs
@@ -37,6 +37,11 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Relative
             CGEventSetDoubleValueField(mouseEvent, CGEventField.mouseEventDeltaY, 0);
         }
 
+        protected override void QueuePendingPositionFromSystem()
+        {
+            QueuePendingPosition(0, 0);
+        }
+
         private CGPoint GetCursorPosition()
         {
             var eventRef = CGEventCreate(IntPtr.Zero);


### PR DESCRIPTION
QueuePendingPosition expects relative coordinates in relative mode, but was incorrectly pulling absolute system coordinates. Now using proper (0,0) deltas for clicks.