### PR TITLE
Add partial support for Wacom PTK-470

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-470.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-470.json
@@ -1,0 +1,29 @@
+{
+  "Name": "Wacom PTK-470",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 187,
+      "Height": 105,
+      "MaxX": 37400,
+      "MaxY": 21000
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ButtonCount": 3
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 5
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 1386,
+      "ProductID": 1013,
+      "InputReportLength": 192,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV3.IntuosV3ReportParser",
+      "FeatureInitReport": [
+        "AgI="
+      ]
+    }
+  ]
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -263,6 +263,7 @@
 | Wacom PTK-1240                |  Missing Features | Wheel is not yet supported.
 | Wacom PTK-440                 |  Missing Features | Wheel is not yet supported.
 | Wacom PTK-450                 |  Missing Features | Wheel is not yet supported.
+| Wacom PTK-470                 |  Missing Features | Wheel is not yet supported.
 | Wacom PTK-540WL               |  Missing Features | Wheel is not yet supported.
 | Wacom PTK-640                 |  Missing Features | Wheel is not yet supported.
 | Wacom PTK-650                 |  Missing Features | Wheel is not yet supported.


### PR DESCRIPTION
- Diagnostics: [Diagnostic.json](https://github.com/user-attachments/files/19918533/Diagnostic.json)
- [HID descriptor from linuxwacom repo](https://github.com/linuxwacom/wacom-hid-descriptors/blob/master/Wacom%20Intuos%20Pro%20S%20(3rd-gen)/sysinfo.vS9sFVLdTW/0003%3A056A%3A03F5.0008.hid.txt)
- Discord confirmation: https://discord.com/channels/615607687467761684/1363018484908425366