### PR TITLE
[!] 0.6.5.1 nullability quickfix

### DIFF
--- a/OpenTabletDriver.Plugin/OpenTabletDriver.Plugin.csproj
+++ b/OpenTabletDriver.Plugin/OpenTabletDriver.Plugin.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup Label="Project Properties">
     <TargetFrameworks>$(FrameworkBase)</TargetFrameworks>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet Package">

--- a/OpenTabletDriver.Plugin/Tablet/DigitizerSpecifications.cs
+++ b/OpenTabletDriver.Plugin/Tablet/DigitizerSpecifications.cs
@@ -47,6 +47,8 @@ namespace OpenTabletDriver.Plugin.Tablet
             return objectType == typeof(double);
         }
 
+#nullable enable
+
         public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
             if (value == null)


### PR DESCRIPTION
This solves all current check warnings in the project.

_Without this PR_, plugin developers (and likely osu!framework) may be seeing misleading or false-negatives in regards to nullability on the API types, and it would've been worth not doing a NuGet release for that - mostly because the types have currently not been picked with nullability in mind - #3691 would also address this but will not be ready in time for 0.6.5.1.

Note issue #3687 