### PR TITLE
Candidate fix for Wacom Graphire AUX buttons.

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-430.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-430.json
@@ -20,7 +20,7 @@
       "VendorID": 1386,
       "ProductID": 19,
       "InputReportLength": 8,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Graphire.GraphireReportParser",
       "FeatureInitReport": [
         "AgI="
       ]

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-440.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-440.json
@@ -23,13 +23,13 @@
       "VendorID": 1386,
       "ProductID": 21,
       "InputReportLength": 9,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser"
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Graphire.GraphireReportParser"
     },
     {
       "VendorID": 1386,
       "ProductID": 21,
       "InputReportLength": 8,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Graphire.GraphireReportParser",
       "FeatureInitReport": [
         "AgI="
       ]

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-630.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-630.json
@@ -20,7 +20,7 @@
       "VendorID": 1386,
       "ProductID": 20,
       "InputReportLength": 8,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Graphire.GraphireReportParser",
       "FeatureInitReport": [
         "AgI="
       ]

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/ET-0405-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/ET-0405-U.json
@@ -17,7 +17,7 @@
       "VendorID": 1386,
       "ProductID": 16,
       "InputReportLength": 8,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Graphire.GraphireReportParser",
       "FeatureInitReport": [
         "AgI="
       ]

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/ET-0405A-U.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/ET-0405A-U.json
@@ -20,7 +20,7 @@
       "VendorID": 1386,
       "ProductID": 17,
       "InputReportLength": 8,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Graphire.GraphireReportParser",
       "FeatureInitReport": [
         "AgI="
       ]

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Graphire/GraphireAuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Graphire/GraphireAuxReport.cs
@@ -1,0 +1,24 @@
+using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Wacom.Graphire
+{
+    public struct GraphireAuxReport : IAuxReport
+    {
+        public GraphireAuxReport(byte[] report)
+        {
+            Raw = report;
+
+            var auxByte = report[7];
+            AuxButtons = new bool[]
+            {
+                auxByte.IsBitSet(6),
+                auxByte.IsBitSet(7),
+            };
+
+            // wheel = report[7][5:3]
+        }
+
+        public byte[] Raw { set; get; }
+        public bool[] AuxButtons { set; get; }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Graphire/GraphireMouseReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Graphire/GraphireMouseReport.cs
@@ -1,0 +1,49 @@
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Wacom.Graphire
+{
+    public struct GraphireMouseReport : IMouseReport, IAuxReport
+    {
+        public GraphireMouseReport(byte[] report)
+        {
+            Raw = report;
+
+            Position = new Vector2
+            {
+                X = Unsafe.ReadUnaligned<ushort>(ref report[2]),
+                Y = Unsafe.ReadUnaligned<ushort>(ref report[4])
+            };
+
+            Scroll = new Vector2
+            {
+                Y = report[7].IsBitSet(1) ? -(report[7] & 1) : report[7] & 1
+            };
+
+            MouseButtons = new bool[]
+            {
+                report[1].IsBitSet(0), // LEFT
+                report[1].IsBitSet(1), // RIGHT
+                report[1].IsBitSet(2)  // MIDDLE
+            };
+
+            var auxByte = report[7];
+            AuxButtons = new bool[]
+            {
+                auxByte.IsBitSet(6),
+                auxByte.IsBitSet(7),
+            };
+
+            // wheel = report[7][5:3]
+
+            // Models using Graphire WACOM_MO protocol also reports mouse hover distance
+        }
+
+        public byte[] Raw { get; set; }
+        public bool[] MouseButtons { get; set; }
+        public Vector2 Position { get; set; }
+        public Vector2 Scroll { get; set; }
+        public bool[] AuxButtons { get; set; }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Graphire/GraphireReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Graphire/GraphireReportParser.cs
@@ -1,0 +1,35 @@
+using System.Runtime.CompilerServices;
+using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Wacom.Graphire
+{
+    public class GraphireReportParser : IReportParser<IDeviceReport>
+    {
+        public IDeviceReport Parse(byte[] report)
+        {
+            return report[0] switch
+            {
+                0x02 => GetToolReport(report),
+                _ => new DeviceReport(report)
+            };
+        }
+
+        private static IDeviceReport GetToolReport(byte[] report)
+        {
+            // If position is available
+            if (report[1].IsBitSet(7)
+                || Unsafe.ReadUnaligned<uint>(ref report[2]) != 0
+                || (report[6] | ((report[7] & 0x03) << 8)) != 0)
+            {
+                if (report[1].IsBitSet(6))
+                {
+                    return new GraphireMouseReport(report);
+                }
+
+                return new GraphireTabletReport(report);
+            }
+
+            return new GraphireAuxReport(report);
+        }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Graphire/GraphireTabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Graphire/GraphireTabletReport.cs
@@ -1,0 +1,48 @@
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Wacom.Graphire
+{
+    public struct GraphireTabletReport : ITabletReport, IAuxReport, IEraserReport, IConfidenceReport
+    {
+        public GraphireTabletReport(byte[] report)
+        {
+            Raw = report;
+
+            Position = new Vector2
+            {
+                X = Unsafe.ReadUnaligned<ushort>(ref report[2]),
+                Y = Unsafe.ReadUnaligned<ushort>(ref report[4])
+            };
+
+            Pressure = report[1].IsBitSet(0) ? (uint)(report[6] | ((report[7] & 0x03) << 8)) : 0;
+            Eraser = report[1].IsBitSet(5);
+
+            PenButtons = new bool[]
+            {
+                report[1].IsBitSet(1),
+                report[1].IsBitSet(2)
+            };
+
+            var auxByte = report[7];
+            AuxButtons = new bool[]
+            {
+                auxByte.IsBitSet(6),
+                auxByte.IsBitSet(7),
+            };
+
+            // wheel = report[7][5:3]
+
+            HighConfidence = report[1].IsBitSet(7);
+        }
+
+        public byte[] Raw { set; get; }
+        public Vector2 Position { set; get; }
+        public uint Pressure { set; get; }
+        public bool[] PenButtons { set; get; }
+        public bool[] AuxButtons { set; get; }
+        public bool Eraser { set; get; }
+        public bool HighConfidence { set; get; }
+    }
+}


### PR DESCRIPTION
To address https://github.com/OpenTabletDriver/OpenTabletDriver/issues/2992

This fix has been tested with a CTE-430 (no aux buttons) and a CTE-440 (2 buttons and scroll wheel). Configuration for models CTE-630, ET-0405* have also been updated but not tested.

Mapping of scrollwheel to AuxButtons report has been removed, but affected raw bits are noted in the source.