### PR TITLE
Fix incorrect usage of proximity in libinput

### DIFF
--- a/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
@@ -143,8 +143,6 @@ namespace OpenTabletDriver.Plugin.Output
             // the SetPosition method is dependent on the proximity state.
             if (report is IProximityReport proximityReport)
             {
-                if (Pointer is IProximityHandler proximityHandler)
-                    proximityHandler.SetProximity(proximityReport.NearProximity);
                 if (Pointer is IHoverDistanceHandler hoverDistanceHandler)
                     hoverDistanceHandler.SetHoverDistance(proximityReport.HoverDistance);
             }

--- a/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
@@ -121,8 +121,6 @@ namespace OpenTabletDriver.Plugin.Output
             // the SetPosition method is dependent on the proximity state.
             if (report is IProximityReport proximityReport)
             {
-                if (Pointer is IProximityHandler proximityHandler)
-                    proximityHandler.SetProximity(proximityReport.NearProximity);
                 if (Pointer is IHoverDistanceHandler hoverDistanceHandler)
                     hoverDistanceHandler.SetHoverDistance(proximityReport.HoverDistance);
             }


### PR DESCRIPTION
Proximity in libinput is not the same as proximity in OTD. Libinput proximity is moreso equivalent to an OTD OutOfRangeReport (https://wayland.freedesktop.org/libinput/doc/latest/tablet-support.html#handling-of-proximity-events). Libinput ignores all reports that do not have proximity set to 1 (true).

The default state for proximity is set (correctly) to true. Since OutOfRangeReport already runs the reset, SetProximity does not need to fire on an out of range report.

Users who need reports to be ignored when out of proximity (by OTD's definition) can use a plugin such as Hover Distance Limiter.