### PR TITLE
Add support for Gaomon M5

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M5.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M5.json
@@ -1,0 +1,36 @@
+{
+    "Name": "M5",
+    "Specifications": {
+      "Digitizer": {
+        "Width": 152,
+        "Height": 95,
+        "MaxX": 35830,
+        "MaxY": 23700
+      },
+      "Pen": {
+        "MaxPressure": 8191,
+        "ButtonCount": 2
+      },
+      "AuxiliaryButtons": {
+        "ButtonCount": 1
+      }
+    },
+    "DigitizerIdentifiers": [
+      {
+        "VendorID": 9580,
+        "ProductID": 100,
+        "InputReportLength": 12,
+        "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicV2ReportParser",
+        "DeviceStrings": {
+          "201": "OEM02_T195_\\d{6}$"
+        },
+        "InitializationStrings": [
+          200
+        ]
+      }
+    ],
+    "Attributes": {
+      "libinputoverride": "1"
+    }
+  }
+  

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -13,6 +13,7 @@
 | Gaomon PD1561                 |     Supported     |
 | Gaomon PD2200                 |     Supported     |
 | Gaomon S620                   |     Supported     |
+| Gaomon M5                     |     Supported     |
 | Genius G-Pen 560              |     Supported     | Soft-buttons are bindable as aux buttons.
 | Huion 1060 Plus               |     Supported     |
 | Huion G930L                   |     Supported     |


### PR DESCRIPTION
I added support for Gaomon M5 Tablet(The old version of Gaomon M5 V2)
Tested on Windows.
USBID: 256c:0064
DeviceStrings[201]: OEM02_T195_210513
[diag for m5](https://github.com/user-attachments/files/20644958/diag.json)
