### PR TITLE
Fill Empty screen with a Label when a tablet isn't detected or selected

### DIFF
--- a/OpenTabletDriver.UX/Controls/ControlPanel.cs
+++ b/OpenTabletDriver.UX/Controls/ControlPanel.cs
@@ -146,7 +146,11 @@ namespace OpenTabletDriver.UX.Controls
                 SetPageVisibility(toolEditor, false);
 
                 if (tabControl.SelectedPage != logView.Parent)
-                    tabControl.SelectedIndex = 0;
+                {
+                    tabControl.SelectedIndex = Profile == null ?
+                        tabControl.Pages.IndexOf(placeholder.Parent as TabPage) :
+                        0;
+                }
             }
 
             SetPageVisibility(logView, true);

--- a/OpenTabletDriver.UX/Controls/Output/OutputModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/OutputModeEditor.cs
@@ -91,6 +91,7 @@ namespace OpenTabletDriver.UX.Controls.Output
         private RelativeModeEditor relativeModeEditor = new RelativeModeEditor();
         private TypeDropDown<IOutputMode> outputModeSelector = new TypeDropDown<IOutputMode> { Width = 300 };
         private Label outputModeUnsupported = new Label { Text = "No supported output mode selected.", TextAlignment = TextAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
+        private Label tabletUnavailable = new Label { Text = "No tablets were detected or selected.", TextAlignment = TextAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
 
         public void SetTabletSize(TabletReference tablet)
         {
@@ -120,6 +121,7 @@ namespace OpenTabletDriver.UX.Controls.Output
         {
             bool showAbsolute = false;
             bool showRelative = false;
+
             if (store?.GetTypeInfo<IOutputMode>() is TypeInfo outputMode)
             {
                 showAbsolute = outputMode.IsSubclassOf(typeof(AbsoluteOutputMode));
@@ -130,8 +132,10 @@ namespace OpenTabletDriver.UX.Controls.Output
                 editorContainer.Content = absoluteModeEditor;
             else if (showRelative)
                 editorContainer.Content = relativeModeEditor;
-            else
+            else if (Profile != null)
                 editorContainer.Content = outputModeUnsupported;
+            else
+                editorContainer.Content = tabletUnavailable;
         }
     }
 }

--- a/OpenTabletDriver.UX/Controls/Output/OutputModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/OutputModeEditor.cs
@@ -70,6 +70,7 @@ namespace OpenTabletDriver.UX.Controls.Output
             ProfileChanged?.Invoke(this, new EventArgs());
             UpdateTablet();
             UpdateOutputMode(Profile?.OutputMode);
+            outputModeSelector.Enabled = Profile != null;
         }
 
         public BindableBinding<OutputModeEditor, Profile> ProfileBinding

--- a/OpenTabletDriver.UX/Controls/TabletSwitcherPanel.cs
+++ b/OpenTabletDriver.UX/Controls/TabletSwitcherPanel.cs
@@ -138,11 +138,14 @@ namespace OpenTabletDriver.UX.Controls
                         this.SelectedIndex = 0;
                         this.OnSelectedValueChanged(EventArgs.Empty);
                     }
+
+                    this.Enabled = true;
                 }
                 else
                 {
                     this.SelectedValue = null;
                     this.OnSelectedValueChanged(EventArgs.Empty);
+                    this.Enabled = false;
                 }
             }
         }


### PR DESCRIPTION
When a tablet is connected & selected, Profile is always non-null.
A null profile probably either means a tablet isn't selected, or none are available.

![image](https://github.com/user-attachments/assets/2031e2bc-6aa6-415e-a778-c27b57114eca)