### PR TITLE
Only clamp width and height in `Lock to usable area` if rotation is 0 or 180

### DIFF
--- a/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
@@ -252,10 +252,13 @@ namespace OpenTabletDriver.UX.Controls.Output
 
                 if (fullBounds.Width != 0 && fullBounds.Height != 0)
                 {
-                    if (display.Area.Width > fullBounds.Width)
-                        display.Area.Width = fullBounds.Width;
-                    if (display.Area.Height > fullBounds.Height)
-                        display.Area.Height = fullBounds.Height;
+                    if (display.Area.Rotation % 180 == 0)
+                    {
+                        if (display.Area.Width > fullBounds.Width)
+                            display.Area.Width = fullBounds.Width;
+                        if (display.Area.Height > fullBounds.Height)
+                            display.Area.Height = fullBounds.Height;
+                    }
 
                     var correction = GetOutOfBoundsAmount(display, display.Area.X, display.Area.Y);
                     display.Area.X -= correction.X;


### PR DESCRIPTION
These make it annoying for users that rotate their area in some cases. Eg. #3811

In theory we could implement a way to shrink the area by exactly how much is needed to fit inside the tablet's usable area for any given rotation. But this feels really strange in practice like I'm fighting OTD to set the area and it's "randomly" changing things that weren't intended to be changed. So I think it's better to just let the user figure it out themselves.

The important thing with `Lock to usable area` is that users can easily set their area offsets exactly to the edges.