### PR TITLE
[06x] workflows/release: Move NuGet deploy to its own step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,8 +66,18 @@ jobs:
           name: OpenTabletDriver.osx-x64.tar.gz
           path: ./dist/macos/*.tar.gz
 
+  nuget:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'workflow_dispatch' }}
+    name: NuGet Deploy (Ubuntu Host)
+    steps:
+      - name: Install required packages
+        run: sudo apt install -y debhelper dotnet-sdk-8.0 build-essential
+
+      - name: Checkout OpenTabletDriver Repository
+        uses: actions/checkout@v4
+
       - name: Publish NuGet package
-        if: ${{ github.event_name != 'workflow_dispatch' }}
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.NUGET_AUTH_TOKEN }}
           SOURCE: https://api.nuget.org/v3/index.json


### PR DESCRIPTION
This should make re-running failed NuGet deploys easier

Fixes #3617 for 0.6.x

Changes are difficult to test so we'll have to keep an eye on whether this works properly when release happens.
The idea is that NuGet deploy should only be possible with a tagged release.