### PR TITLE
Add identifier and fix dimensions to Huion RTP-700

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/RTP-700.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/RTP-700.json
@@ -2,10 +2,10 @@
   "Name": "Huion RTP-700",
   "Specifications": {
     "Digitizer": {
-      "Width": 279.395,
-      "Height": 174.495,
-      "MaxX": 55879,
-      "MaxY": 34899
+      "Width": 279.4,
+      "Height": 174.6,
+      "MaxX": 55880,
+      "MaxY": 34920
     },
     "Pen": {
       "MaxPressure": 8191,
@@ -19,6 +19,18 @@
     {
       "VendorID": 9580,
       "ProductID": 109,
+      "InputReportLength": 12,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
+      "DeviceStrings": {
+        "201": "HUION_T19k_\\d{6}$"
+      },
+      "InitializationStrings": [
+        200
+      ]
+    },
+    {
+      "VendorID": 9580,
+      "ProductID": 100,
       "InputReportLength": 12,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
       "DeviceStrings": {


### PR DESCRIPTION
Investigating with a user on [Discord](https://discord.com/channels/615607687467761684/723399565780189234/1321209010795577365) we noticed that this needs a new identifier and that the max x and y can actually be higher.

It now lines up exactly as the huion page says.
https://www.huion.com/pen_tablet/Inspiroy/RTP700.html
![image](https://github.com/user-attachments/assets/7b96b019-3340-45d4-94b6-910b787be414)
