### PR TITLE
Bump to version 0.6.5.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionBase>0.6.4.0</VersionBase>
+    <VersionBase>0.6.5.0</VersionBase>
     <FrameworkBase>net8.0</FrameworkBase>
     <LangVersion>preview</LangVersion>
     <VersionPrefix>$(VersionBase)</VersionPrefix>


### PR DESCRIPTION
We should probably do these version bumps immediately after a release, so that people compiling from git source is easier to spot in diagnostics.

Like #3122

/e: I'm being notified by James that merging this early will likely conflict with the updater.
