### PR TITLE
Fix eraser tool state getting stuck in libinput

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -91,6 +91,9 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
 
         public void SetPosition(Vector2 pos)
         {
+            // Reset opposite tool
+            Device.Write(EventType.EV_KEY, !isEraser ? EventCode.BTN_TOOL_RUBBER : EventCode.BTN_TOOL_PEN, 0);
+
             Device.Write(EventType.EV_KEY, isEraser ? EventCode.BTN_TOOL_RUBBER : EventCode.BTN_TOOL_PEN, proximity ? 1 : 0);
             Device.Write(EventType.EV_ABS, EventCode.ABS_X, (int)(pos.X * RESOLUTION));
             Device.Write(EventType.EV_ABS, EventCode.ABS_Y, (int)(pos.Y * RESOLUTION));


### PR DESCRIPTION
Fixes #3534 

Tested on Arch with `libinput 1.27.1-1`. Haven't checked master to see if the issue is there as well.
