### PR TITLE
Add interface attribute to WinUSB tablets where applicable

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Artisul/AP604.json
+++ b/OpenTabletDriver.Configurations/Configurations/Artisul/AP604.json
@@ -21,6 +21,7 @@
     }
   ],
   "Attributes": {
-    "libinputoverride": "1"
+    "libinputoverride": "1",
+    "Interface": "1"
   }
 }

--- a/OpenTabletDriver.Configurations/Configurations/FlooGoo/FMA100.json
+++ b/OpenTabletDriver.Configurations/Configurations/FlooGoo/FMA100.json
@@ -21,6 +21,7 @@
     }
   ],
   "Attributes": {
-    "libinputoverride": "1"
+    "libinputoverride": "1",
+    "Interface": "1"
   }
 }

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/S630.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/S630.json
@@ -30,6 +30,7 @@
     }
   ],
   "Attributes": {
-    "libinputoverride": "1"
+    "libinputoverride": "1",
+    "Interface": "0"
   }
 }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H690.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H690.json
@@ -44,6 +44,7 @@
     }
   ],
   "Attributes": {
-    "libinputoverride": "1"
+    "libinputoverride": "1",
+    "Interface": 0
   }
 }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/H690.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H690.json
@@ -45,6 +45,6 @@
   ],
   "Attributes": {
     "libinputoverride": "1",
-    "Interface": 0
+    "Interface": "0"
   }
 }

--- a/OpenTabletDriver.Configurations/Configurations/Huion/New 1060 Plus (2048).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/New 1060 Plus (2048).json
@@ -42,6 +42,7 @@
     }
   ],
   "Attributes": {
-    "libinputoverride": "1"
+    "libinputoverride": "1",
+    "Interface": "1"
   }
 }

--- a/OpenTabletDriver.Configurations/Configurations/Monoprice/10594.json
+++ b/OpenTabletDriver.Configurations/Configurations/Monoprice/10594.json
@@ -29,9 +29,24 @@
         100,
         123
       ]
+    },
+    {
+      "VendorID": 9580,
+      "ProductID": 110,
+      "InputReportLength": 8,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "DeviceStrings": {
+        "6": "10594",
+        "121": "HA60-F400"
+      },
+      "InitializationStrings": [
+        100,
+        123
+      ]
     }
   ],
   "Attributes": {
-    "libinputoverride": "1"
+    "libinputoverride": "1",
+    "Interface": "0"
   }
 }

--- a/OpenTabletDriver.Configurations/Configurations/Monoprice/MP1060-HA60.json
+++ b/OpenTabletDriver.Configurations/Configurations/Monoprice/MP1060-HA60.json
@@ -27,6 +27,7 @@
     }
   ],
   "Attributes": {
-    "libinputoverride": "1"
+    "libinputoverride": "1",
+    "Interface": "0"
   }
 }

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/A610.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/A610.json
@@ -31,6 +31,7 @@
     }
   ],
   "Attributes": {
-    "libinputoverride": "1"
+    "libinputoverride": "1",
+    "Interface": "0"
   }
 }

--- a/OpenTabletDriver.Configurations/Configurations/Turcom/TS-6580.json
+++ b/OpenTabletDriver.Configurations/Configurations/Turcom/TS-6580.json
@@ -41,6 +41,7 @@
     }
   ],
   "Attributes": {
-    "libinputoverride": "1"
+    "libinputoverride": "1",
+    "Interface": "0"
   }
 }

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/M708.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/M708.json
@@ -33,6 +33,7 @@
     }
   ],
   "Attributes": {
-    "libinputoverride": "1"
+    "libinputoverride": "1",
+    "Interface": "0"
   }
 }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 10S.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 10S.json
@@ -27,6 +27,7 @@
     }
   ],
   "Attributes": {
-    "libinputoverride": "1"
+    "libinputoverride": "1",
+    "Interface": "0"
   }
 }

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 22HD.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 22HD.json
@@ -22,5 +22,8 @@
         100
       ]
     }
-  ]
+  ],
+  "Attributes": {
+    "Interface": "0"
+  }
 }


### PR DESCRIPTION
Fixes #3716.

Heres the thought process for the more confusing ones:

- For the Gaomon S56K it is unknown which require interface 1 or 0 at this time, so interface hasn't been defined.
- Did not touch The Gaomon S830 because the user deleted the diag, and because this tablet is already scuffed enough.
- Huion WH1409 V2 (Variant 2) because its inconsistent between variants and the TABLETS.md may be incorrect about interface for some potential variants.
- Parblo A610 has not had an extra interface added because i have no proof that the lengths change and I don't want to mess with this config too much, its fragile enough.
  -  Same with the original M708, as they basically are the same hardware

- Artist 16 didn't have the 16 length added because theres no evidence that the lengths change as the user did not provide a windows diagnostics with WinUSB installed.


Artist 22HD is touched, theres no diagnostic though so i haven't added an extra length as theres no proof.

