### PR TITLE
[06x] Fix memory leaks on macOS

### DIFF
--- a/OpenTabletDriver.Daemon/OpenTabletDriver.Daemon.csproj
+++ b/OpenTabletDriver.Daemon/OpenTabletDriver.Daemon.csproj
@@ -6,6 +6,7 @@
     <NoWarn>VSTHRD100; VSTHRD101; VSTHRD110; VSTHRD200</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TieredPGO>true</TieredPGO>
+    <AutoreleasePoolSupport>true</AutoreleasePoolSupport>
   </PropertyGroup>
 
   <ItemGroup Label="Project References">

--- a/OpenTabletDriver.Desktop/Interop/Input/MacOSVirtualMouse.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/MacOSVirtualMouse.cs
@@ -326,9 +326,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input
 
         private void PostEvent()
         {
-            var pool = ObjectiveCRuntime.objc_autoreleasePoolPush();
             CGEventPost(CGEventTapLocation.kCGHIDEventTap, _mouseEvent);
-            ObjectiveCRuntime.objc_autoreleasePoolPop(pool);
             // Fields in a CGEvent are stored in a union determined by the event type,
             // and they cannot be safely reused.
             CFRelease(_mouseEvent);

--- a/OpenTabletDriver.Desktop/Interop/Input/MacOSVirtualMouse.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/MacOSVirtualMouse.cs
@@ -326,7 +326,9 @@ namespace OpenTabletDriver.Desktop.Interop.Input
 
         private void PostEvent()
         {
+            var pool = ObjectiveCRuntime.objc_autoreleasePoolPush();
             CGEventPost(CGEventTapLocation.kCGHIDEventTap, _mouseEvent);
+            ObjectiveCRuntime.objc_autoreleasePoolPop(pool);
             // Fields in a CGEvent are stored in a union determined by the event type,
             // and they cannot be safely reused.
             CFRelease(_mouseEvent);

--- a/OpenTabletDriver.Native/OSX/OSX.cs
+++ b/OpenTabletDriver.Native/OSX/OSX.cs
@@ -63,8 +63,9 @@ namespace OpenTabletDriver.Native.OSX
         [DllImport(Quartz)]
         public extern static ulong CGEventSourceFlagsState(int stateID);
 
-        [DllImport(Quartz)]
-        public extern static CGEventRef CGEventPost(CGEventTapLocation tap, CGEventRef eventRef);
+        [DllImport(Quartz, EntryPoint = "CGEventPost")]
+        private extern static void _CGEventPost(CGEventTapLocation tap, CGEventRef eventRef);
+
 
         [DllImport(Quartz)]
         public extern static CGError CGGetActiveDisplayList(uint maxDisplays,
@@ -76,6 +77,13 @@ namespace OpenTabletDriver.Native.OSX
         public static double GetDoubleClickInterval()
         {
             return objc_msgSend_double(objc_getClass("NSEvent"), sel_registerName("doubleClickInterval"));
+        }
+
+        public static void CGEventPost(CGEventTapLocation tap, CGEventRef eventRef)
+        {
+            var pool = objc_autoreleasePoolPush();
+            _CGEventPost(tap, eventRef);
+            objc_autoreleasePoolPop(pool);
         }
     }
 }

--- a/OpenTabletDriver.Native/OSX/ObjectiveCRuntime.cs
+++ b/OpenTabletDriver.Native/OSX/ObjectiveCRuntime.cs
@@ -15,6 +15,12 @@ namespace OpenTabletDriver.Native.OSX
 
         [DllImport(ObjCLibrary, CharSet = CharSet.Ansi)]
         public static extern IntPtr objc_getClass(string namePtr);
+
+        [DllImport(ObjCLibrary)]
+        public static extern IntPtr objc_autoreleasePoolPush();
+
+        [DllImport(ObjCLibrary)]
+        public static extern void objc_autoreleasePoolPop(IntPtr pool);
     }
 }
 

--- a/OpenTabletDriver.UX.MacOS/OpenTabletDriver.UX.MacOS.csproj
+++ b/OpenTabletDriver.UX.MacOS/OpenTabletDriver.UX.MacOS.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(FrameworkBase)</TargetFramework>
     <RuntimeIdentifiers>osx-x64</RuntimeIdentifiers>
+    <AutoreleasePoolSupport>true</AutoreleasePoolSupport>
   </PropertyGroup>
 
   <ItemGroup Label="NuGet Packages">


### PR DESCRIPTION
The .NET runtime do not enables the autorelease pool by default.

This causes memory leaks in long-running processes that call Objective-C functions relying on the autorelease pool for memory management.

Although CGEventPost is not an Objective-C function, it internally depends on CFAutorelease to release locally created objects.