### PR TITLE
[0.6.x] Dispose of plugins on InputDeviceTree Disconnected

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -177,10 +177,8 @@ namespace OpenTabletDriver.Daemon
         {
             try
             {
-                // Dispose filters that implement IDisposable interface
-                foreach (var obj in Driver.InputDevices.SelectMany(d => d.OutputMode?.Elements ?? (IEnumerable<object>)Array.Empty<object>()))
-                    if (obj is IDisposable disposable)
-                        disposable.Dispose();
+                foreach (var dev in Driver.InputDevices)
+                    dev.OutputMode?.Dispose();
 
                 Settings = settings ??= Settings.GetDefaults();
 

--- a/OpenTabletDriver.Plugin/Output/IOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/IOutputMode.cs
@@ -1,10 +1,11 @@
+using System;
 using System.Collections.Generic;
 using System.Numerics;
 using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Plugin.Output
 {
-    public interface IOutputMode : IPipelineElement<IDeviceReport>
+    public interface IOutputMode : IPipelineElement<IDeviceReport>, IDisposable
     {
         /// <summary>
         /// Consume the <see cref="IDeviceReport"/> emitted by the device endpoints to be transformed by the pipeline, including <see cref="TransformationMatrix"/>.

--- a/OpenTabletDriver.Plugin/Output/OutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/OutputMode.cs
@@ -135,5 +135,14 @@ namespace OpenTabletDriver.Plugin.Output
                 UnlinkAll(PreTransformElements, this, PostTransformElements, output);
             }
         }
+
+        public virtual void Dispose()
+        {
+            entryElement = null;
+
+            foreach (var obj in Elements ?? [])
+                if (obj is IDisposable disposable)
+                    disposable.Dispose();
+        }
     }
 }

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -60,6 +60,10 @@ namespace OpenTabletDriver
 
                         tree.Disconnected += (sender, e) =>
                         {
+                            foreach (var obj in tree.OutputMode?.Elements ?? [])
+                                if (obj is IDisposable disposable)
+                                    disposable.Dispose();
+
                             // save the immutable array for later use
                             Unsafe.SkipInit(out ImmutableArray<InputDeviceTree> updatedTrees);
                             ImmutableInterlocked.Update(ref _inputDeviceTrees, (trees, tree) =>

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -60,9 +60,7 @@ namespace OpenTabletDriver
 
                         tree.Disconnected += (sender, e) =>
                         {
-                            foreach (var obj in tree.OutputMode?.Elements ?? [])
-                                if (obj is IDisposable disposable)
-                                    disposable.Dispose();
+                            tree.OutputMode?.Dispose();
 
                             // save the immutable array for later use
                             Unsafe.SkipInit(out ImmutableArray<InputDeviceTree> updatedTrees);


### PR DESCRIPTION
Not disposing of plugins when a device is disconnected will cause some to stay active.
Plugins still have to properly dispose themselves to avoid a memory leak.

Closes #3620