### PR TITLE
[06x] UX: Rewrite FileDialog directory checks

### DIFF
--- a/OpenTabletDriver.UX/Extensions.cs
+++ b/OpenTabletDriver.UX/Extensions.cs
@@ -68,7 +68,7 @@ namespace OpenTabletDriver.UX
             return tablets.FirstOrDefault(t => t.Properties.Name == profile.Tablet);
         }
 
-        #nullable enable
+#nullable enable
 
         public static T BuildFileDialog<T>(string? title, string? directory, IEnumerable<FileFilter>? filters, bool? multiSelect = null)
             where T : FileDialog, new()
@@ -86,7 +86,7 @@ namespace OpenTabletDriver.UX
                 fileDialog.Title = dialogTitle;
 
             if (filters != null)
-                fileDialog.AddRangeToFilters(filters);;
+                fileDialog.AddRangeToFilters(filters);
 
             if (!string.IsNullOrEmpty(directory))
                 fileDialog.Directory = new Uri(directory);

--- a/OpenTabletDriver.UX/Extensions.cs
+++ b/OpenTabletDriver.UX/Extensions.cs
@@ -65,5 +65,36 @@ namespace OpenTabletDriver.UX
             var tablets = await App.Driver.Instance.GetTablets();
             return tablets.FirstOrDefault(t => t.Properties.Name == profile.Tablet);
         }
+
+        public static SaveFileDialog SaveFileDialog(string title, string directory, FileFilter[] filters)
+        {
+            var fileDialog = new SaveFileDialog();
+
+            SetupFileDialog(fileDialog, title, directory, filters, "Save File");
+
+            return fileDialog;
+        }
+
+        public static OpenFileDialog OpenFileDialog(string title, string directory, FileFilter[] filters, bool multiSelect = false)
+        {
+            var fileDialog = new OpenFileDialog();
+
+            SetupFileDialog(fileDialog, title, directory, filters, "Open File");
+            fileDialog.MultiSelect = multiSelect;
+
+            return fileDialog;
+        }
+
+        private static void SetupFileDialog(FileDialog fileDialog, string title, string directory, FileFilter[] filters, string defaultTitle)
+        {
+            fileDialog.Title = !string.IsNullOrEmpty(title) ? title : defaultTitle;
+
+            if (filters != null)
+                foreach (var filter in filters)
+                    fileDialog.Filters.Add(filter);
+
+            if (!string.IsNullOrEmpty(directory))
+                fileDialog.Directory = new Uri(directory);
+        }
     }
 }

--- a/OpenTabletDriver.UX/Extensions.cs
+++ b/OpenTabletDriver.UX/Extensions.cs
@@ -70,7 +70,7 @@ namespace OpenTabletDriver.UX
 
         #nullable enable
 
-        public static T BuildFileDialog<T>(string? title, string? directory, FileFilter[]? filters, bool? multiSelect = null)
+        public static T BuildFileDialog<T>(string? title, string? directory, IEnumerable<FileFilter>? filters, bool? multiSelect = null)
             where T : FileDialog, new()
         {
             var fileDialog = new T();
@@ -99,10 +99,10 @@ namespace OpenTabletDriver.UX
             return fileDialog;
         }
 
-        public static OpenFileDialog OpenFileDialog(string? title, string? directory, FileFilter[]? filters, bool? multiSelect = null) =>
+        public static OpenFileDialog OpenFileDialog(string? title, string? directory, IEnumerable<FileFilter>? filters, bool? multiSelect = null) =>
             BuildFileDialog<OpenFileDialog>(title, directory, filters, multiSelect);
 
-        public static SaveFileDialog SaveFileDialog(string? title, string? directory, FileFilter[]? filters) =>
+        public static SaveFileDialog SaveFileDialog(string? title, string? directory, IEnumerable<FileFilter>? filters) =>
             BuildFileDialog<SaveFileDialog>(title, directory, filters);
 
         public static void AddRangeToFilters(this FileDialog fileDialog, IEnumerable<FileFilter> filters)

--- a/OpenTabletDriver.UX/Extensions.cs
+++ b/OpenTabletDriver.UX/Extensions.cs
@@ -66,6 +66,8 @@ namespace OpenTabletDriver.UX
             return tablets.FirstOrDefault(t => t.Properties.Name == profile.Tablet);
         }
 
+        #nullable enable
+
         public static SaveFileDialog SaveFileDialog(string title, string directory, FileFilter[] filters)
         {
             var fileDialog = new SaveFileDialog();

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -450,15 +450,12 @@ namespace OpenTabletDriver.UX
 
         private async Task LoadSettingsDialog()
         {
-            var fileDialog = new OpenFileDialog
-            {
-                Title = "Load OpenTabletDriver settings...",
-                Directory = new Uri(Eto.EtoEnvironment.GetFolderPath(Eto.EtoSpecialFolder.Documents)),
-                Filters =
-                {
-                    new FileFilter("OpenTabletDriver Settings (*.json)", ".json")
-                }
-            };
+            var fileDialog = Extensions.OpenFileDialog(
+                "Load OpenTabletDriver settings...",
+                Eto.EtoEnvironment.GetFolderPath(Eto.EtoSpecialFolder.Documents),
+                [new FileFilter("OpenTabletDriver Settings (*.json)", ".json")]
+            );
+
             switch (fileDialog.ShowDialog(this))
             {
                 case DialogResult.Ok:
@@ -485,15 +482,12 @@ namespace OpenTabletDriver.UX
 
         private async Task SaveSettingsDialog()
         {
-            var fileDialog = new SaveFileDialog
-            {
-                Title = "Save OpenTabletDriver settings...",
-                Directory = new Uri(Eto.EtoEnvironment.GetFolderPath(Eto.EtoSpecialFolder.Documents)),
-                Filters =
-                {
-                    new FileFilter("OpenTabletDriver Settings (*.json)", ".json")
-                }
-            };
+            var fileDialog = Extensions.SaveFileDialog(
+                "Save OpenTabletDriver settings...",
+                Eto.EtoEnvironment.GetFolderPath(Eto.EtoSpecialFolder.Documents),
+                [new FileFilter("OpenTabletDriver Settings (*.json)", ".json")]
+            );
+
             switch (fileDialog.ShowDialog(this))
             {
                 case DialogResult.Ok:
@@ -599,15 +593,12 @@ namespace OpenTabletDriver.UX
 
         private async Task SavePresetDialog()
         {
-            var fileDialog = new SaveFileDialog
-            {
-                Title = "Save OpenTabletDriver settings as preset...",
-                Directory = new Uri(AppInfo.Current.PresetDirectory),
-                Filters =
-                {
-                    new FileFilter("OpenTabletDriver Settings (*.json)", ".json")
-                }
-            };
+            var fileDialog = Extensions.SaveFileDialog(
+                "Save OpenTabletDriver settings as preset...",
+                AppInfo.Current.PresetDirectory,
+                [new FileFilter("OpenTabletDriver Settings (*.json)", ".json")]
+            );
+
             switch (fileDialog.ShowDialog(this))
             {
                 case DialogResult.Ok:
@@ -641,15 +632,12 @@ namespace OpenTabletDriver.UX
             {
                 var log = await Driver.Instance.GetCurrentLog();
                 var diagnosticDump = new DiagnosticInfo(log, await Driver.Instance.GetDevices());
-                var fileDialog = new SaveFileDialog
-                {
-                    Title = "Save diagnostic information to...",
-                    Directory = new Uri(Eto.EtoEnvironment.GetFolderPath(Eto.EtoSpecialFolder.Documents)),
-                    Filters =
-                    {
-                        new FileFilter("Diagnostic information", ".json")
-                    }
-                };
+                var fileDialog = Extensions.SaveFileDialog(
+                    "Save diagnostic information to...",
+                    Eto.EtoEnvironment.GetFolderPath(Eto.EtoSpecialFolder.Documents),
+                    [new FileFilter("Diagnostic information", ".json")]
+                );
+
                 switch (fileDialog.ShowDialog(this))
                 {
                     case DialogResult.Ok:

--- a/OpenTabletDriver.UX/Windows/DeviceStringReader.cs
+++ b/OpenTabletDriver.UX/Windows/DeviceStringReader.cs
@@ -112,15 +112,11 @@ namespace OpenTabletDriver.UX.Windows
                     return;
             }
 
-            var fileDialog = new SaveFileDialog
-            {
-                Title = "Save string dump to...",
-                Directory = new Uri(Eto.EtoEnvironment.GetFolderPath(Eto.EtoSpecialFolder.Documents)),
-                Filters =
-                {
-                    new FileFilter("String dump", ".txt")
-                }
-            };
+            var fileDialog = Extensions.SaveFileDialog(
+                "Save string dump to...",
+                Eto.EtoEnvironment.GetFolderPath(Eto.EtoSpecialFolder.Documents),
+                [new FileFilter("String dump", ".txt")]
+            );
 
             switch (fileDialog.ShowDialog(this))
             {

--- a/OpenTabletDriver.UX/Windows/Plugins/PluginManagerWindow.cs
+++ b/OpenTabletDriver.UX/Windows/Plugins/PluginManagerWindow.cs
@@ -170,16 +170,12 @@ namespace OpenTabletDriver.UX.Windows.Plugins
             if (!this.ParentWindow.Enabled)
                 return;
 
-            var dialog = new OpenFileDialog()
-            {
-                Title = "Choose a plugin to install...",
-                Directory = new Uri(Eto.EtoEnvironment.GetFolderPath(Eto.EtoSpecialFolder.Documents)),
-                MultiSelect = true,
-                Filters =
-                {
-                    new FileFilter("Plugin (.zip, .dll)", ".zip", ".dll")
-                }
-            };
+            var dialog = Extensions.OpenFileDialog(
+                "Choose a plugin to install...",
+                Eto.EtoEnvironment.GetFolderPath(Eto.EtoSpecialFolder.Documents),
+                [new FileFilter("Plugin (.zip, .dll)", ".zip", ".dll")],
+                true
+            );
 
             if (dialog.ShowDialog(this) == DialogResult.Ok)
             {


### PR DESCRIPTION
Fixes #3668 for 0.6.x

Previously, we assumed that `Eto.EtoEnvironment.GetFolderPath` would never return an empty string. It is however apparent that this is actually the case on some systems, seen on both Windows and Linux.

Constructing URI's with an empty string throws an exception, which this commit attempts to avoid. It was not an option to simply wrap the `Uri` constructor, as `Directory` in `SaveFileDialog`/`OpenFileDialog` must only be set if it is a valid Uri, so instead the `SaveFileDialog`/`OpenFileDialog` Eto constructor has been moved to a wrapper method internal to the project.