### PR TITLE
[06x] eng/lib.sh: Autodetect VERSION_SUFFIX when unset

### DIFF
--- a/eng/lib.sh
+++ b/eng/lib.sh
@@ -9,6 +9,25 @@ set -eu
 
 VERSION_SUFFIX=${VERSION_SUFFIX:-}
 
+# if unset, autodetect suffix from git
+if [ -z "$VERSION_SUFFIX" ]; then
+  # limit git repo discovery to project root
+  export GIT_CEILING_DIRECTORIES="$(realpath $(dirname "${BASH_SOURCE[0]}")/../..)"
+
+  if hash git &>/dev/null && hash sed &>/dev/null; then
+    VERSION_SUFFIX="$(git describe --long --tags --dirty | sed -E 's/^v((.\.)*.)-(.*)$/\3/')"
+
+    # don't set suffix if this is a tagged commit
+    COMMIT_DISTANCE_FROM_TAG="$(sed -E 's/^([0-9]+)-(.*)$/\1/' <<< "$VERSION_SUFFIX")"
+    if [ "$COMMIT_DISTANCE_FROM_TAG" -eq "0" ]; then
+      echo "INFO: This looks like a tagged commit, not setting a version suffix"
+      unset VERSION_SUFFIX
+    fi
+  else
+    echo "WARN: VERSION_SUFFIX unset and git or sed not found, VERSION_SUFFIX remains unset!"
+  fi
+fi
+
 ### Global variables
 
 PREV_PATH=${PWD}


### PR DESCRIPTION
Detects correct version suffix based on git tags

Solves #3538 for 0.6.x

- [x] Linux Build
- [ ] Windows Build

Fixing Windows build is out of my skillset for now.

**Has bugs:**
- Assumes we're in a git root
- Assumes tags are exactly e.g. `v0.7.0.0` - does not support `v0.7.0.0alpha` or similar