### PR TITLE
config/Huion Kamvas Pro 13: Add an additional device string

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 13.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 13.json
@@ -24,7 +24,7 @@
       "InputReportLength": 12,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
       "DeviceStrings": {
-        "201": "HUION_M182_\\d{6}$"
+        "201": "HUION_M(182|20k)_\\d{6}$"
       },
       "InitializationStrings": [
         200


### PR DESCRIPTION
Adds a new device string supplied by a Discord user. [Discord Verification](https://discord.com/channels/615607687467761684/723399565780189234/1322695019064459335)

~~Leaving as draft because I'm awaiting confirmation on dimensions, they seem weird.~~ [confirmed](https://discord.com/channels/615607687467761684/723399565780189234/1322698442413183087)