### PR TITLE
[0.6.x] Link to release instead of updating

### DIFF
--- a/OpenTabletDriver.UX/Windows/Updater/UpdaterWindow.cs
+++ b/OpenTabletDriver.UX/Windows/Updater/UpdaterWindow.cs
@@ -121,6 +121,6 @@ namespace OpenTabletDriver.UX.Windows.Updater
         });
 
         private void OpenRelease(object sender, EventArgs e)
-            => DesktopInterop.Open(string.Format(LATEST_RELEASE_URL));
+            => DesktopInterop.Open(LATEST_RELEASE_URL);
     }
 }

--- a/OpenTabletDriver.UX/Windows/Updater/UpdaterWindow.cs
+++ b/OpenTabletDriver.UX/Windows/Updater/UpdaterWindow.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Eto.Drawing;
 using Eto.Forms;
+using OpenTabletDriver.Desktop.Interop;
 using OpenTabletDriver.Interop;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.UX.Controls;
@@ -36,6 +37,7 @@ namespace OpenTabletDriver.UX.Windows.Updater
             _ = InitializeAsync();
         }
 
+        public const string LATEST_RELEASE_URL = "https://github.com/OpenTabletDriver/OpenTabletDriver/releases/latest";
         private int _isUpdateRequested;
         private TaskCompletionSource<bool> _updateAvailable = new();
         public Task<bool> HasUpdates() => _updateAvailable.Task;
@@ -54,9 +56,9 @@ namespace OpenTabletDriver.UX.Windows.Updater
                         new Bitmap(App.Logo.WithSize(256, 256)),
                         "An update is available to install",
                         $"OpenTabletDriver v{updateAvailable.Version}",
-                        new Button(Update)
+                        new Button(OpenRelease)
                         {
-                            Text = "Install"
+                            Text = "Go to Release"
                         },
                         new PaddingSpacerItem(),
                     }
@@ -117,5 +119,8 @@ namespace OpenTabletDriver.UX.Windows.Updater
             else
                 Environment.Exit(0);
         });
+
+        private void OpenRelease(object sender, EventArgs e)
+            => DesktopInterop.Open(string.Format(LATEST_RELEASE_URL));
     }
 }

--- a/OpenTabletDriver.UX/Windows/Updater/UpdaterWindow.cs
+++ b/OpenTabletDriver.UX/Windows/Updater/UpdaterWindow.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Eto.Drawing;
 using Eto.Forms;
+using OpenTabletDriver.Desktop;
 using OpenTabletDriver.Desktop.Interop;
 using OpenTabletDriver.UX.Controls;
 using OpenTabletDriver.UX.Controls.Generic;
@@ -49,9 +50,22 @@ namespace OpenTabletDriver.UX.Windows.Updater
                         new Bitmap(App.Logo.WithSize(256, 256)),
                         "An update is available to install",
                         $"OpenTabletDriver v{updateAvailable.Version}",
-                        new Button(OpenRelease)
+                        new PaddingSpacerItem(),
+                        new StackLayout()
                         {
-                            Text = "Go to Release"
+                            Orientation = Orientation.Horizontal,
+                            Items =
+                            {
+                                new Button(OpenRelease)
+                                {
+                                    Text = "Go to Release"
+                                },
+                                new Button(OpenDirectory)
+                                {
+                                    Text = "Open Directory"
+                                }
+                            },
+                            Spacing = 5
                         },
                         new PaddingSpacerItem(),
                     }
@@ -70,5 +84,8 @@ namespace OpenTabletDriver.UX.Windows.Updater
 
         private void OpenRelease(object sender, EventArgs e)
             => DesktopInterop.Open(LATEST_RELEASE_URL);
+
+        private void OpenDirectory(object sender, EventArgs e)
+            => DesktopInterop.Open(AppContext.BaseDirectory);
     }
 }


### PR DESCRIPTION
Open the Github release instead of using the faulty updater for now.

One thing to note is that since no updater object is provided for Linux, they aren't notified of new updates.
That is, until they manually check for one via their Package Manager.

Closes #3618
