### PR TITLE
Add support for XP-Pen Artist 15.6 Pro V2

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 15.6 Pro V2.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 15.6 Pro V2.json
@@ -1,0 +1,33 @@
+{
+  "Name": "XP-Pen Artist 15.6 Pro V2",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 340.99,
+      "Height": 191.81,
+      "MaxX": 68199,
+      "MaxY": 38399
+    },
+    "Pen": {
+      "MaxPressure": 16383,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 8
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 10429,
+      "ProductID": 2415,
+      "InputReportLength": 14,
+      "OutputReportLength": 14,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenGen2ReportParser",
+      "OutputInitReport": [
+        "ArAE"
+      ]
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -133,6 +133,7 @@
 | XP-Pen Artist 13 (2nd Gen)    |     Supported     |
 | XP-Pen Artist 13.3            |     Supported     |
 | XP-Pen Artist 15.6            |     Supported     |
+| XP-Pen Artist 15.6 V2         |     Supported     |
 | XP-Pen Artist 16 (2nd Gen)    |     Supported     |
 | XP-Pen Artist 22 (2nd Gen)    |     Supported     |
 | XP-Pen Artist 24              |     Supported     |


### PR DESCRIPTION
https://www.xp-pen.com/product/artist-15-6-pro-v2.html

I own this tablet and it seems to work alright (display via a bundled HDMI-to-USB cable)

From diagnostics output (avalonia branch):

```
    {
      "ProductID": 2415,
      "VendorID": 10429,
      "InputReportLength": 8,
      "OutputReportLength": 0,
      "FeatureReportLength": 0,
      "Manufacturer": "XPPen̦Ar",
      "ProductName": "Artist 15.6 Pro V2",
      "FriendlyName": "Artist 15.6 Pro V2",
      "SerialNumber": "00000",
      "DevicePath": "/sys/devices/pci0000:00/0000:00:14.0/usb1/1-2/1-2:1.0/0003:28BD:096F.0010/hidraw/hidraw12",
      "CanOpen": true
    },
    {
      "ProductID": 2415,
      "VendorID": 10429,
      "InputReportLength": 10,
      "OutputReportLength": 0,
      "FeatureReportLength": 0,
      "Manufacturer": "XPPen̦Ar",
      "ProductName": "Artist 15.6 Pro V2",
      "FriendlyName": "Artist 15.6 Pro V2",
      "SerialNumber": "00000",
      "DevicePath": "/sys/devices/pci0000:00/0000:00:14.0/usb1/1-2/1-2:1.1/0003:28BD:096F.0011/hidraw/hidraw13",
      "CanOpen": true
    },
    {
      "ProductID": 2415,
      "VendorID": 10429,
      "InputReportLength": 14,
      "OutputReportLength": 14,
      "FeatureReportLength": 0,
      "Manufacturer": "XPPen̦Ar",
      "ProductName": "Artist 15.6 Pro V2",
      "FriendlyName": "Artist 15.6 Pro V2",
      "SerialNumber": "00000",
      "DevicePath": "/sys/devices/pci0000:00/0000:00:14.0/usb1/1-2/1-2:1.2/0003:28BD:096F.0012/hidraw/hidraw14",
      "CanOpen": true
    },

...

    {
      "Time": "2025-08-18T20:01:42.4794503+02:00",
      "Group": "Detect",
      "Message": "XP-Pen Artist 15.6 Pro V2 detected",
      "StackTrace": null,
      "Level": 1,
      "Notification": false
    },,
    {
      "Time": "2025-08-18T20:01:42.4795362+02:00",
      "Group": "Detect",
      "Message": "XP-Pen Artist 15.6 Pro V2 digitizer: /sys/devices/pci0000:00/0000:00:14.0/usb1/1-2/1-2:1.2/0003:28BD:096F.0012/hidraw/hidraw14",
      "StackTrace": null,
      "Level": 1,
      "Notification": false
    },
    {
      "Time": "2025-08-18T20:01:42.4801267+02:00",
      "Group": "Detect",
      "Message": "Search done",
      "StackTrace": null,
      "Level": 1,
      "Notification": false
    },
    {
      "Time": "2025-08-18T20:01:42.4803452+02:00",
      "Group": "Driver",
      "Message": "Initializing XP-Pen Artist 15.6 Pro V2...",
      "StackTrace": null,
      "Level": 1,
      "Notification": false
    },
    {
      "Time": "2025-08-18T20:01:42.5352557+02:00",
      "Group": "Device",
      "Message": "Using report parser type 'OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenGen2ReportParser'",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2025-08-18T20:01:42.5444094+02:00",
      "Group": "Device",
      "Message": "Set device output: 02-B0-04",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2025-08-18T20:01:42.571875+02:00",
      "Group": "Daemon",
      "Message": "Applying settings for XP-Pen Artist 15.6 Pro V2...",
      "StackTrace": null,
      "Level": 1,
      "Notification": false
    },
    {
      "Time": "2025-08-18T20:01:42.5760041+02:00",
      "Group": "Evdev",
      "Message": "Successfully initialized virtual pressure sensitive tablet. (code NONE)",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2025-08-18T20:01:42.5884154+02:00",
      "Group": "LinuxArtistMode",
      "Message": "Input: [340.99x191.81@<170.495, 95.905>:0°]",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2025-08-18T20:01:42.5900609+02:00",
      "Group": "LinuxArtistMode",
      "Message": "Output: [2560x2520@<1280, 1260>]",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2025-08-18T20:01:42.5909911+02:00",
      "Group": "LinuxArtistMode",
      "Message": "LockAspectRatio: False",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2025-08-18T20:01:42.5910577+02:00",
      "Group": "LinuxArtistMode",
      "Message": "AreaClipping: True",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2025-08-18T20:01:42.5910825+02:00",
      "Group": "LinuxArtistMode",
      "Message": "AreaLimiting: True",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2025-08-18T20:01:42.5911062+02:00",
      "Group": "LinuxArtistMode",
      "Message": "LockToBounds: True",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2025-08-18T20:01:42.5912438+02:00",
      "Group": "Settings",
      "Message": "Output mode: Artist Mode",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2025-08-18T20:01:42.5924355+02:00",
      "Group": "MouseBinding",
      "Message": "Button: Left",
      "StackTrace": null,
      "Level": 0,
      "Notification": false
    },
    {
      "Time": "2025-08-18T20:01:42.5949511+02:00",
      "Group": "Daemon",
      "Message": "Settings applied",
      "StackTrace": null,
      "Level": 1,
      "Notification": false
    },

```