### PR TITLE
Add support for Huion Kamvas 24 (GS2401)

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 24.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 24.json
@@ -1,0 +1,32 @@
+{
+  "Name": "Huion Kamvas 24",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 526.85,
+      "Height": 296.35,
+      "MaxX": 105370,
+      "MaxY": 59270
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ButtonCount": 2
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 9580,
+      "ProductID": 109,
+      "InputReportLength": 64,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
+      "DeviceStrings": {
+        "201": "HUION_M206_\\d{6}$"
+      },
+      "InitializationStrings": [
+        200
+      ]
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -37,6 +37,7 @@
 | Huion Kamvas 20               |     Supported     |
 | Huion Kamvas 22               |     Supported     |
 | Huion Kamvas 22 Plus          |     Supported     |
+| Huion Kamvas 24               |     Supported     |
 | Huion Kamvas 24 Plus          |     Supported     |
 | Huion Kamvas Pro 13 (2.5K)    |     Supported     |
 | Huion Kamvas Pro 16 (2.5K)    |     Supported     |


### PR DESCRIPTION
- Diagnostics: [kamvas-24-diag.json](https://github.com/user-attachments/files/18631525/kamvas-24-diag.json)
- String dump: [kamvas-24-stringdump.txt](https://github.com/user-attachments/files/18631526/kamvas-24-stringdump.txt)
- Tablet data recording: [kamvas-24-tablet-data.txt](https://github.com/user-attachments/files/18631527/kamvas-24-tablet-data.txt)
- [Discord confirmation on 7P's server](https://discord.com/channels/1242714066917523456/1242714067425038473/1335505058133184513)