### PR TITLE
Add support for 16k pressure variant of Gaomon M8

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M8 (Variant 2).json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M8 (Variant 2).json
@@ -1,0 +1,35 @@
+{
+  "Name": "Gaomon M8 (Variant 2)",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 258.465,
+      "Height": 161.535,
+      "MaxX": 51693,
+      "MaxY": 32307
+    },
+    "Pen": {
+      "MaxPressure": 16383,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 9
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 9580,
+      "ProductID": 100,
+      "InputReportLength": 12,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicV2ReportParser",
+      "DeviceStrings": {
+        "201": "GM001_T221_\\d{6}$"
+      },
+      "InitializationStrings": [
+        200
+      ]
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}


### PR DESCRIPTION
Verification: https://discord.com/channels/615607687467761684/723399565780189234/1321114298243747964

Identical to other M8 config but new string and higher pressure.