### PR TITLE
Add wireless support for Wacom CTC-6110WL

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTC-6110WL.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTC-6110WL.json
@@ -21,6 +21,15 @@
       "FeatureInitReport": [
         "AgI="
       ]
+    },
+    {
+      "VendorID": 1329,
+      "ProductID": 259,
+      "InputReportLength": 19,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV3.IntuosV3ReportParser",
+      "FeatureInitReport": [
+        "AgI="
+      ]
     }
   ]
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV3/IntuosV3ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV3/IntuosV3ReportParser.cs
@@ -8,7 +8,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV3
         {
             return data[0] switch
             {
-                0x1F => new IntuosV3Report(data),
+                0x1F => data[1] == 0x01 ? new IntuosV3Report(data) : new DeviceReport(data),
                 _ => new DeviceReport(data)
             };
         }


### PR DESCRIPTION
Add wireless (Bluetooth) support for Wacom CTC-6110WL. Wireless variant have product ID of 259 when connected using Bluetooth, comparing to product ID 258 when connected using cable.

The tablet when connected using Bluetooth always send a report every second while idling, which is why I changed `IntuosV3ReportParser` to prevent the cursor from teleporting to top-left corner.

Confirmed working with my CTC-6110WL on Windows 11. I don't have CTC-4110WL to test wireless.