### PR TITLE
[Backport] Add string for kamvas pro 13

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 13.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas Pro 13.json
@@ -36,7 +36,7 @@
       "InputReportLength": 12,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
       "DeviceStrings": {
-        "201": "HUION_M182_\\d{6}$"
+        "201": "HUION_M(182|20k)_\\d{6}$"
       },
       "InitializationStrings": [
         200


### PR DESCRIPTION
Backport of  #3755

The first identifier already had this string for some reason (even though the config on master didnt).