### PR TITLE
Fix invalid json exploding the udev script

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTH-271.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTH-271.json
@@ -15,7 +15,7 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    },
+    }
   },
   "DigitizerIdentifiers": [
     {
@@ -25,7 +25,7 @@
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser",
       "FeatureInitReport": [
         "AgI="
-      ],
+      ]
     }
-  ],
+  ]
 }


### PR DESCRIPTION
I have no words for this other than: wtf why doesn't the tests catch this