### PR TITLE
Add linux support to Huion H610 Pro V3

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/H610 Pro V3.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H610 Pro V3.json
@@ -21,9 +21,19 @@
       "DeviceStrings": {
         "121": "^HA60$"
       }
+    },
+    {
+      "VendorID": 9580,
+      "ProductID": 110,
+      "InputReportLength": 8,
+      "ReportParser": "OpenTabletDriver.Tablet.TabletReportParser",
+      "DeviceStrings": {
+        "121": "^HA60$"
+      }
     }
   ],
   "Attributes": {
-    "libinputoverride": "1"
+    "libinputoverride": "1",
+    "Interface": "1"
   }
 }


### PR DESCRIPTION
As WinUSB changes the identifiers to 16, the current config doesn't work on other platforms than Windows.The correct interface is grabbed from the TABLETS.md, so this change shouldn't break anything.