### PR TITLE
[0.6.x] Fix AppInfo desync in UX

### DIFF
--- a/OpenTabletDriver.Desktop/AppInfo.cs
+++ b/OpenTabletDriver.Desktop/AppInfo.cs
@@ -49,9 +49,9 @@ namespace OpenTabletDriver.Desktop
             };
         }
 
-        public static DesktopPluginManager PluginManager { get; } = new DesktopPluginManager();
+        public static DesktopPluginManager PluginManager { set; get; } = new DesktopPluginManager();
 
-        public static PresetManager PresetManager { get; } = new PresetManager();
+        public static PresetManager PresetManager { set; get; } = new PresetManager();
 
         public string AppDataDirectory { set; get; }
 

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -76,7 +76,6 @@ namespace OpenTabletDriver.UX
         private const int DEFAULT_CLIENT_WIDTH = 960;
         private const int DEFAULT_CLIENT_HEIGHT = 760;
 
-        private TabletSwitcherPanel mainPanel;
         private MenuBar menu;
         private Placeholder placeholder;
         private TrayIcon trayIcon;

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -11,6 +11,7 @@ using Newtonsoft.Json.Linq;
 using OpenTabletDriver.Desktop;
 using OpenTabletDriver.Desktop.Diagnostics;
 using OpenTabletDriver.Desktop.Interop;
+using OpenTabletDriver.Desktop.Reflection;
 using OpenTabletDriver.Interop;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Logging;
@@ -369,6 +370,9 @@ namespace OpenTabletDriver.UX
             // Load the application information from the daemon
             AppInfo.Current = await Driver.Instance.GetApplicationInfo();
 
+            AppInfo.PluginManager = new DesktopPluginManager();
+            AppInfo.PresetManager = new PresetManager();
+
             // Load any new plugins
             AppInfo.PluginManager.Load();
 
@@ -382,7 +386,7 @@ namespace OpenTabletDriver.UX
 
             // Set window content
             base.Menu = menu ??= ConstructMenu();
-            base.Content = mainPanel ??= new TabletSwitcherPanel
+            base.Content = new TabletSwitcherPanel
             {
                 CommandsControl = new StackLayout
                 {


### PR DESCRIPTION
Attempt at fixing the Plugin Manager & Preset Manager being instantiated with the wrong AppInfo.

Closes #3575