### PR TITLE
Use `blacklist` to disable `wacom` and `hid_uclogic` modules

### DIFF
--- a/eng/linux/Generic/usr/lib/modprobe.d/99-opentabletdriver.conf
+++ b/eng/linux/Generic/usr/lib/modprobe.d/99-opentabletdriver.conf
@@ -1,2 +1,2 @@
-install wacom /usr/bin/true
-install hid_uclogic /usr/bin/true
+blacklist wacom
+blacklist hid_uclogic


### PR DESCRIPTION
Simply installing OpenTabletDriver breaks wacom drivers on Linux. I had to waste hours trying to fix a non-existent issue thinking it was related to libinput just because I forgot I had OpenTabletDriver installed.

`install wacom /usr/bin/true` should **NOT** be a thing. It renders modprobe for loading drivers useless.