### PR TITLE
Add support for Gaomon M5 V2

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M5 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M5 V2.json
@@ -1,0 +1,35 @@
+{
+    "Name": "Gaomon M5 V2",
+    "Specifications": {
+        "Digitizer": {
+            "Width": 177.8,
+            "Height": 110,
+            "MaxX": 35560,
+            "MaxY": 22000
+        },
+        "Pen": {
+            "MaxPressure": 16383,
+            "ButtonCount": 2
+        },
+        "AuxiliaryButtons": {
+            "ButtonCount": 8
+        }
+    },
+    "DigitizerIdentifiers": [
+        {
+            "VendorID": 9580,
+            "ProductID": 8206,
+            "InputReportLength": 12,
+            "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicV2ReportParser",
+            "DeviceStrings": {
+                "201": "GM001_T238_\\d{6}$"
+            },
+            "InitializationStrings": [
+                200
+            ]
+        }
+    ],
+    "Attributes": {
+        "libinputoverride": "1"
+    }
+}

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M5 V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M5 V2.json
@@ -1,35 +1,35 @@
 {
-    "Name": "Gaomon M5 V2",
-    "Specifications": {
-        "Digitizer": {
-            "Width": 177.8,
-            "Height": 110,
-            "MaxX": 35560,
-            "MaxY": 22000
-        },
-        "Pen": {
-            "MaxPressure": 16383,
-            "ButtonCount": 2
-        },
-        "AuxiliaryButtons": {
-            "ButtonCount": 8
-        }
+  "Name": "Gaomon M5 V2",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 177.8,
+      "Height": 110,
+      "MaxX": 35560,
+      "MaxY": 22000
     },
-    "DigitizerIdentifiers": [
-        {
-            "VendorID": 9580,
-            "ProductID": 8206,
-            "InputReportLength": 12,
-            "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicV2ReportParser",
-            "DeviceStrings": {
-                "201": "GM001_T238_\\d{6}$"
-            },
-            "InitializationStrings": [
-                200
-            ]
-        }
-    ],
-    "Attributes": {
-        "libinputoverride": "1"
+    "Pen": {
+      "MaxPressure": 16383,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 8
     }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 9580,
+      "ProductID": 8206,
+      "InputReportLength": 12,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicV2ReportParser",
+      "DeviceStrings": {
+        "201": "GM001_T238_\\d{6}$"
+      },
+      "InitializationStrings": [
+        200
+      ]
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
 }

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -9,6 +9,7 @@
 | Gaomon M5                     |     Supported     |
 | Gaomon M106K                  |     Supported     |
 | Gaomon M106K Pro              |     Supported     |
+| Gaomon M5 V2                  |     Supported     |
 | Gaomon PD1161                 |     Supported     |
 | Gaomon PD1560                 |     Supported     |
 | Gaomon PD1561                 |     Supported     |


### PR DESCRIPTION
Gaomon M5 V2 is an upgraded version of the Gaomon M5.

Tested on Arch Linux. The values of maxX, maxY and MaxPressure are from the official driver.

- USBID: 256c:200e GAOMON M5 V2
- DeviceStrings[201]: GM001_T238_250102
- [diag for gaomon m5v2.json](https://github.com/user-attachments/files/19614476/diag.for.gaomon.m5v2.json)
