### PR TITLE
Add support for Gaomon WH851

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/WH851.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/WH851.json
@@ -1,0 +1,41 @@
+{
+  "Name": "Gaomon WH851",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 203.2,
+      "Height": 127,
+      "MaxX": 40640,
+      "MaxY": 25400
+    },
+    "Pen": {
+      "MaxPressure": 16383,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 9
+    },
+    "MouseButtons": null,
+    "Touch": null
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 9580,
+      "ProductID": 8195,
+      "InputReportLength": 12,
+      "OutputReportLength": null,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.InspiroyReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "DeviceStrings": {
+        "201": "GM001_T21f_\\d{6}$"
+      },
+      "InitializationStrings": [
+        200
+      ]
+    }
+  ],
+  "AuxiliaryDeviceIdentifiers": [],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/WH851.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/WH851.json
@@ -13,19 +13,14 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 9
-    },
-    "MouseButtons": null,
-    "Touch": null
+    }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 8195,
       "InputReportLength": 12,
-      "OutputReportLength": null,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.InspiroyReportParser",
-      "FeatureInitReport": null,
-      "OutputInitReport": null,
       "DeviceStrings": {
         "201": "GM001_T21f_\\d{6}$"
       },

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/WH851.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/WH851.json
@@ -29,7 +29,6 @@
       ]
     }
   ],
-  "AuxiliaryDeviceIdentifiers": [],
   "Attributes": {
     "libinputoverride": "1"
   }

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -198,6 +198,7 @@
 | Gaomon M6                     |  Missing Features | Wheel and touch bar are not yet supported.
 | Gaomon M8                     |  Missing Features | Wheel is not yet supported.
 | Gaomon PD156 Pro              |  Missing Features | Wheel is not yet supported.
+| Gaomon WH851                  |  Missing Features | Wheel is not yet supported. Wireless is not yet supported.
 | Huion G10T                    |  Missing Features | Touchpad is not yet supported.
 | Huion GC610                   |  Missing Features | Touchpad is not yet supported.
 | Huion GT-156HD V2             |  Missing Features | Touch bar is not yet supported.


### PR DESCRIPTION
although duplicate of https://github.com/OpenTabletDriver/OpenTabletDriver/pull/3446, but I have tested the functionality:

## Aux Buttons

![image](https://github.com/user-attachments/assets/3a8d85e0-de6b-43c2-b23e-fc2809a7d16d)

## Wheel rotate (not supported yet)

- CW: `08 F1 01 01 00 01 00 00 00 00 00 00`
- CCW: `08 F1 01 01 00 02 00 00 00 00 00 00`

## Pen Buttons

![image](https://github.com/user-attachments/assets/337e9d9a-5a5f-4d7e-ae73-6331c8bd441b)

(OpenTabletDriver GUI 0.6.5.1 pen button settings are missing)

![image](https://github.com/user-attachments/assets/acfcaaf2-95fe-4474-ae40-0e27e78629ca)

## Pen Tilt

tilt range is -80 ~ 80 degs in both direction

![image](https://github.com/user-attachments/assets/4bf3bac5-e0f2-4c78-8880-a46b99165d57)

## Reporting Rate

- Hover: ~410 Hz
- Press: ~400 Hz to ~365 Hz, the greater the pressure, the lower the reporting rate
