### PR TITLE
[06x] conf/Parblo A610: Add interface

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Parblo/A610.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/A610.json
@@ -29,7 +29,10 @@
       "InitializationStrings": [
         100,
         123
-      ]
+      ],
+      "Attributes": {
+        "Interface": "0"
+      }
     }
   ],
   "Attributes": {


### PR DESCRIPTION
Fixes inconsistent detection on Linux

Unsure if this has side effects on Windows

(should probably do a pass over configs which have a WinUSB interface specified in TABLETS.md at some point)