### PR TITLE
[06x] Fix: Prevent proximity event on mouse up for macOS

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/MacOSVirtualMouse.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/MacOSVirtualMouse.cs
@@ -244,7 +244,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input
         private void ApplyTabletValues()
         {
             // send proximity events if there are no reports for a while.
-            if (_currButtonStates == 0)
+            if (_currButtonStates == 0 && _prevButtonStates == 0)
             {
                 var elapsed = _stopWatch.ElapsedMilliseconds;
                 _stopWatch.Restart();


### PR DESCRIPTION
Resolves an issue where a proximity event is incorrectly sent on mouse up, causing Wacom Inkspace app to fail in stopping the stroke after mouse release.