### PR TITLE
Revert Huion 420 parser change

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/420.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/420.json
@@ -17,7 +17,7 @@
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 8,
-      "ReportParser": "OpenTabletDriver.Tablet.TabletReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
       "DeviceStrings": {
         "6": "^\\x00*420\\x00*$"
       },
@@ -30,7 +30,7 @@
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 8,
-      "ReportParser": "OpenTabletDriver.Tablet.TabletReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
       "DeviceStrings": {
         "6": "^$",
         "121": "^H850_F210$"


### PR DESCRIPTION
Some Huion 420 tablets send something that breaks TabletReportParser. Revert of https://github.com/OpenTabletDriver/OpenTabletDriver/commit/2bfe9183f65d5840e5e2f0ac551075e2cee5a3aa.

Verification https://discord.com/channels/615607687467761684/615611007951306863/1328244031796285481