### PR TITLE
[06x] Daemon: Properly output filters to log in development edge case

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -328,8 +328,9 @@ namespace OpenTabletDriver.Daemon
                            select filter;
             outputMode.Elements = elements.Append(bindingHandler).ToList();
 
-            if (outputMode.Elements.Count > 1)
-                Log.Write(group, $"Filters: {string.Join(", ", outputMode.Elements.Where(e => e != bindingHandler))}");
+            var activeFilters = outputMode.Elements.Where(e => e != bindingHandler).ToList();
+            if (activeFilters.Count != 0)
+                Log.Write(group, $"Filters: {string.Join(", ", activeFilters)}");
         }
 
         private void SetAbsoluteModeSettings(InputDeviceTree dev, AbsoluteOutputMode absoluteMode, AbsoluteModeSettings settings)


### PR DESCRIPTION
This has no real change for releases, but helps with debugging without the bindingHandler in place since it counts as a filter.

## Pre-PR, if you have the binding handler removed:

Plugins do not show up in the filter when using exactly 1 plugin

## Post-PR, if you have the binding handler removed:

Plugins show up in log output regardless of filter count, unless no filters are enabled.

---

Mostly harmless code change, so targeting v0.6.5.1
