### PR TITLE
Add eraser support for CTC-4110WL/CTC-6110WL

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV3/IntuosV3Report.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV3/IntuosV3Report.cs
@@ -4,7 +4,7 @@ using OpenTabletDriver.Tablet;
 
 namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV3
 {
-    public struct IntuosV3Report : ITabletReport, IHoverReport, IConfidenceReport, ITiltReport
+    public struct IntuosV3Report : ITabletReport, IHoverReport, IConfidenceReport, ITiltReport, IEraserReport
     {
         public IntuosV3Report(byte[] report)
         {
@@ -30,6 +30,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV3
                 penByte.IsBitSet(1),
                 penByte.IsBitSet(2)
             };
+            Eraser = report[2].IsBitSet(5);
             HighConfidence = report[2].IsBitSet(6);
             HoverDistance = report[13];
         }
@@ -41,5 +42,6 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV3
         public bool[] PenButtons { set; get; }
         public bool HighConfidence { set; get; }
         public uint HoverDistance { set; get; }
+        public bool Eraser { get; set; }
     }
 }


### PR DESCRIPTION
Add eraser support for Wacom CTC-x110WL.

Bit index 5 of byte index 2 indicate the eraser nib. On official Wacom driver, eraser can be activated with bundled pen by holding the 2nd pen button (while the tablet not detecting the pen), then move the pen close to digitizer, regardless of settings in driver.