### PR TITLE
Add partial support for Wacom DTH-135

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTH-135.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTH-135.json
@@ -1,0 +1,26 @@
+{
+  "Name": "Wacom Movink 13 (DTH-135)",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 297.76,
+      "Height": 169.24,
+      "MaxX": 59552,
+      "MaxY": 33848
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ButtonCount": 3
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 1386,
+      "ProductID": 1008,
+      "InputReportLength": 192,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV3.IntuosV3ReportParser",
+      "FeatureInitReport": [
+        "AgI="
+      ]
+    }
+  ]
+}

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV3/IntuosV3ExtendedReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV3/IntuosV3ExtendedReport.cs
@@ -1,0 +1,48 @@
+﻿using System.Numerics;
+using System.Runtime.CompilerServices;
+using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV3
+{
+    public struct IntuosV3ExtendedReport : ITabletReport, IHoverReport, IConfidenceReport, ITiltReport, IEraserReport
+    {
+        public IntuosV3ExtendedReport(byte[] report)
+        {
+            Raw = report;
+
+            Position = new Vector2
+            {
+                X = Unsafe.ReadUnaligned<ushort>(ref report[3]) | report[5] << 16,
+                Y = Unsafe.ReadUnaligned<ushort>(ref report[6]) | report[8] << 16
+            };
+
+            Tilt = new Vector2
+            {
+                X = Unsafe.ReadUnaligned<short>(ref report[11]),
+                Y = Unsafe.ReadUnaligned<short>(ref report[13])
+            };
+
+            Pressure = Unsafe.ReadUnaligned<ushort>(ref report[9]);
+
+            var penByte = report[2];
+            PenButtons = new bool[]
+            {
+                penByte.IsBitSet(1),
+                penByte.IsBitSet(2),
+                penByte.IsBitSet(3)
+            };
+            Eraser = report[2].IsBitSet(5);
+            HighConfidence = report[2].IsBitSet(6);
+            HoverDistance = report[19];
+        }
+
+        public byte[] Raw { set; get; }
+        public Vector2 Position { set; get; }
+        public Vector2 Tilt { set; get; }
+        public uint Pressure { set; get; }
+        public bool[] PenButtons { set; get; }
+        public bool HighConfidence { set; get; }
+        public uint HoverDistance { set; get; }
+        public bool Eraser { get; set; }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV3/IntuosV3ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV3/IntuosV3ReportParser.cs
@@ -8,6 +8,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV3
         {
             return data[0] switch
             {
+                0x1E => new IntuosV3ExtendedReport(data),
                 0x1F => data[1] == 0x01 ? new IntuosV3Report(data) : new DeviceReport(data),
                 _ => new DeviceReport(data)
             };

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -239,6 +239,7 @@
 | Wacom CTH-461                 |  Missing Features | Tablet buttons and touch are not yet supported.
 | Wacom CTL-6100WL              |  Missing Features | Wireless is not yet supported.
 | Wacom DTH-1320                |  Missing Features | Touch is not yet supported.
+| Wacom DTH-135                 |  Missing Features | Touch is not yet supported.
 | Wacom DTH-271                 |  Missing Features | Aux buttons are not yet supported.
 | Wacom DTK-1300                |  Missing Features | Center button is not yet supported.
 | Wacom DTK-2200                |  Missing Features | Touch Strips are not yet supported.


### PR DESCRIPTION
- Diagnostics: [diagnostics-macos.json](https://github.com/user-attachments/files/18443415/diagnostics-macos.json)
  + Tester requested both username and serial number to be redacted.
- Tablet recording data:
  + Pro Pen 3: [tablet-data (1).txt](https://github.com/user-attachments/files/18443389/tablet-data.1.txt)
  + Pro Pen 2: [tablet-data-pp2.txt](https://github.com/user-attachments/files/18443395/tablet-data-pp2.txt)
- Missing feature: Touch
- External resources:
  + [HID Descriptor for pen digitizer (linuxwacom/wacom-hid-descriptors)](https://github.com/linuxwacom/wacom-hid-descriptors/blob/master/Wacom%20Movink%20DTH135K0C/sysinfo.4XIn8KkXzp/0003%3A056A%3A03F0.000D.hid.txt)
  + [Discord thread on 7P's server](https://discord.com/channels/1242714066917523456/1328863013582803024)