### PR TITLE
[0.6.x] Ensure user configuration is loaded correctly on macos

### DIFF
--- a/OpenTabletDriver.Desktop/AppInfo.cs
+++ b/OpenTabletDriver.Desktop/AppInfo.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using OpenTabletDriver.Desktop.Reflection;
 using OpenTabletDriver.Interop;
 using OpenTabletDriver.Plugin;
@@ -109,15 +108,7 @@ namespace OpenTabletDriver.Desktop
             get => this.trashDirectory ?? GetDefaultTrashDirectory();
         }
 
-        public static string ProgramDirectory => SystemInterop.CurrentPlatform switch
-        {
-            PluginPlatform.MacOS => Regex.Match(AppContext.BaseDirectory, "^(.*)/[^/]+\\.app/Contents/MacOS/?$", RegexOptions.IgnoreCase) switch
-            {
-                { Success: true } match => match.Groups[1].ToString(),
-                _ => AppContext.BaseDirectory
-            },
-            _ => AppContext.BaseDirectory
-        };
+        public static string ProgramDirectory => AppContext.BaseDirectory;
 
         private static string GetDirectory(params string[] directories)
         {

--- a/OpenTabletDriver.Desktop/Updater/GitHubUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/GitHubUpdater.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Octokit;
 using OpenTabletDriver.Plugin;
@@ -9,10 +10,15 @@ namespace OpenTabletDriver.Desktop.Updater
 {
     public abstract class GitHubUpdater : Updater
     {
+        static private readonly string _binaryDirectory = Regex.Match(AppContext.BaseDirectory, "^(.*)/[^/]+\\.app/Contents/MacOS/?$", RegexOptions.IgnoreCase) switch
+        {
+            { Success: true } match => match.Groups[1].ToString(),
+            _ => AppContext.BaseDirectory
+        };
         private readonly IGitHubClient _github;
 
         protected GitHubUpdater(Version currentVersion, AppInfo appInfo, IGitHubClient client)
-            : base(currentVersion, AppInfo.ProgramDirectory, appInfo.AppDataDirectory, appInfo.BackupDirectory)
+            : base(currentVersion, _binaryDirectory, appInfo.AppDataDirectory, appInfo.BackupDirectory)
         {
             _github = client;
         }

--- a/OpenTabletDriver.UX/DaemonWatchdog.cs
+++ b/OpenTabletDriver.UX/DaemonWatchdog.cs
@@ -23,8 +23,7 @@ namespace OpenTabletDriver.UX
             },
             PluginPlatform.MacOS => new ProcessStartInfo
             {
-                FileName = Path.Join(AppContext.BaseDirectory, "OpenTabletDriver.Daemon"),
-                Arguments = $"-c {Path.Join(AppContext.BaseDirectory, "Configurations")}"
+                FileName = Path.Join(AppContext.BaseDirectory, "OpenTabletDriver.Daemon")
             },
             _ => new ProcessStartInfo
             {


### PR DESCRIPTION
Removes the hardcoded daemon configuration path on macOS when starting with watchdog, which prevented user-specific configurations from being loaded.