### PR TITLE
[Avalonia] build/linux: Add 'Simple' package

### DIFF
--- a/eng/linux/Simple/README-SimplePackage.md
+++ b/eng/linux/Simple/README-SimplePackage.md
@@ -1,0 +1,18 @@
+About
+=====
+
+This packaging script is mostly intended for use with testing and
+with our CI/CD scripts to allow for easy testing of PR's
+
+If you are testing a new configuration, you likely need new udev rules as well.
+These are included as `70-opentabletdriver.rules` and can be placed in
+/etc/udev/rules.d/. You will need to reload udev rules after putting the file
+there.
+
+
+Requirements
+============
+
+- Existing OpenTabletDriver install
+or
+- Having permissions to `uinput` and `hidraw`

--- a/eng/linux/Simple/package.sh
+++ b/eng/linux/Simple/package.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# This is a packaging script is intended to just provide the barebones files
+#
+# At the time of writing the script (Avalonia), the following files should be
+# emitted: Apps and local dependencies (e.g. Avalonia has Skia), as well as the
+# local README and udev rules
+
+PKG_FILE="${OTD_LNAME}-${OTD_VERSION}-${NET_RUNTIME}_simple.tar.gz"
+folder_name="${OTD_LNAME}-Simple"
+
+output="$(readlink -f "${1}")"
+
+# strip last slash if present
+output="${output%/}"
+
+packager_folder="$(dirname "${BASH_SOURCE[0]}")"
+
+[ "${BUILD}" != "true" ] && exit_with_error "ERR: This package needs build files(?)"
+
+echo "Moving build output to subfolder"
+move_to_nested "${output}" "${output}/bin"
+
+cp -v -- "${REPO_ROOT}/LICENSE" "${output}/"
+cp -v -- "${packager_folder}/README-SimplePackage.md" "${output}/"
+
+generate_rules "${output}/70-opentabletdriver.rules"
+move_to_nested "${output}" "${output}/${folder_name}"
+create_binary_tarball "${output}/${folder_name}" "${output}/${PKG_FILE}"


### PR DESCRIPTION
Includes only the most essential files needed for local use.

Useful for 'portable' use, e.g. existing users with a functional OTD setup testing PR's.

Isn't included for CI yet - it would just duplicate more code needlessly and would make my work on #3771 more difficult.

tar file list on Avalonia:
```
opentabletdriver-Simple/
opentabletdriver-Simple/70-opentabletdriver.rules
opentabletdriver-Simple/bin/
opentabletdriver-Simple/bin/libHarfBuzzSharp.so
opentabletdriver-Simple/bin/libSkiaSharp.so
opentabletdriver-Simple/bin/OpenTabletDriver.Daemon
opentabletdriver-Simple/bin/OpenTabletDriver.UI
opentabletdriver-Simple/LICENSE
opentabletdriver-Simple/README-SimplePackage.md
```