### PR TITLE
Disable libinput smoothing for OpenTabletDriver virtual tablet

### DIFF
--- a/eng/linux/Debian/debian/opentabletdriver.install
+++ b/eng/linux/Debian/debian/opentabletdriver.install
@@ -11,3 +11,4 @@ usr/share/man/man8/opentabletdriver.8.gz
 usr/share/doc/opentabletdriver/LICENSE
 usr/share/pixmaps/otd.ico
 usr/share/pixmaps/otd.png
+usr/share/libinput/30-vendor-opentabletdriver.quirks

--- a/eng/linux/Generic/usr/share/libinput/30-vendor-opentabletdriver.quirks
+++ b/eng/linux/Generic/usr/share/libinput/30-vendor-opentabletdriver.quirks
@@ -1,0 +1,3 @@
+[OpenTabletDriver Virtual Tablets]
+MatchName=OpenTabletDriver*
+AttrTabletSmoothing=0

--- a/eng/linux/RedHat/package.sh
+++ b/eng/linux/RedHat/package.sh
@@ -87,6 +87,7 @@ cp -r bin "%{buildroot}/%{_prefix}/lib/opentabletdriver"
 %{_prefix}/share/doc/opentabletdriver/LICENSE
 %{_prefix}/share/pixmaps/otd.ico
 %{_prefix}/share/pixmaps/otd.png
+%{_prefix}/share/libinput/30-vendor-opentabletdriver.quirks
 
 %changelog
 EOF


### PR DESCRIPTION
Forward port of #3566

Fixes #2895

Linux packagers: notice that this requires you to add a file