### PR TITLE
[06x] evdev: Dispose device when no longer needed

### DIFF
--- a/OpenTabletDriver.Benchmarks/Output/NoopAbsoluteMode.cs
+++ b/OpenTabletDriver.Benchmarks/Output/NoopAbsoluteMode.cs
@@ -16,6 +16,8 @@ namespace OpenTabletDriver.Benchmarks.Output
             {
                 Position = pos;
             }
+
+            public bool HasValidDevice() => true;
         }
     }
 }

--- a/OpenTabletDriver.Desktop/Interop/DesktopInterop.cs
+++ b/OpenTabletDriver.Desktop/Interop/DesktopInterop.cs
@@ -83,7 +83,7 @@ namespace OpenTabletDriver.Desktop.Interop
         public static IAbsolutePointer AbsolutePointer => CurrentPlatform switch
         {
             PluginPlatform.Windows => new WindowsAbsolutePointer(),
-            PluginPlatform.Linux => absolutePointer ??= new EvdevAbsolutePointer(),
+            PluginPlatform.Linux => absolutePointer?.HasValidDevice() ?? false ? absolutePointer : absolutePointer = new EvdevAbsolutePointer(),
             PluginPlatform.MacOS => new MacOSAbsolutePointer(),
             _ => null
         };
@@ -91,21 +91,21 @@ namespace OpenTabletDriver.Desktop.Interop
         public static IRelativePointer RelativePointer => CurrentPlatform switch
         {
             PluginPlatform.Windows => new WindowsRelativePointer(),
-            PluginPlatform.Linux => relativePointer ??= new EvdevRelativePointer(),
+            PluginPlatform.Linux => relativePointer?.HasValidDevice() ?? false ? relativePointer : relativePointer = new EvdevRelativePointer(),
             PluginPlatform.MacOS => new MacOSRelativePointer(),
             _ => null
         };
 
         public static IPressureHandler VirtualTablet => CurrentPlatform switch
         {
-            PluginPlatform.Linux => virtualTablet ??= new EvdevVirtualTablet(),
+            PluginPlatform.Linux => virtualTablet?.HasValidDevice() ?? false ? virtualTablet : virtualTablet = new EvdevVirtualTablet(),
             _ => null
         };
 
         public static IVirtualKeyboard VirtualKeyboard => CurrentPlatform switch
         {
             PluginPlatform.Windows => new WindowsVirtualKeyboard(),
-            PluginPlatform.Linux => virtualKeyboard ??= new EvdevVirtualKeyboard(),
+            PluginPlatform.Linux => virtualKeyboard?.HasValidDevice() ?? false ? virtualKeyboard : virtualKeyboard = new EvdevVirtualKeyboard(),
             PluginPlatform.MacOS => new MacOSVirtualKeyboard(),
             _ => null
         };

--- a/OpenTabletDriver.Desktop/Interop/Input/EvdevVirtualMouse.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/EvdevVirtualMouse.cs
@@ -10,6 +10,8 @@ namespace OpenTabletDriver.Desktop.Interop
     {
         protected EvdevDevice Device { set; get; }
 
+        public bool HasValidDevice() => Device?.CanWrite ?? false;
+
         public void MouseDown(MouseButton button)
         {
             if (GetCode(button) is EventCode code)
@@ -39,11 +41,12 @@ namespace OpenTabletDriver.Desktop.Interop
         public virtual void Dispose()
         {
             Device?.Dispose();
+            Device = null;
         }
 
         public void Flush()
         {
-            Device.Sync();
+            Device?.Sync();
         }
 
         public virtual void Reset()

--- a/OpenTabletDriver.Desktop/Interop/Input/Keyboard/EvdevVirtualKeyboard.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Keyboard/EvdevVirtualKeyboard.cs
@@ -30,6 +30,8 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Keyboard
 
         private EvdevDevice Device { set; get; }
 
+        public bool HasValidDevice() => Device?.CanWrite ?? false;
+
         private void KeyEvent(string key, bool isPress)
         {
             var keyEventCode = EtoKeysymToEventCode[key];
@@ -63,6 +65,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Keyboard
         public void Dispose()
         {
             Device?.Dispose();
+            Device = null;
         }
 
         public IEnumerable<string> SupportedKeys => EtoKeysymToEventCode.Keys;

--- a/OpenTabletDriver.Desktop/Interop/Input/Keyboard/MacOSVirtualKeyboard.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Keyboard/MacOSVirtualKeyboard.cs
@@ -190,5 +190,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Keyboard
                 _ => 0
             };
         }
+
+        public bool HasValidDevice() => true;
     }
 }

--- a/OpenTabletDriver.Desktop/Interop/Input/Keyboard/WindowsVirtualKeyboard.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Keyboard/WindowsVirtualKeyboard.cs
@@ -186,5 +186,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Keyboard
             { "Control", VirtualKey.VK_CONTROL },
             { "Application", VirtualKey.VK_LWIN },
         };
+
+        public bool HasValidDevice() => true;
     }
 }

--- a/OpenTabletDriver.Desktop/Interop/Input/MacOSVirtualMouse.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/MacOSVirtualMouse.cs
@@ -24,6 +24,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input
         private CGMouseButton _lastButton;
         private Vector2 _lastMouseDownPosition;
         private bool _mouseMovedSinceLastDown;
+        private bool _initialized;
 
         private int _clickState;
         private readonly Stopwatch _stopWatch;
@@ -34,13 +35,13 @@ namespace OpenTabletDriver.Desktop.Interop.Input
 
         public MacOSVirtualMouse()
         {
-
             _doubleClickIntervalInMs = GetDoubleClickInterval() * 1000;
             _doubleClickStopWatch = new Stopwatch();
             _stopWatch = new Stopwatch();
             _stopWatch.Start();
             _eventSource = CGEventSourceCreate(CGEventSourceStatePrivate);
             _mouseEvent = CGEventCreate(_eventSource);
+            _initialized = true;
         }
 
         public void MouseDown(MouseButton button)
@@ -306,6 +307,10 @@ namespace OpenTabletDriver.Desktop.Interop.Input
             {
                 CFRelease(_mouseEvent);
             }
+
+            _initialized = false;
         }
+
+        public bool HasValidDevice() => _initialized;
     }
 }

--- a/OpenTabletDriver.Desktop/Interop/Input/WindowsVirtualMouse.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/WindowsVirtualMouse.cs
@@ -102,5 +102,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input
         public void Reset()
         {
         }
+
+        public bool HasValidDevice() => true;
     }
 }

--- a/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
@@ -1,4 +1,5 @@
-﻿using System.Numerics;
+﻿using System;
+using System.Numerics;
 using OpenTabletDriver.Plugin.Attributes;
 using OpenTabletDriver.Plugin.Platform.Pointer;
 using OpenTabletDriver.Plugin.Tablet;
@@ -165,6 +166,14 @@ namespace OpenTabletDriver.Plugin.Output
                     synchronousPointer.Reset();
                 synchronousPointer.Flush();
             }
+        }
+
+        public override void Dispose()
+        {
+            if (Pointer is IDisposable pointer)
+                pointer.Dispose();
+
+            base.Dispose();
         }
     }
 }

--- a/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
@@ -144,5 +144,13 @@ namespace OpenTabletDriver.Plugin.Output
                 synchronousPointer.Flush();
             }
         }
+
+        public override void Dispose()
+        {
+            if (Pointer is IDisposable pointer)
+                pointer.Dispose();
+
+            base.Dispose();
+        }
     }
 }

--- a/OpenTabletDriver.Plugin/Platform/IValidatableDevice.cs
+++ b/OpenTabletDriver.Plugin/Platform/IValidatableDevice.cs
@@ -1,0 +1,6 @@
+namespace OpenTabletDriver.Plugin.Platform;
+
+public interface IValidatableDevice
+{
+    bool HasValidDevice();
+}

--- a/OpenTabletDriver.Plugin/Platform/Keyboard/IVirtualKeyboard.cs
+++ b/OpenTabletDriver.Plugin/Platform/Keyboard/IVirtualKeyboard.cs
@@ -2,7 +2,7 @@
 
 namespace OpenTabletDriver.Plugin.Platform.Keyboard
 {
-    public interface IVirtualKeyboard
+    public interface IVirtualKeyboard : IValidatableDevice
     {
         void Press(string key);
         void Release(string key);

--- a/OpenTabletDriver.Plugin/Platform/Pointer/IAbsolutePointer.cs
+++ b/OpenTabletDriver.Plugin/Platform/Pointer/IAbsolutePointer.cs
@@ -2,7 +2,7 @@
 
 namespace OpenTabletDriver.Plugin.Platform.Pointer
 {
-    public interface IAbsolutePointer
+    public interface IAbsolutePointer : IValidatableDevice
     {
         void SetPosition(Vector2 pos);
     }

--- a/OpenTabletDriver.Plugin/Platform/Pointer/IPressureHandler.cs
+++ b/OpenTabletDriver.Plugin/Platform/Pointer/IPressureHandler.cs
@@ -1,6 +1,6 @@
 namespace OpenTabletDriver.Plugin.Platform.Pointer
 {
-    public interface IPressureHandler
+    public interface IPressureHandler : IValidatableDevice
     {
         void SetPressure(float percentage);
     }

--- a/OpenTabletDriver.Plugin/Platform/Pointer/IRelativePointer.cs
+++ b/OpenTabletDriver.Plugin/Platform/Pointer/IRelativePointer.cs
@@ -2,7 +2,7 @@ using System.Numerics;
 
 namespace OpenTabletDriver.Plugin.Platform.Pointer
 {
-    public interface IRelativePointer
+    public interface IRelativePointer : IValidatableDevice
     {
         void SetPosition(Vector2 delta);
     }

--- a/OpenTabletDriver.Plugin/Platform/Pointer/ISynchronousPointer.cs
+++ b/OpenTabletDriver.Plugin/Platform/Pointer/ISynchronousPointer.cs
@@ -1,6 +1,6 @@
 namespace OpenTabletDriver.Plugin.Platform.Pointer
 {
-    public interface ISynchronousPointer
+    public interface ISynchronousPointer : IValidatableDevice
     {
         void Reset();
         void Flush();


### PR DESCRIPTION
This adds IValidatableDevice to almost all cached DesktopInterop classes, to ensure that they remain usable when disposed.
(advice on how to better do this would be appreciated, it ended up more ugly than I liked - can I avoid adding an interface?)

Fixes #3055

I think we also had an issue about keys being held when tablet is disconnected - can't find it, but this should fix at least mouse left click being held when device is disconnected.

Post-PR only the Virtual Keyboard remains connected, unsure how to dispose of it correctly.