### PR TITLE
Config: Add Supernote Nomad parser, Nomad config, and TABLETS.md entry

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Supernote/Nomad.json
+++ b/OpenTabletDriver.Configurations/Configurations/Supernote/Nomad.json
@@ -1,0 +1,28 @@
+{
+  "Name": "Supernote Nomad",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 119,
+      "Height": 158,
+      "MaxX": 32767,
+      "MaxY": 32767
+    },
+    "Pen": {
+      "MaxPressure": 4095,
+    },
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 8711,
+      "ProductID": 7,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Supernote.SupernoteNomadReportParser",
+          "DeviceStrings": {
+         "1": "Supernote",
+         "2": "Supernote Nomad"
+       }
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Supernote/SupernoteNomadReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Supernote/SupernoteNomadReport.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Supernote // Create a new namespace for Supernote
+{
+    public struct SupernoteNomadReport : ITabletReport, ITiltReport // Implement necessary interfaces
+    {
+        // Constructor takes the raw byte array
+        public SupernoteNomadReport(byte[] report)
+        {
+            Raw = report;
+            Tip = report[1].IsBitSet(0);
+            Proximity = report[1].IsBitSet(1); // Assuming Proximity is still valid
+
+            if (!Tip)
+            {
+                Pressure = 0;
+            }
+            else
+            {
+                uint rawPressure = report[2];
+                // Subtract the offset (C0 hex = 192 dec)
+                uint adjustedPressure = (uint)Math.Max(0, (int)rawPressure - 192);
+                // Scale the adjusted range (0-63) to the target range (0-4095)
+                // Scaling factor = TargetMax / (HardwareMax - HardwareMin) = 4095.0 / (255.0 - 192.0) = 4095.0 / 63.0
+                const double scaleFactor = 4095.0 / 63.0;
+                Pressure = (uint)Math.Min(4095, Math.Round(adjustedPressure * scaleFactor)); // Apply scaling and clamp to 0-4095
+            }
+            Position = new Vector2
+            {
+                X = Unsafe.ReadUnaligned<ushort>(ref report[3]),
+                Y = Unsafe.ReadUnaligned<ushort>(ref report[5])
+            };
+            Tilt = new Vector2
+            {
+                X = Unsafe.ReadUnaligned<sbyte>(ref report[7]),
+                Y = Unsafe.ReadUnaligned<sbyte>(ref report[8])
+            };
+            PenButtons = System.Array.Empty<bool>();
+            Eraser = false;
+        }
+
+        public byte[] Raw { get; set; } // Raw report data
+        public Vector2 Position { get; set; } // X and Y coordinates
+        public uint Pressure { get; set; } // Pressure value
+        public bool[] PenButtons { get; set; } // Array of button states
+        public bool Eraser { get; set; } // Eraser state
+        public bool Tip { get; set; } // Tip switch state
+        public bool Proximity { get; set; } // Proximity state
+        public Vector2 Tilt { get; set; } // Tilt X and Y coordinates
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Supernote/SupernoteNomadReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Supernote/SupernoteNomadReportParser.cs
@@ -1,0 +1,26 @@
+using OpenTabletDriver.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Supernote // Use the same namespace
+{
+    // This is the main parser class OpenTabletDriver interacts with
+    public class SupernoteNomadReportParser : IReportParser<IDeviceReport>
+    {
+        // This method is called by OTD for each raw report received
+        public IDeviceReport Parse(byte[] data)
+        {
+            // Check if the report matches the expected format for the Supernote Nomad pen report
+            // We expect a 9-byte report starting with 0x00 (Report ID 0)
+            if (data.Length == 9 && data[0] == 0x00)
+            {
+                // If it matches, create and return a SupernoteNomadReport
+                return new SupernoteNomadReport(data);
+            }
+
+            // If the report doesn't match the expected format,
+            // return a generic DeviceReport or potentially log a warning.
+            // Returning DeviceReport(data) allows OTD's debugger to still show the raw data
+            // for reports that aren't handled by this parser.
+            return new DeviceReport(data);
+        }
+    }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -1,5 +1,6 @@
 | Tablet                        |      Status       | Notes |
 | ---------------------------   | :---------------: | ----- |
+| Supernote Nomad               |     Supported     |
 | Acepen AP906                  |     Supported     |
 | Acepen AP1060                 |     Supported     |
 | Adesso Cybertablet K8         |     Supported     |


### PR DESCRIPTION
Supernote has added a beta app to their line of X2 e-tablets called "inkflow" that is meant to turn the tablet into a drawing tablet. Obviously, being in beta, Linux support is far on the back burner.

Tested on Arch Linux. The values of maxX (119) and maxY (158) are compiled from various Reddit threads, while the pressure is from personal testing to be a bit strange. Values range from C0, to FF. The parser simply scales that to the official listings of "...4096 levels of pressure sensitivity..." Not perfect, but it's a known bug as of writing.

USBID: 2207:0007
Manufacturer: Supernote
ProductName: Supernote Nomad

[nomad_diag.txt](https://github.com/user-attachments/files/20042653/nomad_diag.txt)