### PR TITLE
[Avalonia] upgrade all nuget packages

### DIFF
--- a/OpenTabletDriver.Analyzers.Tests/OpenTabletDriver.Analyzers.Tests.csproj
+++ b/OpenTabletDriver.Analyzers.Tests/OpenTabletDriver.Analyzers.Tests.csproj
@@ -6,15 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup Label="NuGet Packages">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -27,6 +26,12 @@
   <ItemGroup>
     <Compile Remove="TestResources\**" />
     <Compile Include="..\OpenTabletDriver\Components\IDeviceConfigurationProvider.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.CodeAnalysis">
+      <HintPath>..\..\..\..\.nuget\packages\microsoft.codeanalysis.common\4.8.0\lib\netstandard2.0\Microsoft.CodeAnalysis.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
 </Project>

--- a/OpenTabletDriver.Analyzers/OpenTabletDriver.Analyzers.csproj
+++ b/OpenTabletDriver.Analyzers/OpenTabletDriver.Analyzers.csproj
@@ -8,14 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup Label="NuGet Packages">
-    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
-    <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/OpenTabletDriver.Benchmarks/OpenTabletDriver.Benchmarks.csproj
+++ b/OpenTabletDriver.Benchmarks/OpenTabletDriver.Benchmarks.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup Label="NuGet Packages">
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
 
   <ItemGroup Label="Project References">

--- a/OpenTabletDriver.Daemon.Contracts/OpenTabletDriver.Daemon.Contracts.csproj
+++ b/OpenTabletDriver.Daemon.Contracts/OpenTabletDriver.Daemon.Contracts.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="NuGet Packages">
-    <PackageReference Include="StreamJsonRpc" Version="2.6.121" />
+    <PackageReference Include="StreamJsonRpc" Version="2.20.20" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/OpenTabletDriver.Daemon.Library/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon.Library/DriverDaemon.cs
@@ -600,14 +600,14 @@ namespace OpenTabletDriver.Daemon.Library
                     {
                         unsafe
                         {
-                            var state = Windows.PowerThrottlingState.Create();
-                            state.ControlMask = (int)Windows.PowerThrottlingStateMask.IgnoreTimerResolution;
+                            var state = WindowsAPI.PowerThrottlingState.Create();
+                            state.ControlMask = (int)WindowsAPI.PowerThrottlingStateMask.IgnoreTimerResolution;
 
-                            if (!Windows.SetProcessInformation(
+                            if (!WindowsAPI.SetProcessInformation(
                                 System.Diagnostics.Process.GetCurrentProcess().Handle,
-                                Windows.ProcessInformationClass.ProcessPowerThrottling,
+                                WindowsAPI.ProcessInformationClass.ProcessPowerThrottling,
                                 (IntPtr)Unsafe.AsPointer(ref state),
-                                Unsafe.SizeOf<Windows.PowerThrottlingState>()))
+                                Unsafe.SizeOf<WindowsAPI.PowerThrottlingState>()))
                             {
                                 Log.Write("Platform", "Failed to allow management of timer resolution, asynchronous filters may have lower timing resolution when OTD is minimized.", LogLevel.Error);
                             }

--- a/OpenTabletDriver.Daemon.Library/Interop/Display/WindowsDisplay.cs
+++ b/OpenTabletDriver.Daemon.Library/Interop/Display/WindowsDisplay.cs
@@ -5,11 +5,10 @@ using System.Numerics;
 using System.Runtime.InteropServices;
 using OpenTabletDriver.Native.Windows;
 using OpenTabletDriver.Platform.Display;
+using static OpenTabletDriver.Native.Windows.WindowsAPI;
 
 namespace OpenTabletDriver.Daemon.Library.Interop.Display
 {
-    using static Windows;
-
     public class WindowsDisplay : IVirtualScreen
     {
         public WindowsDisplay()

--- a/OpenTabletDriver.Daemon.Library/Interop/Input/Keyboard/WindowsVirtualKeyboard.cs
+++ b/OpenTabletDriver.Daemon.Library/Interop/Input/Keyboard/WindowsVirtualKeyboard.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using OpenTabletDriver.Native.Windows;
 using OpenTabletDriver.Native.Windows.Input;
 using OpenTabletDriver.Platform.Keyboard;
+using static OpenTabletDriver.Native.Windows.WindowsAPI;
 
 namespace OpenTabletDriver.Daemon.Library.Interop.Input.Keyboard
 {
-    using static Windows;
-
     public class WindowsVirtualKeyboard : IVirtualKeyboard
     {
         private readonly IKeyMapper _keyMapper;

--- a/OpenTabletDriver.Daemon.Library/Interop/Input/WindowsVirtualMouse.cs
+++ b/OpenTabletDriver.Daemon.Library/Interop/Input/WindowsVirtualMouse.cs
@@ -3,11 +3,10 @@ using OpenTabletDriver.Attributes;
 using OpenTabletDriver.Native.Windows;
 using OpenTabletDriver.Native.Windows.Input;
 using OpenTabletDriver.Platform.Pointer;
+using static OpenTabletDriver.Native.Windows.WindowsAPI;
 
 namespace OpenTabletDriver.Daemon.Library.Interop.Input
 {
-    using static Windows;
-
     [PluginIgnore]
     public abstract class WindowsVirtualMouse : IMouseButtonHandler, ISynchronousPointer
     {

--- a/OpenTabletDriver.Daemon.Library/Interop/Timer/WindowsTimer.cs
+++ b/OpenTabletDriver.Daemon.Library/Interop/Timer/WindowsTimer.cs
@@ -2,11 +2,10 @@ using System;
 using System.Runtime.InteropServices;
 using OpenTabletDriver.Native.Windows;
 using OpenTabletDriver.Native.Windows.Timers;
+using static OpenTabletDriver.Native.Windows.WindowsAPI;
 
 namespace OpenTabletDriver.Daemon.Library.Interop.Timer
 {
-    using static Windows;
-
     internal class WindowsTimer : ITimer, IDisposable
     {
         public WindowsTimer()

--- a/OpenTabletDriver.Daemon.Library/OpenTabletDriver.Daemon.Library.csproj
+++ b/OpenTabletDriver.Daemon.Library/OpenTabletDriver.Daemon.Library.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup Label="NuGet Packages">
-    <PackageReference Include="Octokit" Version="0.50.0" />
-    <PackageReference Include="SharpZipLib" Version="1.3.3" />
+    <PackageReference Include="Octokit" Version="14.0.0" />
+    <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20253.1" />
     <PackageReference Include="WaylandNET" Version="0.2.0" />
   </ItemGroup>

--- a/OpenTabletDriver.Native.Linux/OpenTabletDriver.Native.Linux.csproj
+++ b/OpenTabletDriver.Native.Linux/OpenTabletDriver.Native.Linux.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="NuGet Packages">
-    <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
   </ItemGroup>
 
 </Project>

--- a/OpenTabletDriver.Native.MacOS/OpenTabletDriver.Native.MacOS.csproj
+++ b/OpenTabletDriver.Native.MacOS/OpenTabletDriver.Native.MacOS.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="NuGet Packages">
-    <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
   </ItemGroup>
 
 </Project>

--- a/OpenTabletDriver.Native.Windows/Generic/SafeFileHandle.cs
+++ b/OpenTabletDriver.Native.Windows/Generic/SafeFileHandle.cs
@@ -11,7 +11,7 @@ namespace OpenTabletDriver.Native.Windows
 
         protected override bool ReleaseHandle()
         {
-            return Windows.CloseHandle(handle);
+            return WindowsAPI.CloseHandle(handle);
         }
     }
 }

--- a/OpenTabletDriver.Native.Windows/OpenTabletDriver.Native.Windows.csproj
+++ b/OpenTabletDriver.Native.Windows/OpenTabletDriver.Native.Windows.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="NuGet Packages">
-    <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
   </ItemGroup>
 
 </Project>

--- a/OpenTabletDriver.Native.Windows/WindowsAPI.cs
+++ b/OpenTabletDriver.Native.Windows/WindowsAPI.cs
@@ -6,7 +6,7 @@ using OpenTabletDriver.Native.Windows.Timers;
 
 namespace OpenTabletDriver.Native.Windows
 {
-    public static class Windows
+    public static class WindowsAPI
     {
         #region Display
 

--- a/OpenTabletDriver.Tests/OpenTabletDriver.Tests.csproj
+++ b/OpenTabletDriver.Tests/OpenTabletDriver.Tests.csproj
@@ -8,15 +8,15 @@
 
   <ItemGroup Label="NuGet Packages">
     <PackageReference Include="DiffPlex" Version="1.7.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.15" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/OpenTabletDriver.UI.Library/OpenTabletDriver.UI.Library.csproj
+++ b/OpenTabletDriver.UI.Library/OpenTabletDriver.UI.Library.csproj
@@ -39,13 +39,13 @@
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
   </ItemGroup>
 
   <!-- TODO -->
   <ItemGroup Label="Windows-specific Nuget Packages">
-    <PackageReference Include="WindowsShortcutFactory" Version="1.1.0" />
+    <PackageReference Include="WindowsShortcutFactory" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenTabletDriver.UI.Tests/OpenTabletDriver.UI.Tests.csproj
+++ b/OpenTabletDriver.UI.Tests/OpenTabletDriver.UI.Tests.csproj
@@ -8,15 +8,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.10.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-        <PackageReference Include="Moq" Version="4.18.4" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="FluentAssertions" Version="8.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="Moq" Version="4.20.72" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/OpenTabletDriver/Devices/WinUSB/WinUSBInterface.cs
+++ b/OpenTabletDriver/Devices/WinUSB/WinUSBInterface.cs
@@ -7,7 +7,7 @@ using HidSharp.Reports;
 using OpenTabletDriver.Devices.HidSharpBackend;
 using OpenTabletDriver.Native.Windows;
 using OpenTabletDriver.Native.Windows.USB;
-using static OpenTabletDriver.Native.Windows.Windows;
+using static OpenTabletDriver.Native.Windows.WindowsAPI;
 using static OpenTabletDriver.Native.Windows.WinUsb;
 
 namespace OpenTabletDriver.Devices.WinUSB

--- a/OpenTabletDriver/OpenTabletDriver.csproj
+++ b/OpenTabletDriver/OpenTabletDriver.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup Label="NuGet Packages">
     <PackageReference Include="HidSharpCore" Version="1.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0-rc.1.21451.13" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NetEscapades.EnumGenerators" Version="1.0.0-beta08" PrivateAssets="all" ExcludeAssets="runtime" />
   </ItemGroup>


### PR DESCRIPTION
Also renames `OpenTabletDriver.Native.Windows.Windows` to `OpenTabletDriver.Native.Windows.WindowsAPI` to avoid a global namespace conflict.

Source generator is only upgraded to 4.8 instead of the newest 4.12, as .NET 8.0 only includes a 4.8 compiler. See https://aka.ms/roslyn-packages for more information

Avalonia was not able to be upgraded seamlessly - upgrading to latest causes an NRE on startup, and as such will need further investigation.