### PR TITLE
XP-Pen Deco L: Remove OutputReportLength requirement

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco L.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco L.json
@@ -22,7 +22,6 @@
       "VendorID": 10429,
       "ProductID": 2357,
       "InputReportLength": 10,
-      "OutputReportLength": 33,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenOffsetPressureReportParser",
       "OutputInitReport": [
         "ArAE"


### PR DESCRIPTION
There are Deco L tablets out there with 0 OutputReportLength - the ProductID seems unique, so we can very likely safely remove the OutputReportLength requirement