### PR TITLE
[06x] Standardize release asset naming

### DIFF
--- a/eng/linux/Debian/package.sh
+++ b/eng/linux/Debian/package.sh
@@ -2,8 +2,7 @@
 
 # increment this when releasing a new package of the same upstream version
 # where the only changes are to the packaging itself
-PKG_VER="1"
-PKG_FILE="${OTD_LNAME}-${OTD_VERSION}-${PKG_VER}-x64.deb"
+PKG_FILE="${OTD_LNAME}-${OTD_VERSION}_x64.deb"
 
 debian_src="$(readlink -f $(dirname "${BASH_SOURCE[0]}"))"
 
@@ -39,9 +38,9 @@ EOF
 
 echo "Generating debian/changelog..."
 cat <<EOF > "${output}/${OTD_LNAME}-${OTD_VERSION}/debian/changelog"
-${OTD_LNAME} (${OTD_VERSION}-${PKG_VER}) unstable; urgency=low
+${OTD_LNAME} (${OTD_VERSION}) unstable; urgency=low
 
-  * New version: ${OTD_VERSION}-${PKG_VER}
+  * New version: ${OTD_VERSION}
 
  -- InfinityGhost <infinityghostgit@gmail.com>  `LANG=C date +"%a, %d %b %Y %X %z"`
 
@@ -53,4 +52,4 @@ cd "${output}/${OTD_LNAME}-${OTD_VERSION}"
 # TODO: fix --no-sign
 dpkg-buildpackage --no-sign -b
 cd "${PREV_DIR}"
-mv "${output}/${OTD_LNAME}_${OTD_VERSION}-${PKG_VER}_amd64.deb" "${output}/${PKG_FILE}"
+mv "${output}/${OTD_LNAME}_${OTD_VERSION}_amd64.deb" "${output}/${PKG_FILE}"

--- a/eng/linux/RedHat/package.sh
+++ b/eng/linux/RedHat/package.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
 
-# increment this when releasing a new package of the same upstream version
-# where the only changes are to the packaging itself
-PKG_VER="1"
-PKG_FILE="${OTD_LNAME}-${OTD_VERSION}-${PKG_VER}-x64.rpm"
-
 redhat_src="$(readlink -f $(dirname "${BASH_SOURCE[0]}"))"
 
 output="$(readlink -f "${1}")"
@@ -19,7 +14,7 @@ echo "Generating ${OTD_LNAME}.spec..."
 cat << EOF > "${output}/SPECS/${OTD_LNAME}.spec"
 Name: ${OTD_LNAME}
 Version: ${OTD_VERSION}
-Release: ${PKG_VER}
+Release: 1
 Summary: A ${OTD_DESC}
 
 Source0: ${OTD_LNAME}-${OTD_VERSION}.tar.gz

--- a/eng/macos/package.sh
+++ b/eng/macos/package.sh
@@ -68,7 +68,7 @@ build "PROJECTS" "extra_args"
 if [ "${PACKAGE}" = "true" ]; then
   echo -e "\nPreparing package..."
 
-  pkg_file="${OTD_NAME}-${OTD_VERSION}-${NET_RUNTIME}.tar.gz"
+  pkg_file="${OTD_NAME}-${OTD_VERSION}_${NET_RUNTIME}.tar.gz"
   pkg_root="${OUTPUT}/${OTD_NAME}.app"
 
   move_to_nested "${OUTPUT}" "${pkg_root}/Contents/MacOS"

--- a/eng/windows/package.ps1
+++ b/eng/windows/package.ps1
@@ -38,6 +38,12 @@ if (!($isRelease)) {
     $Options += "/p:SourceRevisionId=$(git rev-parse --short HEAD)";
 }
 
+$gitVersion = "$(git describe --tags --abbrev=0)"
+if (Test-Path variable:gitVersion) {
+  $gitVersion = $gitVersion.replace('v','');
+  Write-Output "Git reports version $gitVersion";
+}
+
 function exitWithError {
     param ($message)
 
@@ -97,7 +103,12 @@ Write-Output "${nl}Build finished! Binaries created in $output";
 if ($isPackage) {
     Write-Output "${nl}Creating package...";
     Copy-Item -Path $PSScriptRoot/convert_to_portable.bat -Destination $output;
-    $zipPath = "$output/OpenTabletDriver-$netRuntime.zip";
+    if (Test-Path variable:gitVersion) {
+      $zipPath = "$output/OpenTabletDriver-$gitVersion_$netRuntime.zip";
+    } else {
+      Write-Output "${nl}Unable to determine release version, using fallback naming for zip";
+      $zipPath = "$output/OpenTabletDriver_$netRuntime.zip";
+    }
     if (Test-Path $zipPath) {
         Remove-Item $zipPath;
     }


### PR DESCRIPTION
Solves #3123 as much as we can for 0.6.x

Will need a corresponding PR ready on web before 0.6.5.1 release.

Using the new proposed format in [this comment](https://github.com/OpenTabletDriver/OpenTabletDriver/issues/3123#issuecomment-2614511586): `OpenTabletDriver-<version>_<platform>-<arch>.<ext>`