### PR TITLE
Fix tilt for Huion H1061P

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/H1061P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H1061P.json
@@ -20,7 +20,7 @@
       "VendorID": 9580,
       "ProductID": 104,
       "InputReportLength": 12,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
       "DeviceStrings": {
         "201": "HUION_T21m_\\d{6}$"
       },


### PR DESCRIPTION
Use UCLogicTiltReportParser instead of UCLogicReportParser.

Confirmed on my tablet that tilt works with this change.

Thanks.