### PR TITLE
Add configuration for Huion GT-191 V2

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/GT-191 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/GT-191 V2.json
@@ -1,0 +1,32 @@
+{
+  "Name": "Huion GT-191 V2",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 434.88,
+      "Height": 238.68,
+      "MaxX": 86976,
+      "MaxY": 47736
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ButtonCount": 2
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 9580,
+      "ProductID": 110,
+      "InputReportLength": 12,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
+      "DeviceStrings": {
+        "201": "HUION_M168_\\d{6}$"
+      },
+      "InitializationStrings": [
+        200
+      ]
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -16,6 +16,7 @@
 | Genius G-Pen 560              |     Supported     | Soft-buttons are bindable as aux buttons.
 | Huion 1060 Plus               |     Supported     |
 | Huion G930L                   |     Supported     |
+| Huion GT-191 V2               |     Supported     |
 | Huion GT-220 V2               |     Supported     |
 | Huion H1060P                  |     Supported     |
 | Huion H320M                   |     Supported     |


### PR DESCRIPTION
- Diagnostics: [Huion GT-191 V2.json](https://github.com/user-attachments/files/19039681/Huion.GT-191.V2.json)
- Device string index 201: `HUION_M168_171103`
- Tablet data recording: [tablet-data (4).txt](https://github.com/user-attachments/files/19039690/tablet-data.4.txt)
- Discord confirmation: https://discord.com/channels/615607687467761684/1344335235868790804
- Digitizer specification obtained from https://www.huion.com/comparison/pen_display/p_3.html (Kamvas 20)

Sorry for previous pull request. Accidentally picked `master`.