### PR TITLE
BindingSettings: Default pressure and eraser threshold to 1%

### DIFF
--- a/OpenTabletDriver.Desktop/Profiles/BindingSettings.cs
+++ b/OpenTabletDriver.Desktop/Profiles/BindingSettings.cs
@@ -8,7 +8,8 @@ namespace OpenTabletDriver.Desktop.Profiles
 {
     public class BindingSettings : ViewModel
     {
-        private float tP, eP;
+        private float tP = 1;
+        private float eP = 1;
         private PluginSettingStore tipButton, eraserButton, mouseScrollUp, mouseScrollDown;
         private PluginSettingStoreCollection penButtons = new PluginSettingStoreCollection(),
             auxButtons = new PluginSettingStoreCollection(),


### PR DESCRIPTION
This fixes instances of the default button being stuck on tablets with nonzero pressure

Some users would've experienced this as mouse buttons stopping working as soon as the daemon starts, especially if they use Absolute Mode on Linux

Fixes #3597 for 0.6.x