### PR TITLE
[06x] Fix occasional sticky modifier keys issue on macOS

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/MacOSVirtualMouse.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/MacOSVirtualMouse.cs
@@ -319,9 +319,10 @@ namespace OpenTabletDriver.Desktop.Interop.Input
                 CGEventSetDoubleValueField(_mouseEvent, CGEventField.tabletEventTiltY, -_tilt.Value.Y / 90.0);
             }
 
-            // set keyboard modifier and filter out `nonCoalesced` and 0x20000000 flags
-            // see https://github.com/Hammerspoon/hammerspoon/blob/0ccc9d07641a660140d1d2f05b76f682b501a0e8/extensions/eventtap/libeventtap_event.m#L1558-L1560
-            CGEventSetFlags(_mouseEvent, CGEventSourceFlagsState(CGEventSourceStateHIDSystemState) & (0xffffffff ^ 0x20000100));
+            // This uses an undocumented flag that tells the system to automatically include the event flags in the event.
+            // It's a better approach than fetching the active event flags ourselves, as doing so can introduce a race condition
+            // (e.g., if a modifier key is released after we check its status but before the event is posted).
+            CGEventSetFlags(_mouseEvent, ~0U);
         }
 
         private void PostEvent()


### PR DESCRIPTION
This commit addresses an occasional issue on macOS where modifier keys (e.g., Shift, Control) could appear "sticky" in certain scenarios. The problem occurred because OpenTabletDriver had to fetch the active modifier key status before sending a pointer event. If a modifier key was released after the status was checked but before the event was posted, the application would receive outdated modifier information, causing the sticky key effect.

To resolve this, we now rely on a system-level mechanism to include the event flags (including modifier key states) directly in the event. This approach is more reliable than manually fetching the modifier status, as it avoids the race condition entirely.