### PR TITLE
Add toolreport for intuos3

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3ExtraAuxReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3ExtraAuxReportParser.cs
@@ -27,6 +27,8 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3
                 return new IntuosV1TabletReport(data, ref _prevPressure, ref _prevTilt, ref _prevPenButtons);
             if ((data[1] & 0xF0) == 0xF0 || (data[1] & 0xF0) == 0xB0)
                 return new Intuos3MouseReport(data);
+            if (data[1] == 0xC2)
+                return new IntuosV1ToolReport(data);
 
             return new DeviceReport(data);
         }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3ReportParser.cs
@@ -27,6 +27,8 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3
                 return new IntuosV1TabletReport(data, ref _prevPressure, ref _prevTilt, ref _prevPenButtons);
             if ((data[1] & 0xF0) == 0xF0 || (data[1] & 0xF0) == 0xB0)
                 return new Intuos3MouseReport(data);
+            if (data[1] == 0xC2)
+                return new IntuosV1ToolReport(data);
 
             return new DeviceReport(data);
         }


### PR DESCRIPTION
Appears to be an oversight when intuos3 was split off of the intuosV1 parser.