### PR TITLE
Remove proximity handling from linux artist mode

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -8,12 +8,11 @@ using OpenTabletDriver.Plugin.Platform.Pointer;
 
 namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
 {
-    public class EvdevVirtualTablet : EvdevVirtualMouse, IAbsolutePointer, IPressureHandler, ITiltHandler, IEraserHandler, IHoverDistanceHandler, IProximityHandler, ISynchronousPointer
+    public class EvdevVirtualTablet : EvdevVirtualMouse, IAbsolutePointer, IPressureHandler, ITiltHandler, IEraserHandler, IHoverDistanceHandler, ISynchronousPointer
     {
         private const int RESOLUTION = 1000; // subpixels per screen pixel
 
         private bool isEraser;
-        private bool proximity = true;
 
         public unsafe EvdevVirtualTablet()
         {
@@ -93,7 +92,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
 
         public void SetPosition(Vector2 pos)
         {
-            Device.Write(EventType.EV_KEY, currentTool, proximity ? 1 : 0);
+            Device.Write(EventType.EV_KEY, currentTool, 1);
             Device.Write(EventType.EV_ABS, EventCode.ABS_X, (int)(pos.X * RESOLUTION));
             Device.Write(EventType.EV_ABS, EventCode.ABS_Y, (int)(pos.Y * RESOLUTION));
         }
@@ -121,11 +120,6 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
             this.isEraser = isEraser;
         }
 
-        public void SetProximity(bool proximity)
-        {
-            this.proximity = proximity;
-        }
-
         public void SetHoverDistance(uint distance)
         {
             Device.Write(EventType.EV_ABS, EventCode.ABS_DISTANCE, (int)distance);
@@ -148,7 +142,6 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
             Device.Write(EventType.EV_KEY, EventCode.BTN_STYLUS3, 0);
 
             isEraser = false;
-            proximity = true; // we counterintuitively set this to true since its the initial state
         }
 
         protected override EventCode? GetCode(MouseButton button) => null;

--- a/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
@@ -138,16 +138,9 @@ namespace OpenTabletDriver.Plugin.Output
         protected override void OnOutput(IDeviceReport report)
         {
             // this should be ordered from least to most chance of having a
-            // dependency to another pointer property. for example, proximity
-            // should be set before position, because in LinuxArtistMode
-            // the SetPosition method is dependent on the proximity state.
-            if (report is IProximityReport proximityReport)
-            {
-                if (Pointer is IProximityHandler proximityHandler)
-                    proximityHandler.SetProximity(proximityReport.NearProximity);
-                if (Pointer is IHoverDistanceHandler hoverDistanceHandler)
-                    hoverDistanceHandler.SetHoverDistance(proximityReport.HoverDistance);
-            }
+            // dependency to another pointer property.
+            if (report is IProximityReport proximityReport && Pointer is IHoverDistanceHandler hoverDistanceHandler)
+                hoverDistanceHandler.SetHoverDistance(proximityReport.HoverDistance);
             if (report is IEraserReport eraserReport && Pointer is IEraserHandler eraserHandler)
                 eraserHandler.SetEraser(eraserReport.Eraser);
             if (report is ITiltReport tiltReport && Pointer is ITiltHandler tiltHandler)

--- a/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
@@ -116,16 +116,9 @@ namespace OpenTabletDriver.Plugin.Output
         protected override void OnOutput(IDeviceReport report)
         {
             // this should be ordered from least to most chance of having a
-            // dependency to another pointer property. for example, proximity
-            // should be set before position, because in LinuxArtistMode
-            // the SetPosition method is dependent on the proximity state.
-            if (report is IProximityReport proximityReport)
-            {
-                if (Pointer is IProximityHandler proximityHandler)
-                    proximityHandler.SetProximity(proximityReport.NearProximity);
-                if (Pointer is IHoverDistanceHandler hoverDistanceHandler)
-                    hoverDistanceHandler.SetHoverDistance(proximityReport.HoverDistance);
-            }
+            // dependency to another pointer property.
+            if (report is IProximityReport proximityReport && Pointer is IHoverDistanceHandler hoverDistanceHandler)
+                hoverDistanceHandler.SetHoverDistance(proximityReport.HoverDistance);
             if (report is IEraserReport eraserReport && Pointer is IEraserHandler eraserHandler)
                 eraserHandler.SetEraser(eraserReport.Eraser);
             if (report is ITiltReport tiltReport && Pointer is ITiltHandler tiltHandler)

--- a/OpenTabletDriver.Plugin/Platform/Pointer/IProximityHandler.cs
+++ b/OpenTabletDriver.Plugin/Platform/Pointer/IProximityHandler.cs
@@ -1,7 +1,0 @@
-namespace OpenTabletDriver.Plugin.Platform.Pointer
-{
-    public interface IProximityHandler
-    {
-        void SetProximity(bool proximity);
-    }
-}


### PR DESCRIPTION
Backport of [#2503](https://github.com/OpenTabletDriver/OpenTabletDriver/pull/2503)

Fixes improper usage of proximity in libinput reporting.

Proximity in libinput is not the same as proximity in OTD. Libinput proximity is moreso equivalent to an OTD OutOfRangeReport (https://wayland.freedesktop.org/libinput/doc/latest/tablet-support.html#handling-of-proximity-events). Libinput ignores all reports that do not have proximity set to 1 (true).

Users who need reports to be ignored when out of proximity (by OTD's definition) can use a plugin such as Hover Distance Limiter.