### PR TITLE
[0.6.x] Improve config dir detection in tests

### DIFF
--- a/OpenTabletDriver.Tests/ConfigurationTest.cs
+++ b/OpenTabletDriver.Tests/ConfigurationTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using DiffPlex.DiffBuilder;
@@ -237,10 +238,13 @@ namespace OpenTabletDriver.Tests
             Assert.False(equality);
         }
 
-        private static readonly string ConfigurationProjectDir = Path.GetFullPath(Path.Join("../../../..", "OpenTabletDriver.Configurations"));
-        private static readonly string ConfigurationDir = Path.Join(ConfigurationProjectDir, "Configurations");
-        private static readonly IEnumerable<(string, string)> ConfigFiles = Directory.EnumerateFiles(ConfigurationDir, "*.json", SearchOption.AllDirectories)
-            .Select(f => (Path.GetRelativePath(ConfigurationDir, f), File.ReadAllText(f)));
+        private static string GetConfigDir([CallerFilePath] string sourceFilePath = "")
+        {
+            return Path.GetFullPath(Path.Join(sourceFilePath, "../../OpenTabletDriver.Configurations/Configurations"));
+        }
+
+        private static readonly IEnumerable<(string, string)> ConfigFiles = Directory.EnumerateFiles(GetConfigDir(), "*.json", SearchOption.AllDirectories)
+            .Select(f => (Path.GetRelativePath(GetConfigDir(), f), File.ReadAllText(f)));
 
         [Fact]
         public void Configurations_Verify_Configs_With_Schema()


### PR DESCRIPTION
Previously some tests failed with `dotnet test OpenTabletDriver.Tests --configuration Release --runtime linux-x64`, because the current working directory was `bin/Release/linux-x64` directory instead of the usual `bin/Release`, and it couldn't find the configuration directory in the `../../../..` path.

This PR prioritizes reading the config directory from an environment variable already used in other files.