### PR TITLE
[06x] UX/About: Add developers and documenters

### DIFF
--- a/OpenTabletDriver.UX/App.cs
+++ b/OpenTabletDriver.UX/App.cs
@@ -143,9 +143,9 @@ namespace OpenTabletDriver.UX
             WebsiteLabel = "OpenTabletDriver GitHub Repository",
             Website = new Uri(@"https://github.com/OpenTabletDriver/OpenTabletDriver"),
             Version = $"v{Version}",
-            Developers = new string[] { "InfinityGhost", "X9VoiD" },
+            Developers = new string[] { "InfinityGhost", "X9VoiD", "gonX", "jamesbt365", "Kuuube", "AkiSakurai" },
             Designers = new string[] { "InfinityGhost" },
-            Documenters = new string[] { "InfinityGhost" },
+            Documenters = new string[] { "InfinityGhost", "gonX", "jamesbt365", "Kuuube" },
             License = string.Empty,
             Copyright = string.Empty,
             Logo = Logo.WithSize(256, 256)


### PR DESCRIPTION
Fixes #1955 

(below titles are kinda unofficial, just what springs to mind)
Adds the following people:

Developers:
@AkiSakurai: Significant MacOS code coverage, "best practices" code PR's
@Kuuuube: Configurations, partial Windows maintainer
@gonX: Linux maintainer, CI/meta contributions, partial core knowledge, PR reviews
@jamesbt365: Configurations maintainer, partial core knowledge, PR reviews

Documenters:
@Kuuuube: Wiki contributor
@gonX: Wiki contributor and website responsibility
@jamesbt365: Wiki contributor

Ordering can be adjusted, I just put in whoever came to mind first. Maybe alphabetical ordering for people below Infinity and X9VoiD?

We can also put some responsibilities or a few keywords in per-developer, like:
- InfinityGhost, Creator
- X9VoiD, Core Developer
- gonX, Maintainer
- etc.

Does not need a forward port (yet) because there is no "about" dialog in Avalonia yet.