### PR TITLE
Add partial support for Wacom PTK-670

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-670.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-670.json
@@ -1,0 +1,29 @@
+{
+  "Name": "Wacom PTK-670",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 263,
+      "Height": 148,
+      "MaxX": 52600,
+      "MaxY": 29600
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ButtonCount": 3
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 10
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 1386,
+      "ProductID": 1015,
+      "InputReportLength": 192,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV3.IntuosV3ReportParser",
+      "FeatureInitReport": [
+        "AgI="
+      ]
+    }
+  ]
+}

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV3/IntuosV3AuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV3/IntuosV3AuxReport.cs
@@ -1,0 +1,31 @@
+﻿using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV3
+{
+    public struct IntuosV3AuxReport : IAuxReport
+    {
+        public IntuosV3AuxReport(byte[] report)
+        {
+            Raw = report;
+
+            var auxByte = report[1];
+            var auxByte2 = report[3];
+            AuxButtons = new bool[]
+            {
+                auxByte.IsBitSet(0),
+                auxByte.IsBitSet(1),
+                auxByte.IsBitSet(2),
+                auxByte.IsBitSet(3),
+                auxByte2.IsBitSet(0),
+                auxByte.IsBitSet(4),
+                auxByte.IsBitSet(5),
+                auxByte.IsBitSet(6),
+                auxByte.IsBitSet(7),
+                auxByte2.IsBitSet(1),
+            };
+        }
+
+        public byte[] Raw { set; get; }
+        public bool[] AuxButtons { set; get; }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV3/IntuosV3ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV3/IntuosV3ReportParser.cs
@@ -8,6 +8,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV3
         {
             return data[0] switch
             {
+                0x11 => new IntuosV3AuxReport(data),
                 0x1E => new IntuosV3ExtendedReport(data),
                 0x1F => data[1] == 0x01 ? new IntuosV3Report(data) : new DeviceReport(data),
                 _ => new DeviceReport(data)

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -264,6 +264,7 @@
 | Wacom PTK-540WL               |  Missing Features | Wheel is not yet supported.
 | Wacom PTK-640                 |  Missing Features | Wheel is not yet supported.
 | Wacom PTK-650                 |  Missing Features | Wheel is not yet supported.
+| Wacom PTK-670                 |  Missing Features | Wheel is not yet supported.
 | Wacom PTK-840                 |  Missing Features | Wheel is not yet supported.
 | Wacom PTZ-1230                |  Missing Features | Touch bars are not yet supported.
 | Wacom PTZ-1231W               |  Missing Features | Touch bars are not yet supported.


### PR DESCRIPTION
- Diagnostics: [ptk670diag.json](https://github.com/user-attachments/files/19442919/ptk670diag.json)
- Tablet data recording: [tablet-data (6).txt](https://github.com/user-attachments/files/19442922/tablet-data.6.txt)
- Missing feature: Wheels
- Discord confirmation: https://discord.com/channels/615607687467761684/1353886967032451132
- External resources:
  - [HID Descriptor (linuxwacom/wacom-hid-descriptors)](https://github.com/linuxwacom/wacom-hid-descriptors/blob/master/Wacom%20Intuos%20Pro%20M%20(3rd-gen)/sysinfo.BSaGepftZP/0003%3A056A%3A03F7.0008.hid.txt)

There are 10 aux buttons in PTK-670: 2 groups of ExpressKeys, each contains 4 big buttons surrounding a circular button. `report[4]` and `report[5]` are relative wheel movement for left and right respectively, each represented as signed 7-bit integer.