### PR TITLE
[0.6.x] Fix NullReferenceException when settings with missing output mode area are loaded

### DIFF
--- a/OpenTabletDriver.UX/Controls/Output/OutputModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/OutputModeEditor.cs
@@ -118,9 +118,8 @@ namespace OpenTabletDriver.UX.Controls.Output
         {
             bool showAbsolute = false;
             bool showRelative = false;
-            if (store != null)
+            if (store?.GetTypeInfo<IOutputMode>() is TypeInfo outputMode)
             {
-                var outputMode = store.GetTypeInfo<IOutputMode>();
                 showAbsolute = outputMode.IsSubclassOf(typeof(AbsoluteOutputMode));
                 showRelative = outputMode.IsSubclassOf(typeof(RelativeOutputMode));
             }

--- a/OpenTabletDriver.UX/Controls/Output/OutputModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/OutputModeEditor.cs
@@ -69,6 +69,7 @@ namespace OpenTabletDriver.UX.Controls.Output
         {
             ProfileChanged?.Invoke(this, new EventArgs());
             UpdateTablet();
+            UpdateOutputMode(Profile?.OutputMode);
         }
 
         public BindableBinding<OutputModeEditor, Profile> ProfileBinding
@@ -89,6 +90,7 @@ namespace OpenTabletDriver.UX.Controls.Output
         private AbsoluteModeEditor absoluteModeEditor = new AbsoluteModeEditor();
         private RelativeModeEditor relativeModeEditor = new RelativeModeEditor();
         private TypeDropDown<IOutputMode> outputModeSelector = new TypeDropDown<IOutputMode> { Width = 300 };
+        private Label outputModeUnsupported = new Label { Text = "No supported output mode selected.", TextAlignment = TextAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
 
         public void SetTabletSize(TabletReference tablet)
         {
@@ -128,6 +130,8 @@ namespace OpenTabletDriver.UX.Controls.Output
                 editorContainer.Content = absoluteModeEditor;
             else if (showRelative)
                 editorContainer.Content = relativeModeEditor;
+            else
+                editorContainer.Content = outputModeUnsupported;
         }
     }
 }


### PR DESCRIPTION
Fixes #3671
Also fixes the same issue with Profiles (They are just Settings files)

Needs testing.

Steps to reproduce :

1. Duplicate your current settings file
2. Write anything that isn't a valid output mode in `Path` for the active output mode
3. Try loading that setting file in.