### PR TITLE
[Avalonia] daemon: Wrap diagnostics call in Task.Run to satisfy async

### DIFF
--- a/OpenTabletDriver.Daemon.Library/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon.Library/DriverDaemon.cs
@@ -402,7 +402,7 @@ namespace OpenTabletDriver.Daemon.Library
 
         public async Task<DiagnosticInfo> GetDiagnostics()
         {
-            return _serviceProvider.CreateInstance<DiagnosticInfo>();
+            return await Task.Run(() => _serviceProvider.CreateInstance<DiagnosticInfo>());
         }
 
         public Task SetTabletDebug(bool enabled)


### PR DESCRIPTION
One less warning, and diag export still works.