### PR TITLE
[06x] Clean up Linux diagnostics env vars

### DIFF
--- a/OpenTabletDriver.Desktop/Diagnostics/EnvironmentDictionary.cs
+++ b/OpenTabletDriver.Desktop/Diagnostics/EnvironmentDictionary.cs
@@ -17,7 +17,9 @@ namespace OpenTabletDriver.Desktop.Diagnostics
                             "DISPLAY",
                             "WAYLAND_DISPLAY",
                             "PWD",
-                            "PATH"
+                            "PATH",
+                            "XDG_CURRENT_DESKTOP",
+                            "XDG_RUNTIME_DIR"
                     );
                     break;
                 case PluginPlatform.Windows:

--- a/OpenTabletDriver.Desktop/Diagnostics/EnvironmentDictionary.cs
+++ b/OpenTabletDriver.Desktop/Diagnostics/EnvironmentDictionary.cs
@@ -9,14 +9,24 @@ namespace OpenTabletDriver.Desktop.Diagnostics
     {
         public EnvironmentDictionary()
         {
-            AddVariable("USER", "TEMP", "TMP", "TMPDIR");
+            AddVariable("USER");
             switch (DesktopInterop.CurrentPlatform)
             {
                 case PluginPlatform.Linux:
-                    AddVariable("DISPLAY", "WAYLAND_DISPLAY", "PWD", "PATH");
+                    AddVariable(
+                            "DISPLAY",
+                            "WAYLAND_DISPLAY",
+                            "PWD",
+                            "PATH"
+                    );
                     break;
                 case PluginPlatform.Windows:
-                    AddVariable("USERPROFILE");
+                    AddVariable(
+                            "TEMP",
+                            "TMP",
+                            "TMPDIR",
+                            "USERPROFILE"
+                    );
                     break;
             }
         }


### PR DESCRIPTION
This PR changes the exported environment variables on Linux.

## Removed environment variables on Linux diagnostics:
- `TEMP`
- `TMP`
- `TMPDIR`

These were usually always empty and does not hold any special meaning on Linux.

## Added environment variables on Linux diagnostics:
- `XDG_CURRENT_DESKTOP`
  - Will be almost always be useful in determining which desktop environment is used by the user
- `XDG_RUNTIME_DIR`
  - Will occasionally be useful in determining misconfiguration

Example trimmed output:
```
  "Environment Variables": {
    "USER": "gonx",
    "DISPLAY": ":1",
    "WAYLAND_DISPLAY": "wayland-1",
    "PWD": "/home/gonx/prog/_opentabletdriver/opentabletdriver/OpenTabletDriver.UX.Gtk/bin/Debug/net8.0",
    "PATH": "/usr/local/sbin:/usr/local/bin:/usr/bin:/var/lib/flatpak/exports/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/opt/rocm/bin:/usr/lib/rustup/bin:/home/gonx/nodejs/bin",
    "XDG_CURRENT_DESKTOP": "sway",
    "XDG_RUNTIME_DIR": "/run/user/8000"
  },
```