### PR TITLE
Ensure Store is properly set when opening advanced binding editor dialog

### DIFF
--- a/OpenTabletDriver.UX/Windows/Bindings/AdvancedBindingEditorDialog.cs
+++ b/OpenTabletDriver.UX/Windows/Bindings/AdvancedBindingEditorDialog.cs
@@ -72,6 +72,7 @@ namespace OpenTabletDriver.UX.Windows.Bindings
 
             bindingTypeDropDown.SelectedItemBinding.Convert(t => new PluginSettingStore(t)).Bind(settingStoreEditor.StoreBinding);
             bindingTypeDropDown.SelectedItem = currentBinding?.GetTypeInfo();
+            settingStoreEditor.Store = currentBinding;
         }
 
         private TypeDropDown<IBinding> bindingTypeDropDown;


### PR DESCRIPTION
Imagine this scenario : 

The user spends some time changing settings for a binding (Scroll Binding for example)

![image](https://github.com/user-attachments/assets/2e60e228-cb55-4594-918f-ef8421443834)

Then they Apply those settings. Suddenly they realize they made a mistake, and need to change a settings, they open back the advanced binding editor to this : 

![image](https://github.com/user-attachments/assets/6db6f694-91eb-4936-9ce3-3a8920c61d45)

The settings are gone, they have to set everything back by hand.

That scenario has been me a dozen of times while testing as well as my users (and probably more users outside of just my plugins)