### PR TITLE
Add Artist 16 Pro

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist Pro 16.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist Pro 16.json
@@ -1,11 +1,11 @@
 {
-  "Name": "XP-Pen Artist 16 Pro",
+  "Name": "XP-Pen Artist Pro 16",
   "Specifications": {
     "Digitizer": {
-      "Width": 344.16,
-      "Height": 193.59,
-      "MaxX": 34419,
-      "MaxY": 19461
+      "Width": 341.07,
+      "Height": 191.795,
+      "MaxX": 68214,
+      "MaxY": 38359
     },
     "Pen": {
       "MaxPressure": 8191,
@@ -18,8 +18,9 @@
   "DigitizerIdentifiers": [
     {
       "VendorID": 10429,
-      "ProductID": 36874,
-      "InputReportLength": 10,
+      "ProductID": 2379,
+      "InputReportLength": 12,
+      "OutputReportLength": 12,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
       "OutputInitReport": [
         "ArAE"

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -133,6 +133,7 @@
 | XP-Pen Artist 13 (2nd Gen)    |     Supported     |
 | XP-Pen Artist 13.3            |     Supported     |
 | XP-Pen Artist 15.6            |     Supported     |
+| XP-Pen Artist 16 Pro          |     Supported     |
 | XP-Pen Artist 16 (2nd Gen)    |     Supported     |
 | XP-Pen Artist 22 (2nd Gen)    |     Supported     |
 | XP-Pen Artist 24              |     Supported     |
@@ -280,8 +281,8 @@
 | XP-Pen Artist 12 Pro          |  Missing Features | Tilt and wheel are not yet supported.
 | XP-Pen Artist 13.3 Pro        |  Missing Features | Wheel is not yet supported.
 | XP-Pen Artist 15.6 Pro        |  Missing Features | Tilt and wheel are not yet supported.
-| XP-Pen Artist 16 Pro          |  Missing Features | Wheel is not yet supported.
 | XP-Pen Artist 24 Pro          |  Missing Features | Wheel is not yet supported.
+| XP-Pen Artist Pro 16          |  Missing Features | Wheel is not yet supported.
 | XP-Pen Artist Pro 16TP        |  Missing Features | Touch is not yet supported.
 | XP-Pen Deco 01 V2             |  Missing Features | Tilt is not yet supported.
 | XP-Pen Deco 01 V2 (Variant 2) |  Missing Features | Tilt is not yet supported


### PR DESCRIPTION
Fixes #3852

I tested this config and everything is working perfectly in the debugger including aux buttons, pen buttons, pointing and pressure.
I couldn't test the pen buttons outside of the debugger as there wasn't any options in the gui but I don't think that's my fault (?)

I've moved the previously incorrectly labelled "XP-Pen Artist 16 Pro" to "X-Pen Artist Pro 16", unsure if thats a breaking change though...

I've measured manually `MaxX` and `MaxY` and they seem to perfectly fall in a 100 LPMM despite the vendor's alleged 200 LPMM.

