### PR TITLE
[0.6.x] Reduce bloat of tablet configuration JSONs

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/10moon/1060N.json
+++ b/OpenTabletDriver.Configurations/Configurations/10moon/1060N.json
@@ -15,22 +15,14 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 12
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 2290,
       "ProductID": 26641,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.TenMoon.TenMoonReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.TenMoon.TenMoonReportParser"
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -45,11 +37,7 @@
         "CAMA//AA//A=",
         "CAMA//AA//A=",
         "CAYBAAAAAAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
   "Attributes": {

--- a/OpenTabletDriver.Configurations/Configurations/Acepen/AP1060.json
+++ b/OpenTabletDriver.Configurations/Configurations/Acepen/AP1060.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,17 +24,11 @@
       "InputReportLength": 11,
       "OutputReportLength": 9,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Acepen.AcepenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "CQrhSgAAbD0A",
         "CQEE",
         "CQIC"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Acepen/AP906.json
+++ b/OpenTabletDriver.Configurations/Configurations/Acepen/AP906.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,17 +24,11 @@
       "InputReportLength": 11,
       "OutputReportLength": 9,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Acepen.AcepenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "CQrhSgAAbD0A",
         "CQEE",
         "CQIC"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Adesso/Cybertablet K8.json
+++ b/OpenTabletDriver.Configurations/Configurations/Adesso/Cybertablet K8.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 10,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Artisul/A1201.json
+++ b/OpenTabletDriver.Configurations/Configurations/Artisul/A1201.json
@@ -15,45 +15,34 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "OEM16_T206_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 100,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "OEM16_T206_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Artisul/AP604.json
+++ b/OpenTabletDriver.Configurations/Configurations/Artisul/AP604.json
@@ -12,26 +12,16 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 21827,
       "ProductID": 84,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser"
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Artisul/D16 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Artisul/D16 Pro.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
-        "201":"OEM16_M193_\\d{6}$"
+        "201": "OEM16_M193_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Artisul/M0610 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Artisul/M0610 Pro.json
@@ -15,45 +15,34 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 21827,
       "ProductID": 129,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "F610_M61P-T\\d{4}$"
       },
       "InitializationStrings": [
         100
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 111,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "OEM16_T205_\\d{6}$"
       },
       "InitializationStrings": [
         100
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/FlooGoo/FMA100.json
+++ b/OpenTabletDriver.Configurations/Configurations/FlooGoo/FMA100.json
@@ -12,26 +12,16 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 2578,
       "ProductID": 16391,
       "InputReportLength": 12,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.FlooGoo.FmaReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.FlooGoo.FmaReportParser"
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/1060 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/1060 Pro.json
@@ -15,77 +15,58 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 12
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "OEM02_T174_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 100,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "OEM02_T174_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "OEM02_T174_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 100,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "GM001_(T213|T216)_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/GM116HD.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/GM116HD.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "(OEM02_M171|GM001_M21t)_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/GM156HD.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/GM156HD.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 10
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "OEM02_M166_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M106K Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M106K Pro.json
@@ -15,45 +15,34 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 12
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "OEM02_T19m_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 111,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "OEM02_T19m_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M106K.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M106K.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 12
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "OEM02_T151_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M10K Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M10K Pro.json
@@ -15,45 +15,34 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 10
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "OEM02_T19n_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 111,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "OEM02_T19n_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M10K.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M10K.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 11
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "OEM02_T17b_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M1220.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M1220.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "GM001_T201_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M1230.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M1230.json
@@ -15,45 +15,34 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 12
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "GM001_T202_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 111,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "GM001_T202_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M6.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M6.json
@@ -15,45 +15,34 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 13
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 100,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicV2ReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "(OEM02_T183|GM001_T223)_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicV2ReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "OEM02_T183_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M8.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M8.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 9
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 100,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicV2ReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "GM001_T208_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/PD1161.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/PD1161.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "OEM02_M191_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/PD156 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/PD156 Pro.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 10
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "OEM02_M19h_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/PD1560.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/PD1560.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 10
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "OEM02_M177_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/PD1561.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/PD1561.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 10
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "OEM02_M196_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/PD2200.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/PD2200.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "OEM02_M198_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/S56K.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/S56K.json
@@ -12,62 +12,46 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T156_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T156_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 16,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T156_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/S620.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/S620.json
@@ -15,45 +15,34 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "OEM02_T18e_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 111,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "OEM02_T18e_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/S630.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/S630.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "GM001_T203_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/S830.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/S830.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "2": "Gaomon Tablet_ S830"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Genius/G-Pen 560.json
+++ b/OpenTabletDriver.Configurations/Configurations/Genius/G-Pen 560.json
@@ -15,29 +15,21 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 12
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1112,
       "ProductID": 20483,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Genius.GeniusReportParserV2",
       "FeatureInitReport": [
         "AgQA",
         "AgIA",
         "AhAB"
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Genius/i405x.json
+++ b/OpenTabletDriver.Configurations/Configurations/Genius/i405x.json
@@ -13,28 +13,19 @@
         "ButtonCount": 2
       }
     },
-    "AuxiliaryButtons": null,
     "MouseButtons": {
       "ButtonCount": 3
-    },
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1112,
       "ProductID": 20496,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Genius.GeniusReportParser",
       "FeatureInitReport": [
         "BRIQERIAAAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Genius/i608x.json
+++ b/OpenTabletDriver.Configurations/Configurations/Genius/i608x.json
@@ -13,28 +13,19 @@
         "ButtonCount": 2
       }
     },
-    "AuxiliaryButtons": null,
     "MouseButtons": {
       "ButtonCount": 3
-    },
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1112,
       "ProductID": 20506,
       "InputReportLength": 16,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Genius.GeniusReportParser",
       "FeatureInitReport": [
         "BRIQERIAAAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/1060 Plus.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/1060 Plus.json
@@ -15,19 +15,14 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 12
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 16,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "6": "1060PRO",
         "121": "HA60-F400"
@@ -35,11 +30,9 @@
       "InitializationStrings": [
         100,
         123
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/420.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/420.json
@@ -12,37 +12,27 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "6": "^420"
       },
       "InitializationStrings": [
         100,
         123
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "6": "^$",
         "121": "^H850_F210$"
@@ -50,11 +40,9 @@
       "InitializationStrings": [
         100,
         123
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1",
     "Interface": "0"

--- a/OpenTabletDriver.Configurations/Configurations/Huion/G10T.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/G10T.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T161_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/G930L.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/G930L.json
@@ -15,28 +15,20 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 97,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T209_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/GC610.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/GC610.json
@@ -15,45 +15,34 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T166_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T166_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/GT-156HD V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/GT-156HD V2.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 14
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M174_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/GT-220 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/GT-220 V2.json
@@ -12,30 +12,22 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M165_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/GT-221 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/GT-221 Pro.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 10
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M167_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/GT-221.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/GT-221.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 10
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M175_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H1060P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H1060P.json
@@ -15,61 +15,46 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 12
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T(167|205)_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T167_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 100,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T(205|219)_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H1161.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H1161.json
@@ -15,45 +15,34 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 10
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T191_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 100,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T191_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H320M.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H320M.json
@@ -15,45 +15,34 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 11
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T198_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 111,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T198_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H420.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H420.json
@@ -15,30 +15,23 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 3
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "6": "H420"
       },
       "InitializationStrings": [
         100,
         123
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1",
     "Interface": "0"

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H420X.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H420X.json
@@ -12,46 +12,34 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T210_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 100,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_(T210|T223)_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H430P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H430P.json
@@ -15,77 +15,58 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T(176|18a|21c)_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T(176|18a|21c)_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 111,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T(176|18a|21c)_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 100,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T(176|18a|21c)_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H580X.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H580X.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 100,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T(211|224)_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H610 Pro V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H610 Pro V2.json
@@ -15,61 +15,46 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T184_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T184_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 100,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T184_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H610 Pro V3.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H610 Pro V3.json
@@ -12,28 +12,19 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 16,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "121": "^HA60$"
-      },
-      "InitializationStrings": [],
-      "Attributes": {}
+      }
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H610 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H610 Pro.json
@@ -15,45 +15,34 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T175_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T175_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H610X.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H610X.json
@@ -15,45 +15,34 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 100,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_(T212|T229)_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T212_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H640P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H640P.json
@@ -15,77 +15,58 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T173_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T173_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T203_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 100,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T203_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H641P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H641P.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 102,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T21j_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H642.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H642.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T19g_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H690.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H690.json
@@ -15,47 +15,36 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 3
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "6": "HuionH690"
       },
       "InitializationStrings": [
         100,
         123
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 16,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "6": "HuionH690"
       },
       "InitializationStrings": [
         100,
         123
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H950P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H950P.json
@@ -15,77 +15,58 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 100,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T22d_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T(172|204)_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T(172|204)_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 111,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T204_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H951P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H951P.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 11
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 103,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.InspiroyReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T21k_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/HC16.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/HC16.json
@@ -15,45 +15,34 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 12
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T18C_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 100,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T18C_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/HS610.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/HS610.json
@@ -15,45 +15,34 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 12
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T194_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 100,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T194_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/HS611.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/HS611.json
@@ -15,46 +15,34 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 10
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T19c_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 111,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T19c_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
-
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/HS64.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/HS64.json
@@ -15,61 +15,46 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T(181|193)_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T181_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 111,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T225_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/HS95.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/HS95.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T206_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 12.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 12.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M19p_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 13.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 13.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 10
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_(?:M20h|M19f|M215)_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 16 (2021).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 16 (2021).json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 10
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M19s_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 16.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 16.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 10
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M18e_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 20.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 20.json
@@ -12,30 +12,22 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_(M192|M189)_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 22 Plus.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 22 Plus.json
@@ -12,30 +12,22 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M19t_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 22.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 22.json
@@ -12,30 +12,22 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M19g_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 24 Plus.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 24 Plus.json
@@ -12,30 +12,22 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M205_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 12.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 12.json
@@ -15,45 +15,34 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M171_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M(20j|171)_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 13 (2.5k).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 13 (2.5k).json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 7
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M(210|213)_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 13.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 13.json
@@ -15,45 +15,34 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M182_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M182_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16 (2.5k).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16 (2.5k).json
@@ -15,44 +15,32 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M214_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M20q_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16 (4k).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16 (4k).json
@@ -12,29 +12,20 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M202_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16 Plus (4k).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16 Plus (4k).json
@@ -12,29 +12,20 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M20a_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 16.json
@@ -15,45 +15,34 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M183_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M20m_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 19 (4K).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 19 (4K).json
@@ -12,29 +12,20 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 107,
       "InputReportLength": 14,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M220_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 20.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 20.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 16
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M193_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 22 (2019).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 22 (2019).json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 20
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M194_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 24 (4K).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 24 (4K).json
@@ -12,30 +12,22 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M207_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 24.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 24.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 20
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M184_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/New 1060 Plus (2048).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/New 1060 Plus (2048).json
@@ -15,45 +15,34 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 12
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 16,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T151_\\d{6}$"
       },
       "InitializationStrings": [
         100
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T151_\\d{6}$"
       },
       "InitializationStrings": [
         100
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/New 1060 Plus.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/New 1060 Plus.json
@@ -15,45 +15,34 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 12
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T174_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T174_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Q11K V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Q11K V2.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T185_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Q11K.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Q11K.json
@@ -15,45 +15,34 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T164_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T164_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Q620M.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Q620M.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T18d_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Q630M.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Q630M.json
@@ -9,35 +9,28 @@
     },
     "Pen": {
       "MaxPressure": 8191,
-      "Buttons": {      
+      "Buttons": {
         "ButtonCount": 2
       }
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 96,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T216_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/RDS-160.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/RDS-160.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 10
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_M211_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/RTE-100.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/RTE-100.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 100,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T217_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/RTM 500.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/RTM 500.json
@@ -15,45 +15,34 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T19h_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 100,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T19h_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/RTP-700.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/RTP-700.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T19k_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/WH1409 V2 (Variant 2).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/WH1409 V2 (Variant 2).json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 12
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 64,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T153_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/WH1409 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/WH1409 V2.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 12
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T188_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/WH1409.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/WH1409.json
@@ -15,29 +15,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 12
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "HUION_T153_\\d{6}$"
       },
       "InitializationStrings": [
         200
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/KENTING/K5540.json
+++ b/OpenTabletDriver.Configurations/Configurations/KENTING/K5540.json
@@ -12,28 +12,19 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 21827,
       "ProductID": 4,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
       "InitializationStrings": [
         100
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Lifetec/LT9570.json
+++ b/OpenTabletDriver.Configurations/Configurations/Lifetec/LT9570.json
@@ -12,17 +12,13 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 2250,
       "ProductID": 16,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Lifetec.LifetecReportParser",
       "FeatureInitReport": [
         "AhgE",
@@ -34,14 +30,9 @@
         "AggA",
         "AhAB",
         "AhEC"
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Monoprice/10594.json
+++ b/OpenTabletDriver.Configurations/Configurations/Monoprice/10594.json
@@ -15,19 +15,14 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 16,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "6": "10594",
         "121": "HA60-F400"
@@ -35,11 +30,9 @@
       "InitializationStrings": [
         100,
         123
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Monoprice/MP1060-HA60.json
+++ b/OpenTabletDriver.Configurations/Configurations/Monoprice/MP1060-HA60.json
@@ -8,34 +8,26 @@
       "MaxY": 24999.0
     },
     "Pen": {
-        "MaxPressure": 1023,
-        "Buttons": {
+      "MaxPressure": 1023,
+      "Buttons": {
         "ButtonCount": 2
       }
-      },
+    },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 21827,
       "ProductID": 1921,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
       "InitializationStrings": [
         100
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/A609.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/A609.json
@@ -15,27 +15,19 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 2903,
       "ProductID": 37009,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/A610 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/A610 Pro.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 10,
       "OutputReportLength": 10,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/A610.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/A610.json
@@ -15,30 +15,23 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 21827,
       "ProductID": 129,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenOffsetAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "F401-HK708-STD"
       },
       "InitializationStrings": [
         100,
         123
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/A640 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/A640 V2.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 10,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAEAAAAAAA="
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/A640.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/A640.json
@@ -12,10 +12,7 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -24,16 +21,11 @@
       "InputReportLength": 10,
       "OutputReportLength": 0,
       "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
       "InitializationStrings": [
         100
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Intangbo M.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Intangbo M.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,13 +24,9 @@
       "InputReportLength": 10,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1155,
@@ -40,16 +34,11 @@
       "InputReportLength": 1101,
       "OutputReportLength": 1101,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Intangbo S.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Intangbo S.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,13 +24,9 @@
       "InputReportLength": 10,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1155,
@@ -40,16 +34,11 @@
       "InputReportLength": 1101,
       "OutputReportLength": 1101,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos M.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos M.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,13 +24,9 @@
       "InputReportLength": 10,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1155,
@@ -40,16 +34,11 @@
       "InputReportLength": 1101,
       "OutputReportLength": 1101,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N4.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N4.json
@@ -12,10 +12,7 @@
       "Buttons": {
         "ButtonCount": 0
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -24,16 +21,11 @@
       "InputReportLength": 10,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N7.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N7.json
@@ -12,10 +12,7 @@
       "Buttons": {
         "ButtonCount": 0
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -24,13 +21,9 @@
       "InputReportLength": 10,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1155,
@@ -38,16 +31,11 @@
       "InputReportLength": 1101,
       "OutputReportLength": 1101,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N7B.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N7B.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 10,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos S.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos S.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 5
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,13 +24,9 @@
       "InputReportLength": 10,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1155,
@@ -40,16 +34,11 @@
       "InputReportLength": 1101,
       "OutputReportLength": 1101,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/RobotPen/T9A.json
+++ b/OpenTabletDriver.Configurations/Configurations/RobotPen/T9A.json
@@ -12,10 +12,7 @@
       "Buttons": {
         "ButtonCount": 1
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -24,16 +21,11 @@
       "InputReportLength": 64,
       "OutputReportLength": 64,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.RobotPen.RobotPenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "qhAC"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Trust/Flex Design Tablet.json
+++ b/OpenTabletDriver.Configurations/Configurations/Trust/Flex Design Tablet.json
@@ -12,30 +12,21 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 5935,
       "ProductID": 55,
       "InputReportLength": 64,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Genius.GeniusReportParserV2",
       "FeatureInitReport": [
         "AgQA",
         "AgIA",
         "AhAB"
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Turcom/TS-6580.json
+++ b/OpenTabletDriver.Configurations/Configurations/Turcom/TS-6580.json
@@ -12,48 +12,36 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "6": "Huion",
         "121": "M508"
       },
       "InitializationStrings": [
         100
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 16,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "6": "Huion",
         "121": "M508"
       },
       "InitializationStrings": [
         100
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/UC-Logic/1060N.json
+++ b/OpenTabletDriver.Configurations/Configurations/UC-Logic/1060N.json
@@ -15,18 +15,14 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 21827,
       "ProductID": 129,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAC"
       ],
@@ -35,11 +31,9 @@
       },
       "InitializationStrings": [
         100
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1",
     "Interface": "0"

--- a/OpenTabletDriver.Configurations/Configurations/UC-Logic/PF1209.json
+++ b/OpenTabletDriver.Configurations/Configurations/UC-Logic/PF1209.json
@@ -12,30 +12,22 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 21827,
       "ProductID": 66,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "2": "TabletPF1209\u0014"
       },
       "InitializationStrings": [
         109
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/M708 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/M708 V2.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 10,
       "OutputReportLength": 10,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/M708.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/M708.json
@@ -15,19 +15,14 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 21827,
       "ProductID": 129,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenOffsetAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "4": "F401-20111028",
         "5": "UC-LOIC",
@@ -36,11 +31,9 @@
       "InitializationStrings": [
         100,
         123
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/M808.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/M808.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 12,
       "OutputReportLength": 20,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/M908.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/M908.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 12,
       "OutputReportLength": 20,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/S1060.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/S1060.json
@@ -15,27 +15,19 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 12
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 10429,
       "ProductID": 2360,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/S640.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/S640.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 10
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,13 +24,9 @@
       "InputReportLength": 12,
       "OutputReportLength": 21,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 10429,
@@ -40,16 +34,11 @@
       "InputReportLength": 12,
       "OutputReportLength": 12,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/U1200.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/U1200.json
@@ -12,10 +12,7 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -24,16 +21,11 @@
       "InputReportLength": 12,
       "OutputReportLength": 12,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/U1600.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/U1600.json
@@ -12,10 +12,7 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -24,16 +21,11 @@
       "InputReportLength": 12,
       "OutputReportLength": 12,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A15 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A15 Pro.json
@@ -15,24 +15,17 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 12
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 12267,
       "ProductID": 6,
       "InputReportLength": 9,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.SkipByteTabletReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 12267,
@@ -40,16 +33,11 @@
       "InputReportLength": 13,
       "OutputReportLength": 9,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkTiltReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A15 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A15 V2.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 12
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,18 +24,13 @@
       "InputReportLength": 13,
       "OutputReportLength": 9,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE",
         "CQIC",
         "CQMC"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A15.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A15.json
@@ -15,29 +15,21 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 12
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 12267,
       "ProductID": 4,
       "InputReportLength": 9,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkA15ReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
-            "CQEE",
-            "CQIC",
-            "CQMC"
-        ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+        "CQEE",
+        "CQIC",
+        "CQMC"
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A30 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A30 V2.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,18 +24,13 @@
       "InputReportLength": 13,
       "OutputReportLength": 9,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE",
         "CQIC",
         "CQMC"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A30.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A30.json
@@ -15,27 +15,19 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 12267,
       "ProductID": 2,
       "InputReportLength": 9,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.SkipByteTabletReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A50 (Variant 2).json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A50 (Variant 2).json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 13,
       "OutputReportLength": 9,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/A50.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/A50.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 12
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,13 +24,9 @@
       "InputReportLength": 9,
       "OutputReportLength": 9,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkV1ReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 12267,
@@ -40,16 +34,11 @@
       "InputReportLength": 8,
       "OutputReportLength": 0,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkV1ReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/S640 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/S640 V2.json
@@ -12,10 +12,7 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -24,16 +21,11 @@
       "InputReportLength": 13,
       "OutputReportLength": 9,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/S640.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/S640.json
@@ -12,10 +12,7 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -24,16 +21,11 @@
       "InputReportLength": 9,
       "OutputReportLength": 9,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkV1ReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/VK1060.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/VK1060.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,18 +24,13 @@
       "InputReportLength": 13,
       "OutputReportLength": 9,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkTiltReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE",
         "CQIC",
         "CQMC"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/VK1060PRO.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/VK1060PRO.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,18 +24,13 @@
       "InputReportLength": 13,
       "OutputReportLength": 9,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE",
         "CQIC",
         "CQMC"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/VK430 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/VK430 V2.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,7 +24,6 @@
       "InputReportLength": 13,
       "OutputReportLength": 9,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE",
         "CQIC",
@@ -34,12 +31,9 @@
       ],
       "DeviceStrings": {
         "23": "^2022/12/9$"
-      },
-      "InitializationStrings": [],
-      "Attributes": {}
+      }
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/VK430.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/VK430.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,7 +24,6 @@
       "InputReportLength": 13,
       "OutputReportLength": 9,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE",
         "CQIC",
@@ -34,9 +31,7 @@
       ],
       "DeviceStrings": {
         "23": "^2022/3/21$"
-      },
-      "InitializationStrings": [],
-      "Attributes": {}
+      }
     },
     {
       "VendorID": 12267,
@@ -44,7 +39,6 @@
       "InputReportLength": 13,
       "OutputReportLength": 9,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE",
         "CQIC",
@@ -52,12 +46,9 @@
       ],
       "DeviceStrings": {
         "23": "^2022/4/25$"
-      },
-      "InitializationStrings": [],
-      "Attributes": {}
+      }
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/VK640.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/VK640.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,18 +24,13 @@
       "InputReportLength": 13,
       "OutputReportLength": 9,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkTiltReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE",
         "CQIC",
         "CQMC"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/VO1060.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/VO1060.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 5
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,17 +24,12 @@
       "InputReportLength": 13,
       "OutputReportLength": 9,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "CQEE",
         "CQIC"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/ViewSonic/Woodpad PF0730.json
+++ b/OpenTabletDriver.Configurations/Configurations/ViewSonic/Woodpad PF0730.json
@@ -12,27 +12,17 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1347,
       "ProductID": 58983,
       "InputReportLength": 14,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.ViewSonic.WoodPadReportParser",
       "FeatureInitReport": [
         "AhABAAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/ViewSonic/Woodpad PF1030.json
+++ b/OpenTabletDriver.Configurations/Configurations/ViewSonic/Woodpad PF1030.json
@@ -12,27 +12,17 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1347,
       "ProductID": 58984,
       "InputReportLength": 14,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.ViewSonic.WoodPadReportParser",
       "FeatureInitReport": [
         "AhABAAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTC-4110WL.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTC-4110WL.json
@@ -12,27 +12,17 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1329,
       "ProductID": 256,
       "InputReportLength": 192,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV3.IntuosV3ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTC-6110WL.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTC-6110WL.json
@@ -12,27 +12,17 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1329,
       "ProductID": 258,
       "InputReportLength": 192,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV3.IntuosV3ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-430.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-430.json
@@ -13,42 +13,28 @@
         "ButtonCount": 2
       }
     },
-    "AuxiliaryButtons": null,
     "MouseButtons": {
       "ButtonCount": 3
-    },
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 19,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 19,
       "InputReportLength": 9,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.WacomDriverIntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-440.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-440.json
@@ -18,47 +18,29 @@
     },
     "MouseButtons": {
       "ButtonCount": 3
-    },
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 21,
       "InputReportLength": 9,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser"
     },
     {
       "VendorID": 1386,
       "ProductID": 21,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 21,
       "InputReportLength": 10,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.WacomDriverIntuosReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.WacomDriverIntuosReportParser"
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -66,14 +48,7 @@
       "VendorID": 1386,
       "ProductID": 21,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Plugin.Tablet.AuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Plugin.Tablet.AuxReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-450.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-450.json
@@ -18,25 +18,17 @@
     },
     "MouseButtons": {
       "ButtonCount": 3
-    },
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 23,
       "InputReportLength": 9,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-460.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-460.json
@@ -12,41 +12,26 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 106,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 106,
       "InputReportLength": 9,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.WacomDriverIntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-630.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-630.json
@@ -13,42 +13,28 @@
         "ButtonCount": 2
       }
     },
-    "AuxiliaryButtons": null,
     "MouseButtons": {
       "ButtonCount": 3
-    },
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 20,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 20,
       "InputReportLength": 9,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.WacomDriverIntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-640.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-640.json
@@ -18,39 +18,26 @@
     },
     "MouseButtons": {
       "ButtonCount": 3
-    },
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 22,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 22,
       "InputReportLength": 9,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.WacomDriverIntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-650.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-650.json
@@ -18,25 +18,17 @@
     },
     "MouseButtons": {
       "ButtonCount": 3
-    },
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 24,
       "InputReportLength": 9,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-660.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-660.json
@@ -12,27 +12,17 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 107,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTF-430.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTF-430.json
@@ -12,10 +12,7 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,13 +23,7 @@
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-300.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-300.json
@@ -15,26 +15,17 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 2
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 793,
       "InputReportLength": 32,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.BambooPad.BambooPadReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-301.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-301.json
@@ -15,26 +15,17 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 2
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 792,
       "InputReportLength": 64,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.BambooPad.BambooPadReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-460.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-460.json
@@ -15,52 +15,35 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 214,
       "InputReportLength": 9,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 214,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.WacomDriverIntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 209,
       "InputReportLength": 20,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -68,26 +51,13 @@
       "VendorID": 1386,
       "ProductID": 214,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser"
     },
     {
       "VendorID": 1386,
       "ProductID": 209,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-461.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-461.json
@@ -15,68 +15,44 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 210,
       "InputReportLength": 9,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 210,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.WacomDriverIntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 215,
       "InputReportLength": 9,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 218,
       "InputReportLength": 9,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-470.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-470.json
@@ -15,38 +15,26 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 222,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 222,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.WacomDriverIntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -54,14 +42,7 @@
       "VendorID": 1386,
       "ProductID": 222,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-480.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-480.json
@@ -16,7 +16,6 @@
     "AuxiliaryButtons": {
       "ButtonCount": 4
     },
-    "MouseButtons": null,
     "Touch": {
       "Width": 152.0,
       "Height": 95.0,
@@ -29,29 +28,19 @@
       "VendorID": 1386,
       "ProductID": 770,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 770,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.WacomDriverIntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -59,14 +48,7 @@
       "VendorID": 1386,
       "ProductID": 770,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-490.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-490.json
@@ -15,38 +15,26 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 828,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 828,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -54,14 +42,7 @@
       "VendorID": 1386,
       "ProductID": 828,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-661.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-661.json
@@ -15,68 +15,44 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 211,
       "InputReportLength": 9,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 211,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.WacomDriverIntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 219,
       "InputReportLength": 9,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 216,
       "InputReportLength": 9,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-670.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-670.json
@@ -15,38 +15,26 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 223,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 223,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.WacomDriverIntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -54,14 +42,7 @@
       "VendorID": 1386,
       "ProductID": 223,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-680.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-680.json
@@ -15,38 +15,26 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 771,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 771,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.WacomDriverIntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -54,14 +42,7 @@
       "VendorID": 1386,
       "ProductID": 771,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-690.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-690.json
@@ -15,38 +15,26 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 830,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 830,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -54,14 +42,7 @@
       "VendorID": 1386,
       "ProductID": 830,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-4100.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-4100.json
@@ -15,36 +15,20 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 884,
       "InputReportLength": 192,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser"
     },
     {
       "VendorID": 1386,
       "ProductID": 884,
       "InputReportLength": 193,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.WacomDriverIntuosV2ReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.WacomDriverIntuosV2ReportParser"
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-4100WL.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-4100WL.json
@@ -15,106 +15,65 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 886,
       "InputReportLength": 64,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 886,
       "InputReportLength": 192,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 886,
       "InputReportLength": 193,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 887,
       "InputReportLength": 361,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser"
     },
     {
       "VendorID": 1386,
       "ProductID": 887,
       "InputReportLength": 193,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.WacomDriverIntuosV2ReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.WacomDriverIntuosV2ReportParser"
     },
     {
       "VendorID": 1386,
       "ProductID": 965,
       "InputReportLength": 192,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 965,
       "InputReportLength": 193,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-460.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-460.json
@@ -12,39 +12,26 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 212,
       "InputReportLength": 9,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 212,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.WacomDriverIntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -52,14 +39,7 @@
       "VendorID": 1386,
       "ProductID": 212,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Plugin.Tablet.AuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Plugin.Tablet.AuxReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-470.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-470.json
@@ -12,39 +12,26 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 221,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 221,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.WacomDriverIntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -52,14 +39,7 @@
       "VendorID": 1386,
       "ProductID": 221,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-471.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-471.json
@@ -12,39 +12,26 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 768,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 768,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.WacomDriverIntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -52,14 +39,7 @@
       "VendorID": 1386,
       "ProductID": 768,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Plugin.Tablet.AuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Plugin.Tablet.AuxReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-472.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-472.json
@@ -12,41 +12,26 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 890,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 890,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.WacomDriverIntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-480.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-480.json
@@ -15,38 +15,26 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 782,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 782,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.WacomDriverIntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -54,14 +42,7 @@
       "VendorID": 1386,
       "ProductID": 782,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-490.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-490.json
@@ -15,38 +15,26 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 827,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 827,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -54,14 +42,7 @@
       "VendorID": 1386,
       "ProductID": 827,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-6100.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-6100.json
@@ -15,26 +15,17 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 885,
       "InputReportLength": 192,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-6100WL.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-6100WL.json
@@ -15,40 +15,26 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 888,
       "InputReportLength": 192,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 967,
       "InputReportLength": 192,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-671.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-671.json
@@ -12,39 +12,26 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 769,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 769,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.WacomDriverIntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -52,14 +39,7 @@
       "VendorID": 1386,
       "ProductID": 769,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Plugin.Tablet.AuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Plugin.Tablet.AuxReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-672.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-672.json
@@ -12,41 +12,26 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 891,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 891,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.WacomDriverIntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-680.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-680.json
@@ -15,38 +15,26 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 803,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 803,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.WacomDriverIntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -54,14 +42,7 @@
       "VendorID": 1386,
       "ProductID": 803,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-690.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-690.json
@@ -15,38 +15,26 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 829,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 829,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -54,14 +42,7 @@
       "VendorID": 1386,
       "ProductID": 829,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTC-133.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTC-133.json
@@ -12,41 +12,26 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 934,
       "InputReportLength": 192,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 934,
       "InputReportLength": 193,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.WacomDriverIntuosV2ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTH-1320.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTH-1320.json
@@ -12,27 +12,17 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 847,
       "InputReportLength": 192,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-1300.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-1300.json
@@ -15,26 +15,17 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 772,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-1660.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-1660.json
@@ -12,41 +12,26 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 912,
       "InputReportLength": 192,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 942,
       "InputReportLength": 192,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-2200.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-2200.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 20
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -28,11 +26,7 @@
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.CintiqV1.CintiqV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
@@ -42,13 +36,7 @@
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.CintiqV1.CintiqV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTZ-1200W.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTZ-1200W.json
@@ -15,26 +15,17 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 10
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 198,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3.Intuos3ExtraAuxReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/ET-0405-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/ET-0405-U.json
@@ -12,41 +12,26 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 16,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 16,
       "InputReportLength": 9,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.SkipByteTabletReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/ET-0405A-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/ET-0405A-U.json
@@ -13,42 +13,28 @@
         "ButtonCount": 2
       }
     },
-    "AuxiliaryButtons": null,
     "MouseButtons": {
       "ButtonCount": 3
-    },
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 17,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 17,
       "InputReportLength": 9,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.WacomDriverIntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/FT-0405-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/FT-0405-U.json
@@ -12,41 +12,26 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 96,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 96,
       "InputReportLength": 9,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.WacomDriverIntuosReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/GD-0405-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/GD-0405-U.json
@@ -12,41 +12,26 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 32,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 32,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/GD-0608-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/GD-0608-U.json
@@ -12,41 +12,26 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 33,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 33,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/GD-0912-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/GD-0912-U.json
@@ -12,41 +12,26 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 34,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 34,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/GD-1212-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/GD-1212-U.json
@@ -12,41 +12,26 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 35,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 35,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/GD-1218-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/GD-1218-U.json
@@ -12,41 +12,26 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 36,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 36,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/MTE-450.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/MTE-450.json
@@ -15,40 +15,26 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 101,
       "InputReportLength": 5,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 101,
       "InputReportLength": 9,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-450.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-450.json
@@ -15,38 +15,26 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 38,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 38,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -54,14 +42,7 @@
       "VendorID": 1386,
       "ProductID": 38,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-451.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-451.json
@@ -15,38 +15,26 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 788,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 788,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -54,14 +42,7 @@
       "VendorID": 1386,
       "ProductID": 788,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-460.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-460.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -29,12 +27,9 @@
       "FeatureInitReport": [
         "AgI="
       ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
       "InitializationStrings": [
         0
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
@@ -42,13 +37,9 @@
       "InputReportLength": 193,
       "OutputReportLength": 0,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.WacomDriverIntuosV2ReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
       "InitializationStrings": [
         0
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
@@ -56,13 +47,9 @@
       "InputReportLength": 192,
       "OutputReportLength": 0,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
       "InitializationStrings": [
         0
-      ],
-      "Attributes": {}
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -70,14 +57,7 @@
       "VendorID": 1386,
       "ProductID": 914,
       "InputReportLength": 44,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-650.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-650.json
@@ -15,38 +15,26 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 39,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 39,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -54,14 +42,7 @@
       "VendorID": 1386,
       "ProductID": 39,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-651.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-651.json
@@ -15,38 +15,26 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 789,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 789,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -54,14 +42,7 @@
       "VendorID": 1386,
       "ProductID": 789,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-660.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-660.json
@@ -15,34 +15,20 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 855,
       "InputReportLength": 192,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser"
     },
     {
       "VendorID": 1386,
       "ProductID": 864,
       "InputReportLength": 361,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser"
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -50,14 +36,7 @@
       "VendorID": 1386,
       "ProductID": 855,
       "InputReportLength": 44,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-850.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-850.json
@@ -15,38 +15,26 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 40,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 40,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -54,14 +42,7 @@
       "VendorID": 1386,
       "ProductID": 40,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-851.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-851.json
@@ -15,38 +15,26 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 791,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 791,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -54,14 +42,7 @@
       "VendorID": 1386,
       "ProductID": 791,
       "InputReportLength": 64,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-860.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-860.json
@@ -15,34 +15,20 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 856,
       "InputReportLength": 192,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser"
     },
     {
       "VendorID": 1386,
       "ProductID": 856,
       "InputReportLength": 193,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.WacomDriverIntuosV2ReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.WacomDriverIntuosV2ReportParser"
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -50,14 +36,7 @@
       "VendorID": 1386,
       "ProductID": 856,
       "InputReportLength": 44,
-      "OutputReportLength": null,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser"
     }
-  ],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-1240.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-1240.json
@@ -15,40 +15,26 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 9
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 187,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 187,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-440.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-440.json
@@ -15,40 +15,26 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 7
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 184,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 184,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-450.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-450.json
@@ -15,40 +15,26 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 41,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 41,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-540WL.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-540WL.json
@@ -15,40 +15,26 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 9
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 188,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 188,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-640.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-640.json
@@ -15,40 +15,26 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 9
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 185,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 185,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-650.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-650.json
@@ -15,40 +15,26 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 42,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 42,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-840.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-840.json
@@ -15,40 +15,26 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 9
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 186,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 186,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTU-600U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTU-600U.json
@@ -12,27 +12,17 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 3,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.PTU.PTUReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-1230.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-1230.json
@@ -18,42 +18,30 @@
     },
     "MouseButtons": {
       "ButtonCount": 5
-    },
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 179,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3.Intuos3ReportParser",
       "FeatureInitReport": [
         "AgI=",
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 179,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3.WacomDriverIntuos3ReportParser",
       "FeatureInitReport": [
         "AgI=",
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "FeatureInitDelayMs": "150"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-1231W.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-1231W.json
@@ -18,42 +18,30 @@
     },
     "MouseButtons": {
       "ButtonCount": 5
-    },
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 180,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3.Intuos3ReportParser",
       "FeatureInitReport": [
         "AgI=",
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 180,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3.WacomDriverIntuos3ReportParser",
       "FeatureInitReport": [
         "AgI=",
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "FeatureInitDelayMs": "150"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-430.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-430.json
@@ -18,42 +18,30 @@
     },
     "MouseButtons": {
       "ButtonCount": 5
-    },
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 176,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3.Intuos3ReportParser",
       "FeatureInitReport": [
         "AgI=",
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 176,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3.WacomDriverIntuos3ReportParser",
       "FeatureInitReport": [
         "AgI=",
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "FeatureInitDelayMs": "150"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-431W.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-431W.json
@@ -18,42 +18,30 @@
     },
     "MouseButtons": {
       "ButtonCount": 5
-    },
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 183,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3.Intuos3ReportParser",
       "FeatureInitReport": [
         "AgI=",
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 183,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3.WacomDriverIntuos3ReportParser",
       "FeatureInitReport": [
         "AgI=",
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "FeatureInitDelayMs": "150"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-630.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-630.json
@@ -18,42 +18,30 @@
     },
     "MouseButtons": {
       "ButtonCount": 5
-    },
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 177,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3.Intuos3ReportParser",
       "FeatureInitReport": [
         "AgI=",
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 177,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3.WacomDriverIntuos3ReportParser",
       "FeatureInitReport": [
         "AgI=",
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "FeatureInitDelayMs": "150"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-631W.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-631W.json
@@ -18,42 +18,30 @@
     },
     "MouseButtons": {
       "ButtonCount": 5
-    },
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 181,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3.Intuos3ReportParser",
       "FeatureInitReport": [
         "AgI=",
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 181,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3.WacomDriverIntuos3ReportParser",
       "FeatureInitReport": [
         "AgI=",
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "FeatureInitDelayMs": "150"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-930.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-930.json
@@ -18,42 +18,30 @@
     },
     "MouseButtons": {
       "ButtonCount": 5
-    },
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 178,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3.Intuos3ReportParser",
       "FeatureInitReport": [
         "AgI=",
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 178,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3.WacomDriverIntuos3ReportParser",
       "FeatureInitReport": [
         "AgI=",
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "FeatureInitDelayMs": "150"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/XD-0405-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/XD-0405-U.json
@@ -12,44 +12,30 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 65,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI=",
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 65,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI=",
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "FeatureInitDelayMs": "150"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/XD-0608-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/XD-0608-U.json
@@ -12,44 +12,30 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 66,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI=",
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 66,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI=",
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "FeatureInitDelayMs": "150"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/XD-0912-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/XD-0912-U.json
@@ -12,44 +12,30 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 67,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI=",
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 67,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI=",
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "FeatureInitDelayMs": "150"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/XD-1212-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/XD-1212-U.json
@@ -12,44 +12,30 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 68,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI=",
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 68,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI=",
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "FeatureInitDelayMs": "150"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/XD-1218-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/XD-1218-U.json
@@ -12,44 +12,30 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 69,
       "InputReportLength": 10,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI=",
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 1386,
       "ProductID": 69,
       "InputReportLength": 11,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
       "FeatureInitReport": [
         "AgI=",
         "BAA="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "FeatureInitDelayMs": "150"
   }

--- a/OpenTabletDriver.Configurations/Configurations/Waltop/Slim Tablet.json
+++ b/OpenTabletDriver.Configurations/Configurations/Waltop/Slim Tablet.json
@@ -12,30 +12,21 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 5935,
       "ProductID": 50,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Genius.GeniusReportParserV2",
       "FeatureInitReport": [
         "AgQA",
         "AgIA",
         "AhAB"
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XENX/P1-640.json
+++ b/OpenTabletDriver.Configurations/Configurations/XENX/P1-640.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -28,14 +26,9 @@
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XENX.XENXReportParser",
       "FeatureInitReport": [
         "IAE="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XENX/P3-1060.json
+++ b/OpenTabletDriver.Configurations/Configurations/XENX/P3-1060.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 10
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -28,14 +26,9 @@
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XENX.XENXReportParser",
       "FeatureInitReport": [
         "IAE="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XENX/X1-640.json
+++ b/OpenTabletDriver.Configurations/Configurations/XENX/X1-640.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 5
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -28,14 +26,9 @@
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XENX.XENXReportParser",
       "FeatureInitReport": [
         "IAE="
-      ],
-      "OutputInitReport": null,
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 10 (2nd Gen).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 10 (2nd Gen).json
@@ -15,27 +15,19 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 10429,
       "ProductID": 2381,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenOffsetPressureReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12 (2nd Gen).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12 (2nd Gen).json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 12,
       "OutputReportLength": 33,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenOffsetPressureReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12 Pro.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 12,
       "OutputReportLength": 12,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 10,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 13 (2nd Gen).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 13 (2nd Gen).json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 9
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 12,
       "OutputReportLength": 33,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenOffsetPressureReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 13.3 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 13.3 Pro.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 12,
       "OutputReportLength": 12,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 13.3.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 13.3.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,13 +24,9 @@
       "InputReportLength": 8,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAC"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -42,13 +36,9 @@
       "InputReportLength": 8,
       "OutputReportLength": 0,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenDedicatedAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
       "InitializationStrings": [
         4
-      ],
-      "Attributes": {}
+      ]
     }
   ],
   "Attributes": {

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 15.6 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 15.6 Pro.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 10,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 15.6.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 15.6.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,13 +24,9 @@
       "InputReportLength": 8,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAC"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 10429,
@@ -40,13 +34,9 @@
       "InputReportLength": 10,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
   "AuxilaryDeviceIdentifiers": [
@@ -56,13 +46,9 @@
       "InputReportLength": 8,
       "OutputReportLength": 0,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenDedicatedAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
       "InitializationStrings": [
         4
-      ],
-      "Attributes": {}
+      ]
     }
   ],
   "Attributes": {

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16 (2nd Gen).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16 (2nd Gen).json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 10
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 12,
       "OutputReportLength": 33,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenOffsetPressureReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16 Pro.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 12,
       "OutputReportLength": 12,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 16.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,17 +24,12 @@
       "InputReportLength": 8,
       "OutputReportLength": 0,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenOffsetAuxReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
       "InitializationStrings": [
         100,
         123
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1",
     "Interface": "0"

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 22 (2nd Gen).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 22 (2nd Gen).json
@@ -12,10 +12,7 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -24,15 +21,9 @@
       "InputReportLength": 10,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 22HD.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 22HD.json
@@ -12,27 +12,17 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 21827,
       "ProductID": 71,
       "InputReportLength": 8,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
-      "DeviceStrings": {},
       "InitializationStrings": [
         100
-      ],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 24 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 24 Pro.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 20
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 12,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist Pro 16 (Gen2).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist Pro 16 (Gen2).json
@@ -12,10 +12,7 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -24,16 +21,11 @@
       "InputReportLength": 14,
       "OutputReportLength": 14,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenGen2ReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist Pro 16TP.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist Pro 16TP.json
@@ -10,12 +10,9 @@
     "Pen": {
       "MaxPressure": 8191,
       "Buttons": {
-      "ButtonCount": 2
+        "ButtonCount": 2
+      }
     }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
   },
   "DigitizerIdentifiers": [
     {
@@ -24,15 +21,9 @@
       "InputReportLength": 12,
       "OutputReportLength": 12,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/CT1060.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/CT1060.json
@@ -12,10 +12,7 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -24,15 +21,9 @@
       "InputReportLength": 12,
       "OutputReportLength": 10,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/CT430.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/CT430.json
@@ -12,10 +12,7 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -24,13 +21,9 @@
       "InputReportLength": 12,
       "OutputReportLength": 10,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 10429,
@@ -38,16 +31,11 @@
       "InputReportLength": 12,
       "OutputReportLength": 21,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/CT640.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/CT640.json
@@ -12,10 +12,7 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -24,13 +21,9 @@
       "InputReportLength": 12,
       "OutputReportLength": 12,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 10429,
@@ -38,15 +31,9 @@
       "InputReportLength": 12,
       "OutputReportLength": 21,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01 V2 (Variant 2).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01 V2 (Variant 2).json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,15 +24,12 @@
       "InputReportLength": 12,
       "OutputReportLength": 10,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
       ],
       "DeviceStrings": {
         "4": "UG902_BPG1002"
-      },
-      "InitializationStrings": [],
-      "Attributes": {}
+      }
     },
     {
       "VendorID": 10429,
@@ -42,19 +37,15 @@
       "InputReportLength": 12,
       "OutputReportLength": 10,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
       ],
       "DeviceStrings": {
         "4": "UG901_BPU1002",
         "5": "2020-10-23_Release3"
-      },
-      "InitializationStrings": [],
-      "Attributes": {}
+      }
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01 V2.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,13 @@
       "InputReportLength": 12,
       "OutputReportLength": 10,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
       ],
       "DeviceStrings": {
         "4": "UG901_BPU1002",
         "5": "^(?!2020-10-23_Release3$).*$"
-      },
-      "InitializationStrings": [],
-      "Attributes": {}
+      }
     },
     {
       "VendorID": 10429,
@@ -43,18 +38,14 @@
       "InputReportLength": 10,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
       ],
       "DeviceStrings": {
         "4": "UG901_BPU1002"
-      },
-      "InitializationStrings": [],
-      "Attributes": {}
+      }
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 8,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAC"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 02.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 02.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 10,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAC"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 03.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 03.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 8,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAC"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco L.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco L.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 10,
       "OutputReportLength": 33,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenOffsetPressureReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport":  [
+      "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco M.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco M.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 12,
       "OutputReportLength": 33,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenOffsetPressureReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro LW Gen2.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro LW Gen2.json
@@ -12,10 +12,7 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -24,16 +21,11 @@
       "InputReportLength": 14,
       "OutputReportLength": 14,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenGen2ReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro Medium.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro Medium.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 10,
       "OutputReportLength": 10,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro SW.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro SW.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,15 +24,9 @@
       "InputReportLength": 12,
       "OutputReportLength": 20,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro Small.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro Small.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 10,
       "OutputReportLength": 10,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro XLW Gen2.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro XLW Gen2.json
@@ -12,10 +12,7 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -24,16 +21,11 @@
       "InputReportLength": 14,
       "OutputReportLength": 14,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenGen2ReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco mini4.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco mini4.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,13 +24,9 @@
       "InputReportLength": 12,
       "OutputReportLength": 12,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 10429,
@@ -40,15 +34,9 @@
       "InputReportLength": 12,
       "OutputReportLength": 10,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
-  ],
-  "AuxilaryDeviceIdentifiers": [],
-  "Attributes": {}
+  ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco mini7.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco mini7.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,13 +24,9 @@
       "InputReportLength": 12,
       "OutputReportLength": 12,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 10429,
@@ -40,13 +34,9 @@
       "InputReportLength": 12,
       "OutputReportLength": 10,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 10429,
@@ -54,13 +44,9 @@
       "InputReportLength": 12,
       "OutputReportLength": 21,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 10429,
@@ -68,16 +54,11 @@
       "InputReportLength": 12,
       "OutputReportLength": 32,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Innovator 16.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Innovator 16.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 12,
       "OutputReportLength": 12,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArEE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 03 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 03 Pro.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 8,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAC"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 03.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 03.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,13 +24,9 @@
       "InputReportLength": 10,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 10429,
@@ -40,13 +34,9 @@
       "InputReportLength": 10,
       "OutputReportLength": 10,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 10429,
@@ -54,16 +44,11 @@
       "InputReportLength": 12,
       "OutputReportLength": 10,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 05 V3.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 05 V3.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 8,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAC"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 06.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 06.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 8,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAC"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 06C.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 06C.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 8,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAC"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G430.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G430.json
@@ -12,10 +12,7 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -24,34 +21,26 @@
       "InputReportLength": 8,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAC"
       ],
       "DeviceStrings": {
         "2": "TABLET G3 4x3"
-      },
-      "InitializationStrings": [],
-      "Attributes": {}
+      }
     },
     {
       "VendorID": 10429,
       "ProductID": 117,
       "InputReportLength": 16,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "2": "TABLET G3 4x3"
       },
       "InitializationStrings": [
         100
-      ],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G430S V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G430S V2.json
@@ -12,10 +12,7 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -24,16 +21,11 @@
       "InputReportLength": 12,
       "OutputReportLength": 12,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G430S.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G430S.json
@@ -12,10 +12,7 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -24,15 +21,12 @@
       "InputReportLength": 8,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAC"
       ],
       "DeviceStrings": {
         "2": "G430S"
-      },
-      "InitializationStrings": [],
-      "Attributes": {}
+      }
     },
     {
       "VendorID": 10429,
@@ -40,16 +34,11 @@
       "InputReportLength": 14,
       "OutputReportLength": 14,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G540 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G540 Pro.json
@@ -12,10 +12,7 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -24,16 +21,11 @@
       "InputReportLength": 8,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAC"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G540.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G540.json
@@ -12,10 +12,7 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -24,18 +21,14 @@
       "InputReportLength": 8,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAC"
       ],
       "DeviceStrings": {
         "2": "TABLET G3 5x4"
-      },
-      "InitializationStrings": [],
-      "Attributes": {}
+      }
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640 (Variant 2).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640 (Variant 2).json
@@ -12,10 +12,7 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -24,16 +21,11 @@
       "InputReportLength": 12,
       "OutputReportLength": 12,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640.json
@@ -12,10 +12,7 @@
       "Buttons": {
         "ButtonCount": 2
       }
-    },
-    "AuxiliaryButtons": null,
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -24,16 +21,13 @@
       "InputReportLength": 8,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAC"
       ],
-      "DeviceStrings": {},
       "InitializationStrings": [
         100,
         110
-      ],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 10429,
@@ -41,16 +35,11 @@
       "InputReportLength": 14,
       "OutputReportLength": 14,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640S.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G640S.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,13 +24,9 @@
       "InputReportLength": 10,
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 10429,
@@ -40,13 +34,9 @@
       "InputReportLength": 10,
       "OutputReportLength": 10,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 10429,
@@ -54,16 +44,11 @@
       "InputReportLength": 12,
       "OutputReportLength": 10,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G960.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G960.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 10,
       "OutputReportLength": 10,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G960S Plus.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G960S Plus.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 12,
       "OutputReportLength": 12,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G960S.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star G960S.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,13 +24,9 @@
       "InputReportLength": 12,
       "OutputReportLength": 12,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 10429,
@@ -40,16 +34,11 @@
       "InputReportLength": 12,
       "OutputReportLength": 10,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XenceLabs/Pen Tablet Medium.json
+++ b/OpenTabletDriver.Configurations/Configurations/XenceLabs/Pen Tablet Medium.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 3
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,13 +24,9 @@
       "InputReportLength": 10,
       "OutputReportLength": 32,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XenceLabs.XenceLabsReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     },
     {
       "VendorID": 10429,
@@ -40,16 +34,11 @@
       "InputReportLength": 10,
       "OutputReportLength": 33,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XenceLabs.XenceLabsReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Configurations/Configurations/XenceLabs/Pen Tablet Small.json
+++ b/OpenTabletDriver.Configurations/Configurations/XenceLabs/Pen Tablet Small.json
@@ -15,9 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 3
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -26,16 +24,11 @@
       "InputReportLength": 10,
       "OutputReportLength": 33,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XenceLabs.XenceLabsReportParser",
-      "FeatureInitReport": null,
       "OutputInitReport": [
         "ArAE"
-      ],
-      "DeviceStrings": {},
-      "InitializationStrings": [],
-      "Attributes": {}
+      ]
     }
   ],
-  "AuxilaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/OpenTabletDriver.Plugin/Tablet/DeviceIdentifier.cs
+++ b/OpenTabletDriver.Plugin/Tablet/DeviceIdentifier.cs
@@ -52,13 +52,13 @@ namespace OpenTabletDriver.Plugin.Tablet
         /// </summary>
         /// <typeparam name="uint">The index to query</typeparam>
         /// <typeparam name="string">The value to match to the queried index</typeparam>
-        public Dictionary<byte, string> DeviceStrings { set; get; } = new Dictionary<byte, string>();
+        public Dictionary<byte, string>? DeviceStrings { set; get; }
 
         /// <summary>
         /// Device strings to query to initialize device endpoints.
         /// </summary>
-        public List<byte> InitializationStrings { set; get; } = new List<byte>();
+        public List<byte>? InitializationStrings { set; get; }
 
-        public Dictionary<string, string> Attributes { set; get; } = new Dictionary<string, string>();
+        public Dictionary<string, string>? Attributes { set; get; }
     }
 }

--- a/OpenTabletDriver.Plugin/Tablet/TabletConfiguration.cs
+++ b/OpenTabletDriver.Plugin/Tablet/TabletConfiguration.cs
@@ -29,13 +29,11 @@ namespace OpenTabletDriver.Plugin.Tablet
         /// <summary>
         /// The auxiliary device identifier.
         /// </summary>
-        [Required(ErrorMessage = $"Tablet {nameof(AuxilaryDeviceIdentifiers)} must be present")]
-        public List<DeviceIdentifier> AuxilaryDeviceIdentifiers { set; get; } = new List<DeviceIdentifier>();
+        public List<DeviceIdentifier>? AuxilaryDeviceIdentifiers { set; get; }
 
         /// <summary>
         /// Other information about the tablet that can be used in tools or other applications.
         /// </summary>
-        [Required(ErrorMessage = $"Tablet {nameof(Attributes)} must be present")]
-        public Dictionary<string, string> Attributes { set; get; } = new Dictionary<string, string>();
+        public Dictionary<string, string>? Attributes { set; get; }
     }
 }

--- a/OpenTabletDriver.Plugin/Tablet/TabletSpecifications.cs
+++ b/OpenTabletDriver.Plugin/Tablet/TabletSpecifications.cs
@@ -1,5 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 
+#nullable enable
+
 namespace OpenTabletDriver.Plugin.Tablet
 {
     public class TabletSpecifications
@@ -8,27 +10,27 @@ namespace OpenTabletDriver.Plugin.Tablet
         /// Specifications for the tablet digitizer.
         /// </summary>
         [Required(ErrorMessage = $"{nameof(Digitizer)} specifications must be defined")]
-        public DigitizerSpecifications Digitizer { set; get; }
+        public DigitizerSpecifications Digitizer { set; get; } = new DigitizerSpecifications();
 
         /// <summary>
         /// Specifications for the tablet's pen.
         /// </summary>
         [Required(ErrorMessage = $"{nameof(Pen)} specifications must be defined")]
-        public PenSpecifications Pen { set; get; }
+        public PenSpecifications Pen { set; get; } = new PenSpecifications();
 
         /// <summary>
         /// Specifications for the auxiliary buttons.
         /// </summary>
-        public ButtonSpecifications AuxiliaryButtons { set; get; }
+        public ButtonSpecifications? AuxiliaryButtons { set; get; }
 
         /// <summary>
         /// Specifications for the mouse buttons.
         /// </summary>
-        public ButtonSpecifications MouseButtons { set; get; }
+        public ButtonSpecifications? MouseButtons { set; get; }
 
         /// <summary>
         /// Specifications for the touch digitizer.
         /// </summary>
-        public DigitizerSpecifications Touch { set; get; }
+        public DigitizerSpecifications? Touch { set; get; }
     }
 }

--- a/OpenTabletDriver.Tests/OpenTabletDriver.Tests.csproj
+++ b/OpenTabletDriver.Tests/OpenTabletDriver.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="NuGet Packages">
+    <PackageReference Include="DiffPlex" Version="1.7.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.15" />

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -100,9 +100,9 @@ namespace OpenTabletDriver
                     Log.Write("Detect", $"Found tablet '{config.Name}'");
                     devices.Add(digitizer);
 
-                    if (config.AuxilaryDeviceIdentifiers.Any())
+                    if ((config.AuxilaryDeviceIdentifiers?.Count ?? 0) > 0)
                     {
-                        if (MatchDevice(config, config.AuxilaryDeviceIdentifiers) is InputDevice aux)
+                        if (MatchDevice(config, config.AuxilaryDeviceIdentifiers!) is InputDevice aux)
                             devices.Add(aux);
                         else
                             Log.Write("Detect", "Failed to find auxiliary device, express keys may be unavailable.", LogLevel.Warning);
@@ -176,7 +176,7 @@ namespace OpenTabletDriver
                    select device;
         }
 
-        private static bool DeviceMatchesStrings(IDeviceEndpoint device, IDictionary<byte, string> deviceStrings)
+        private static bool DeviceMatchesStrings(IDeviceEndpoint device, IDictionary<byte, string>? deviceStrings)
         {
             if (deviceStrings == null || deviceStrings.Count == 0)
                 return true;
@@ -200,11 +200,15 @@ namespace OpenTabletDriver
             return true;
         }
 
-        private static bool DeviceMatchesAttribute(IDeviceEndpoint device, Dictionary<string, string> identifier_attributes, Dictionary<string, string> config_attributes)
+        private static bool DeviceMatchesAttribute(IDeviceEndpoint device, Dictionary<string, string>? identifier_attributes, Dictionary<string, string>? config_attributes)
         {
-            var attributes = new Dictionary<string, string>(identifier_attributes);
-            foreach (var kvp in config_attributes)
-                attributes.TryAdd(kvp.Key, kvp.Value);
+            var attributes = new Dictionary<string, string>(identifier_attributes ?? Enumerable.Empty<KeyValuePair<string, string>>());
+
+            if (config_attributes != null)
+            {
+                foreach (var kvp in config_attributes)
+                    attributes.TryAdd(kvp.Key, kvp.Value);
+            }
 
             // Windows only configuration attribute.
             if (SystemInterop.CurrentPlatform == PluginPlatform.Windows)

--- a/OpenTabletDriver/InputDevice.cs
+++ b/OpenTabletDriver/InputDevice.cs
@@ -29,7 +29,7 @@ namespace OpenTabletDriver
             Configuration = configuration;
             Identifier = identifier;
 
-            if (Configuration.Attributes.TryGetValue(DELAY_ATTRIBUTE_KEY_NAME, out var delayStr))
+            if (Configuration.Attributes?.TryGetValue(DELAY_ATTRIBUTE_KEY_NAME, out var delayStr) ?? false)
                 if (!uint.TryParse(delayStr, out _featureInitDelayMs))
                     Log.Write("Device", $"Could not parse '{delayStr}' from attribute {DELAY_ATTRIBUTE_KEY_NAME}", LogLevel.Warning);
 


### PR DESCRIPTION
Backports #3522 to `0.6.x` branch.

For the cleanup, I used the following script:

```py
import json
import os
import sys

def process_file(filepath):
    if filepath.endswith(".json"):
        try:
            with open(filepath, 'r+') as f:
                data = json.load(f)

                def remove_redundant(obj):
                    if isinstance(obj, dict):
                        return {k: remove_redundant(v) for k, v in obj.items() if v is not None and v != {} and (not isinstance(v, list) or v)}
                    elif isinstance(obj, list):
                        return [remove_redundant(item) for item in obj if item is not None and item != {} and (not isinstance(item, list) or item)]
                    else:
                        return obj

                cleaned_data = remove_redundant(data)
                f.seek(0)
                json.dump(cleaned_data, f, indent=2)
                f.truncate()

        except (FileNotFoundError, json.JSONDecodeError) as e:
            print(f"Error processing {filepath}: {e}")
            return

    with open(filepath, 'r+', encoding='utf-8') as f:
        content = f.read()
        if not content.endswith('\n'):
            f.write('\n')

def process_directory(directory):
    for root, _, files in os.walk(directory):
        for filename in files:
            process_file(os.path.join(root, filename))

if __name__ == "__main__":
    if len(sys.argv) < 2:
        print("Usage: python cleanup.py <directory>")
        sys.exit(1)

    directory = sys.argv[1]
    process_directory(directory)
```

Will commit this to repo if desired.