### PR TITLE
Fix the problem debugging on Macos requiring app bundle

### DIFF
--- a/OpenTabletDriver.UX.Gtk/LinuxApp.cs
+++ b/OpenTabletDriver.UX.Gtk/LinuxApp.cs
@@ -9,7 +9,7 @@ namespace OpenTabletDriver.UX.Gtk
     {
         private Process? _daemon;
 
-        public LinuxApp(string[] args) : base(Platforms.Gtk, args)
+        public LinuxApp(string[] args) : base(new Eto.GtkSharp.Platform(), args)
         {
         }
 

--- a/OpenTabletDriver.UX.MacOS/MacOSApp.cs
+++ b/OpenTabletDriver.UX.MacOS/MacOSApp.cs
@@ -8,7 +8,7 @@ namespace OpenTabletDriver.UX.MacOS
     {
         private Process? _daemon;
 
-        public MacOSApp(string[] args) : base(Platforms.Mac64, args)
+        public MacOSApp(string[] args) : base(new Eto.Mac.Platform(), args)
         {
         }
 

--- a/OpenTabletDriver.UX.Wpf/WindowsApp.cs
+++ b/OpenTabletDriver.UX.Wpf/WindowsApp.cs
@@ -8,7 +8,7 @@ namespace OpenTabletDriver.UX.Wpf
     {
         private Process? _daemon;
 
-        public WindowsApp(string[] args) : base(Platforms.Wpf, args)
+        public WindowsApp(string[] args) : base(new Eto.Wpf.Platform(), args)
         {
         }
 

--- a/OpenTabletDriver.UX/App.cs
+++ b/OpenTabletDriver.UX/App.cs
@@ -20,7 +20,7 @@ namespace OpenTabletDriver.UX
     [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
     public abstract class App : NotifyPropertyChanged
     {
-        protected App(string platform, string[] args)
+        protected App(Eto.Platform platform, string[] args)
         {
             Platform = platform;
             Arguments = args;
@@ -100,7 +100,7 @@ namespace OpenTabletDriver.UX
         /// <summary>
         /// The <see cref="Eto.Platform"/> this app was built with.
         /// </summary>
-        public string Platform { get; }
+        public Eto.Platform Platform { get; }
 
         /// <summary>
         /// The command line arguments passed to the app.


### PR DESCRIPTION
When debugging by launching the UX.Mac project in Rider, it throwed an error about needing to be an app bundle. This occured only when providing the platform with a string instead of the Eto.Platform class.

I replaced these with the actual platform instance.