### PR TITLE
[Avalonia] DriverDaemon: Default to 1% pressure threshold

### DIFF
--- a/OpenTabletDriver.Daemon.Library/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon.Library/DriverDaemon.cs
@@ -712,7 +712,9 @@ namespace OpenTabletDriver.Daemon.Library
                 ),
                 PenButtons = new Collection<PluginSettings?>(),
                 AuxButtons = new Collection<PluginSettings?>(),
-                MouseButtons = new Collection<PluginSettings?>()
+                MouseButtons = new Collection<PluginSettings?>(),
+                TipActivationThreshold = 1f,
+                EraserActivationThreshold = 1f,
             };
             return bindingSettings;
         }


### PR DESCRIPTION
Some tablets can report anywhere from within 0-5% of their pressure range when hovering, with some tablets never truly reaching 0. This solves mouse buttons being unavailable as soon as the tablet pen is brought into range

Fixes #3597 for avalonia