### PR TITLE
[06x] RelativeOutputMode warn on reset spam

### DIFF
--- a/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
@@ -19,7 +19,7 @@ namespace OpenTabletDriver.Plugin.Output
         private bool outOfRange;
 
         // for handling detection of low resetTimes
-        private uint _resets, _passes;
+        private uint _resets;
         private bool _warnedBadResets = false;
 
         /// <summary>
@@ -70,7 +70,6 @@ namespace OpenTabletDriver.Plugin.Output
             {
                 _resetTime = value;
                 _resets = 0;
-                _passes = 0;
                 _warnedBadResets = false;
             }
             get => _resetTime;
@@ -101,11 +100,11 @@ namespace OpenTabletDriver.Plugin.Output
                     lastTransformedPos = null;
                     _resets++;
                 }
-                else _passes++;
+                else _resets = 0;
 
                 if (!_warnedBadResets &&
                     (_warnedBadResets =
-                        _resets > 10 && _resets > _passes))
+                        _resets > 10))
                     Log.Write("RelativeOutputMode",
                         $"Position reset spam detected - the configured reset time ({ResetTime.TotalMilliseconds} ms) is likely too low",
                         LogLevel.Warning);

--- a/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
@@ -105,7 +105,7 @@ namespace OpenTabletDriver.Plugin.Output
                 if (!_warnedBadResets &&
                     (_warnedBadResets =
                         _resets > 10))
-                    Log.Write("RelativeOutputMode",
+                    Log.WriteNotify("RelativeOutputMode",
                         $"Position reset spam detected - the configured reset time ({ResetTime.TotalMilliseconds} ms) is likely too low",
                         LogLevel.Warning);
 


### PR DESCRIPTION
Fixes #1947 for 0.6.x. Will warn the user if 10 consecutive resets have been hit. Unsure if this should error instead.

Alternative fixes could have been calculating a ratio, maybe >10%? It would help detect resets times that are marginally too low, especially in the case of 200hz tablets that alternate between 4 and 6ms reports (as seen in 200Hz USB1.1 Wacoms).

~~Enabling data validation in the UI seems like a larger undertaking: https://gist.github.com/cwensley/8348615c67618dc46102~~ We can actually just check in `ApplySettings()` if needed. Propagating it back into the UI is the hard part.
