### PR TITLE
[06x] Fix support for pressure sensitivity in Adobe software on macOS

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/MacOSVirtualMouse.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/MacOSVirtualMouse.cs
@@ -302,10 +302,12 @@ namespace OpenTabletDriver.Desktop.Interop.Input
                 buttons |= 2;
             else if (IsButtonSet(_currButtonStates, CGMouseButton.kCGMouseButtonCenter))
                 buttons |= 4;
-            CGEventSetIntegerValueField(_mouseEvent, CGEventField.tabletEventPointButtons, buttons);
+
+            CGEventSetDoubleValueField(_mouseEvent, CGEventField.mouseEventPressure, _pressure ?? 1.0);
 
             CGEventSetIntegerValueField(_mouseEvent, CGEventField.mouseEventSubtype, (long)CGMouseEventSubtype.TabletPoint);
-            CGEventSetDoubleValueField(_mouseEvent, CGEventField.mouseEventPressure, _pressure ?? 1.0);
+            // The fields of tabletEvent can only be set after the subtype is defined.
+            CGEventSetIntegerValueField(_mouseEvent, CGEventField.tabletEventPointButtons, buttons);
             CGEventSetIntegerValueField(_mouseEvent, CGEventField.tabletEventDeviceID, deviceId);
             CGEventSetDoubleValueField(_mouseEvent, CGEventField.tabletEventPointPressure, _pressure ?? 1.0);
 

--- a/OpenTabletDriver.Desktop/Interop/Input/MacOSVirtualMouse.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/MacOSVirtualMouse.cs
@@ -327,6 +327,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input
             CGEventPost(CGEventTapLocation.kCGHIDEventTap, _mouseEvent);
             // Fields in a CGEvent are stored in a union determined by the event type,
             // and they cannot be safely reused.
+            CFRelease(_mouseEvent);
             _mouseEvent = CGEventCreate(_eventSource);
         }
 

--- a/OpenTabletDriver.Native/OSX/Input/CGEventField.cs
+++ b/OpenTabletDriver.Native/OSX/Input/CGEventField.cs
@@ -23,11 +23,14 @@ namespace OpenTabletDriver.Native.OSX.Input
         scrollWheelEventPointDeltaAxis2 = 97, // int
         scrollWheelEventPointDeltaAxis3 = 98, // int
         scrollWheelEventInstantMouser = 14, // int
-        tabletEventPointButtons = 18, //int
-        tabletEventPointPressure = 19, //double
+        tabletEventPointButtons = 18, // int
+        tabletEventPointPressure = 19, // double
         tabletEventTiltX = 20, // double
         tabletEventTiltY = 21, // double
-        tabletProximityEventPointerType = 37, //int
-        tabletProximityEventEnterProximity = 38, //int
+        tabletEventDeviceID = 24, // int
+        tabletProximityEventDeviceID = 31, // int
+        tabletProximityEventCapabilityMask = 36, // int
+        tabletProximityEventPointerType = 37, // int
+        tabletProximityEventEnterProximity = 38, // int
     }
 }

--- a/OpenTabletDriver.Native/OSX/Input/WacomCapabilityMask.cs
+++ b/OpenTabletDriver.Native/OSX/Input/WacomCapabilityMask.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace OpenTabletDriver.Native.OSX.Input;
+
+/*
+ * see https://github.com/Wacom-Developer/wacom-device-kit-macos-scribble-demo/blob/754c72c0c76e23e57d97f9a773cab522fb502f81/ScribbleDemo/Wacom.h#L24-L37
+ */
+[Flags]
+public enum WacomCapabilityMask : long
+{
+    deviceIdBitMask = 0x001,
+    absXBitMask = 0x002,
+    absYBitMask = 0x004,
+    buttonsBitMask = 0x040,
+    tiltXBitMask = 0x080,
+    tiltYBitMask = 0x100,
+    pressureBitMask = 0x400,
+}


### PR DESCRIPTION
Adobe software requires specific Wacom information to recognize a tablet. We set this regardless, so events from the tablet get recognized by Adobe software.