### PR TITLE
Update Gaomon 1060 pro maximum pressure level to 16k

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/1060 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/1060 Pro.json
@@ -8,7 +8,7 @@
       "MaxY": 31750
     },
     "Pen": {
-      "MaxPressure": 8191,
+      "MaxPressure": 16383,
       "Buttons": {
         "ButtonCount": 2
       }


### PR DESCRIPTION
My gaomon tablet has support for 16k pressure and the official website clearly says so too
![image](https://github.com/user-attachments/assets/9f082cec-4a3b-46b6-9ce6-b36f9dd9588b)

Changes the string value MaxPressure to 16383