### PR TITLE
Add support for XP-Pen Star 02

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 02.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 02.json
@@ -1,0 +1,38 @@
+{
+  "Name": "XP-Pen Star 02",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 203.2,
+      "Height": 127,
+      "MaxX": 32000,
+      "MaxY": 20000
+    },
+    "Pen": {
+      "MaxPressure": 2047,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 5
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 21827,
+      "ProductID": 80,
+      "InputReportLength": 8,
+      "OutputReportLength": 0,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "OutputInitReport": [],
+      "DeviceStrings": {
+      },
+      "InitializationStrings": [
+        100,
+        123
+      ]
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1",
+    "Interface": "0"
+  }
+}

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 02.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Star 02.json
@@ -22,9 +22,6 @@
       "InputReportLength": 8,
       "OutputReportLength": 0,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
-      "OutputInitReport": [],
-      "DeviceStrings": {
-      },
       "InitializationStrings": [
         100,
         123

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -285,5 +285,6 @@
 | XP-Pen Deco Pro Small         |  Missing Features | Tilt and wheel are not yet supported.
 | XP-Pen Deco Pro SW            |  Missing Features | Wheel is not yet supported.
 | XP-Pen Innovator 16           |  Missing Features | Wheel is not yet supported.
+| XP-Pen Star 02                |  Missing Features | Pen and auxiliary buttons may produce malformed reports. Windows: Requires Zadig's WinUSB to be installed on interface 0.
 | XP-Pen Star 06                |  Missing Features | Wheel is not yet supported.
 | XP-Pen Star 06C               |  Missing Features | Wheel is not yet supported.


### PR DESCRIPTION
Fixes #3738, all information is within that thread.

Pen and tablet buttons may cause malformed reports, but the user has mentioned that their pen is broken and because of that its too hard to tell what is good data and what is bad data. 

Supporting this now in hopes that somebody can help us confirm in the future if this works.