### PR TITLE
OutputMode: Refactor `Elements`

### DIFF
--- a/OpenTabletDriver.Plugin/Output/OutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/OutputMode.cs
@@ -41,8 +41,11 @@ namespace OpenTabletDriver.Plugin.Output
             get => this.passthrough;
         }
 
-        protected IList<IPositionedPipelineElement<IDeviceReport>> PreTransformElements { private set; get; } = Array.Empty<IPositionedPipelineElement<IDeviceReport>>();
-        protected IList<IPositionedPipelineElement<IDeviceReport>> PostTransformElements { private set; get; } = Array.Empty<IPositionedPipelineElement<IDeviceReport>>();
+        protected IList<IPositionedPipelineElement<IDeviceReport>> PreTransformElements { private set; get; } =
+            Array.Empty<IPositionedPipelineElement<IDeviceReport>>();
+
+        protected IList<IPositionedPipelineElement<IDeviceReport>> PostTransformElements { private set; get; } =
+            Array.Empty<IPositionedPipelineElement<IDeviceReport>>();
 
         public Matrix3x2 TransformationMatrix { protected set; get; }
 
@@ -62,27 +65,11 @@ namespace OpenTabletDriver.Plugin.Output
 
                     Action<IDeviceReport> output = this.OnOutput;
 
-                    if (PreTransformElements.Any() && !PostTransformElements.Any())
-                    {
-                        entryElement = PreTransformElements.First();
+                    var links = ElementsAsPipeline;
 
-                        // PreTransform --> Transform --> Output
-                        LinkAll(PreTransformElements, this, output);
-                    }
-                    else if (PostTransformElements.Any() && !PreTransformElements.Any())
-                    {
-                        entryElement = this;
+                    entryElement = links.First();
 
-                        // Transform --> PostTransform --> Output
-                        LinkAll(this, PostTransformElements, output);
-                    }
-                    else if (PreTransformElements.Any() && PostTransformElements.Any())
-                    {
-                        entryElement = PreTransformElements.First();
-
-                        // PreTransform --> Transform --> PostTransform --> Output
-                        LinkAll(PreTransformElements, this, PostTransformElements, output);
-                    }
+                    LinkAll(links, output);
                 }
                 else
                 {
@@ -92,6 +79,20 @@ namespace OpenTabletDriver.Plugin.Output
                 }
             }
             get => this.elements;
+        }
+
+        private List<IPipelineElement<IDeviceReport>> ElementsAsPipeline
+        {
+            get
+            {
+                var links = new List<IPipelineElement<IDeviceReport>>();
+
+                links.AddRange(PreTransformElements);
+                links.Add(this);
+                links.AddRange(PostTransformElements);
+
+                return links;
+            }
         }
 
         public virtual TabletReference Tablet
@@ -122,18 +123,9 @@ namespace OpenTabletDriver.Plugin.Output
         {
             Action<IDeviceReport> output = this.OnOutput;
 
-            if (PreTransformElements.Any() && !PostTransformElements.Any())
-            {
-                UnlinkAll(PreTransformElements, this, output);
-            }
-            else if (PostTransformElements.Any() && !PreTransformElements.Any())
-            {
-                UnlinkAll(this, PostTransformElements, output);
-            }
-            else if (PreTransformElements.Any() && PostTransformElements.Any())
-            {
-                UnlinkAll(PreTransformElements, this, PostTransformElements, output);
-            }
+            var links = ElementsAsPipeline;
+
+            UnlinkAll(links, output);
         }
     }
 }


### PR DESCRIPTION
This cleans up the code to be slightly more intuitive. It's pretty difficult to read longer negated booleans in if statements, at least IMO. I tested with both pre- and post-transpose filters, as well as async filters.

This seems to slightly change behavior - previously, link/unlink operations only ran if there was something to link/unlink, but the end result seems to be exactly the same. **Please try to break this.**.

I originally had an `if (ElementsAsPipeline.Count > 1)` (since `this` is always in the list) in place before the link/unlink operations to match the original behavior, but I don't think the original behavior was intended, so I kept this out.

Another change that this PR does is that previously, an `IPipelineElement<IDeviceReport>` plugin could exist that was neither pre- nor post-transpose (but instead `None`) which would break the pipeline linkage, since the elements would be set, but no links would need to be set (`Elements` > 1 but no Post/Pretranspose plugins, so no linkage performed), and yet the passthrough was disabled, so `entryElement` ended up being null, effectively unsubscribing the `PipelineManager` (`OutputMode`). This PR solves that (but it wasn't really an issue to begin with, since the Binding Handler is a post-transpose plugin).

(not sure which label to file this under)

TL;DR:
Cleaner code, slight behavior change which I think is more intuitive, end effect should be no different (but please try to prove me wrong)