### PR TITLE
[06x] CTH-*61: Add auxiliary key support

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-461.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-461.json
@@ -60,19 +60,19 @@
       "VendorID": 1386,
       "ProductID": 210,
       "InputReportLength": 20,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.BambooV2AuxReportParser"
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.BambooV2.BambooV2AuxReportParser"
     },
     {
       "VendorID": 1386,
       "ProductID": 215,
       "InputReportLength": 20,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.BambooV2AuxReportParser"
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.BambooV2.BambooV2AuxReportParser"
     },
     {
       "VendorID": 1386,
       "ProductID": 218,
       "InputReportLength": 20,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.BambooV2AuxReportParser"
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.BambooV2.BambooV2AuxReportParser"
     }
   ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-461.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-461.json
@@ -61,6 +61,18 @@
       "ProductID": 210,
       "InputReportLength": 20,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosAuxReportParser"
+    },
+    {
+      "VendorID": 1386,
+      "ProductID": 215,
+      "InputReportLength": 20,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosAuxReportParser"
+    },
+    {
+      "VendorID": 1386,
+      "ProductID": 218,
+      "InputReportLength": 20,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosAuxReportParser"
     }
   ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-461.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-461.json
@@ -54,5 +54,13 @@
         "AgI="
       ]
     }
+  ],
+  "AuxilaryDeviceIdentifiers": [
+    {
+      "VendorID": 1386,
+      "ProductID": 210,
+      "InputReportLength": 20,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosAuxReportParser"
+    }
   ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-461.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-461.json
@@ -60,19 +60,19 @@
       "VendorID": 1386,
       "ProductID": 210,
       "InputReportLength": 20,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosAuxReportParser"
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.BambooV2AuxReportParser"
     },
     {
       "VendorID": 1386,
       "ProductID": 215,
       "InputReportLength": 20,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosAuxReportParser"
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.BambooV2AuxReportParser"
     },
     {
       "VendorID": 1386,
       "ProductID": 218,
       "InputReportLength": 20,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosAuxReportParser"
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.BambooV2AuxReportParser"
     }
   ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-661.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-661.json
@@ -60,19 +60,19 @@
       "VendorID": 1386,
       "ProductID": 211,
       "InputReportLength": 20,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosAuxReportParser"
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.BambooV2AuxReportParser"
     },
     {
       "VendorID": 1386,
       "ProductID": 216,
       "InputReportLength": 20,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosAuxReportParser"
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.BambooV2AuxReportParser"
     },
     {
       "VendorID": 1386,
       "ProductID": 219,
       "InputReportLength": 20,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosAuxReportParser"
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.BambooV2AuxReportParser"
     }
   ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-661.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-661.json
@@ -54,5 +54,13 @@
         "AgI="
       ]
     }
+  ],
+  "AuxilaryDeviceIdentifiers": [
+    {
+      "VendorID": 1386,
+      "ProductID": 211,
+      "InputReportLength": 20,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosAuxReportParser"
+    }
   ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-661.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-661.json
@@ -60,19 +60,19 @@
       "VendorID": 1386,
       "ProductID": 211,
       "InputReportLength": 20,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.BambooV2AuxReportParser"
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.BambooV2.BambooV2AuxReportParser"
     },
     {
       "VendorID": 1386,
       "ProductID": 216,
       "InputReportLength": 20,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.BambooV2AuxReportParser"
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.BambooV2.BambooV2AuxReportParser"
     },
     {
       "VendorID": 1386,
       "ProductID": 219,
       "InputReportLength": 20,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.BambooV2AuxReportParser"
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.BambooV2.BambooV2AuxReportParser"
     }
   ]
 }

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-661.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-661.json
@@ -61,6 +61,18 @@
       "ProductID": 211,
       "InputReportLength": 20,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosAuxReportParser"
+    },
+    {
+      "VendorID": 1386,
+      "ProductID": 216,
+      "InputReportLength": 20,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosAuxReportParser"
+    },
+    {
+      "VendorID": 1386,
+      "ProductID": 219,
+      "InputReportLength": 20,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosAuxReportParser"
     }
   ]
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/BambooV2/BambooV2AuxReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/BambooV2/BambooV2AuxReportParser.cs
@@ -1,9 +1,9 @@
 using OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2;
 using OpenTabletDriver.Plugin.Tablet;
 
-namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos
+namespace OpenTabletDriver.Configurations.Parsers.Wacom.BambooV2
 {
-    public class IntuosAuxReportParser : IReportParser<IDeviceReport>
+    public class BambooV2AuxReportParser : IReportParser<IDeviceReport>
     {
         public virtual IDeviceReport Parse(byte[] data)
         {

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos/IntuosAuxReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos/IntuosAuxReportParser.cs
@@ -1,5 +1,5 @@
-using OpenTabletDriver.Plugin.Tablet;
 using OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2;
+using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos
 {

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos/IntuosAuxReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos/IntuosAuxReportParser.cs
@@ -1,0 +1,17 @@
+using OpenTabletDriver.Plugin.Tablet;
+using OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2;
+
+namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos
+{
+    public class IntuosAuxReportParser : IReportParser<IDeviceReport>
+    {
+        public virtual IDeviceReport Parse(byte[] data)
+        {
+            return data[0] switch
+            {
+                0x02 => new IntuosV2AuxReport(data),
+                _ => new DeviceReport(data),
+            };
+        }
+    }
+}


### PR DESCRIPTION
This adds a new aux report parser, but the report matches the offset on IntuosV2AuxReport, so we reuse that

Fixes #3692

[Discord verification](https://discord.com/channels/615607687467761684/723399565780189234/1330557683144851468)

Example output from a CTH-661:
```
{ 02 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 }
{ 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 }
{ 02 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 }
{ 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 }
{ 02 04 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 }
{ 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 }
{ 02 08 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 }
{ 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 }
```

diag HID devices:
```
    {
      "DevicePath": "/sys/devices/pci0000:00/0000:00:14.0/usb1/1-6/1-6:1.1/0003:056A:00D3.000D/hidraw/hidraw10",
      "Manufacturer": "Wacom Co.,Ltd.",
      "ProductName": "CTH-661",
      "SerialNumber": "",
      "FriendlyName": "CTH-661",
      "VendorID": 1386,
      "ProductID": 211,
      "InputReportLength": 20,
      "OutputReportLength": 0,
      "FeatureReportLength": 0,
      "CanOpen": true,
      "DeviceAttributes": {
        "USB_INTERFACE_NUMBER": "1",
        "HID_REPORTS": "02:FF00:0001"
      }
    },
    {
      "DevicePath": "/sys/devices/pci0000:00/0000:00:14.0/usb1/1-6/1-6:1.0/0003:056A:00D3.000C/hidraw/hidraw9",
      "Manufacturer": "Wacom Co.,Ltd.",
      "ProductName": "CTH-661",
      "SerialNumber": "",
      "FriendlyName": "CTH-661",
      "VendorID": 1386,
      "ProductID": 211,
      "InputReportLength": 9,
      "OutputReportLength": 0,
      "FeatureReportLength": 17,
      "CanOpen": true,
      "DeviceAttributes": {
        "USB_INTERFACE_NUMBER": "0",
        "HID_REPORTS": "01:0001:0002, 02:000D:0001"
      }
    },
```