### PR TITLE
[06x] Invert tilt in UCLogicTiltReportParser

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicTiltReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicTiltReportParser.cs
@@ -9,7 +9,7 @@ namespace OpenTabletDriver.Configurations.Parsers.UCLogic
             if (data[1].IsBitSet(6))
                 return new UCLogicAuxReport(data);
             else
-                return new TiltTabletReport(data);
+                return new TiltTabletReport(data, false, true);
         }
     }
 }

--- a/OpenTabletDriver.Plugin/Tablet/TiltTabletReport.cs
+++ b/OpenTabletDriver.Plugin/Tablet/TiltTabletReport.cs
@@ -5,7 +5,7 @@ namespace OpenTabletDriver.Plugin.Tablet
 {
     public struct TiltTabletReport : ITabletReport, ITiltReport
     {
-        public TiltTabletReport(byte[] report)
+        public TiltTabletReport(byte[] report, bool invertTiltX, bool invertTiltY)
         {
             Raw = report;
 
@@ -16,8 +16,8 @@ namespace OpenTabletDriver.Plugin.Tablet
             };
             Tilt = new Vector2
             {
-                X = (sbyte)report[10],
-                Y = (sbyte)report[11]
+                X = (sbyte)(invertTiltX ? -1 : 1) * (sbyte)report[10],
+                Y = (sbyte)(invertTiltY ? -1 : 1) * (sbyte)report[11]
             };
             Pressure = Unsafe.ReadUnaligned<ushort>(ref report[6]);
 
@@ -29,6 +29,8 @@ namespace OpenTabletDriver.Plugin.Tablet
                 penByte.IsBitSet(3)
             };
         }
+
+        public TiltTabletReport(byte[] report) : this(report, false, false) { }
 
         public byte[] Raw { set; get; }
         public Vector2 Position { set; get; }


### PR DESCRIPTION
Backport of #1841

Fixes #2378

Affects the following tablets:

Artisul/A1201.json
Artisul/A1201.json
Gaomon/1060 Pro.json
Gaomon/1060 Pro.json
Gaomon/1060 Pro.json
Gaomon/1060 Pro.json
Gaomon/M106K Pro.json
Gaomon/M106K Pro.json
Gaomon/M10K Pro.json
Gaomon/M10K Pro.json
Gaomon/M1220.json
Gaomon/M1230.json
Gaomon/M1230.json
Gaomon/PD1161.json
Huion/H1061P.json
Huion/RTP-700.json
Huion/RTP-700.json
Huion/H1060P.json
Huion/H1060P.json
Huion/H1060P.json
Huion/H1161.json
Huion/H1161.json
Huion/H320M.json
Huion/H320M.json
Huion/H580X.json
Huion/H610 Pro V2.json
Huion/H610 Pro V2.json
Huion/H610 Pro V2.json
Huion/H610X.json
Huion/H610X.json
Huion/H640P.json
Huion/H640P.json
Huion/H640P.json
Huion/H640P.json
Huion/H641P.json
Huion/H642.json
Huion/H642.json
Huion/H950P.json
Huion/H950P.json
Huion/H950P.json
Huion/H950P.json
Huion/HC16.json
Huion/HC16.json
Huion/HS610.json
Huion/HS610.json
Huion/HS611.json
Huion/HS611.json
Huion/HS95.json
Huion/Kamvas 13.json
Huion/Kamvas Pro 13 (2.5k).json
Huion/Kamvas Pro 13.json
Huion/Kamvas Pro 13.json
Huion/Q11K V2.json
Huion/RTM 500.json
Huion/RTM 500.json
Huion/Kamvas 13 (Gen 3).json