### PR TITLE
[06x] Enhance handling of invalid settings

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -33,6 +33,8 @@ namespace OpenTabletDriver.Daemon
 {
     public class DriverDaemon : IDriverDaemon
     {
+        private const string AVALONIA_REVISION = "0.7.0.0";
+
         public DriverDaemon(Driver driver)
         {
             Driver = driver;
@@ -297,7 +299,7 @@ namespace OpenTabletDriver.Daemon
             if (settingsFile.Exists)
             {
                 if (Settings.TryDeserialize(settingsFile, out var settings) &&
-                    settings.Revision != "0.7.0.0")
+                    settings.Revision != AVALONIA_REVISION)
                 {
                     await SetSettings(settings);
                 }

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -296,7 +296,7 @@ namespace OpenTabletDriver.Daemon
 
             if (settingsFile.Exists)
             {
-                if (Settings.TryDeserialize(settingsFile, out var settings))
+                if (Settings.TryDeserialize(settingsFile, out var settings) && settings.Revision != "0.7.0.0")
                 {
                     await SetSettings(settings);
                 }

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -301,6 +301,7 @@ namespace OpenTabletDriver.Daemon
                 if (Settings.TryDeserialize(settingsFile, out var settings) &&
                     settings.Revision != AVALONIA_REVISION)
                 {
+                    settings.Revision = Settings.GetVersion(); // ensure Revision matches Daemon version
                     await SetSettings(settings);
                 }
                 else

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -294,20 +294,11 @@ namespace OpenTabletDriver.Daemon
 
             var settingsFile = new FileInfo(AppInfo.Current.SettingsFile);
 
-            if (settingsFile.Exists)
+            if (settingsFile.Exists &&
+                Settings.TryDeserialize(settingsFile, out var settings) &&
+                settings.Revision != "0.7.0.0")
             {
-                if (Settings.TryDeserialize(settingsFile, out var settings) && settings.Revision != "0.7.0.0")
-                {
-                    await SetSettings(settings);
-                }
-                else
-                {
-                    Log.Write("Settings", "Invalid settings detected. Attempting recovery.", LogLevel.Error);
-                    settings = Settings.GetDefaults();
-                    Settings.Recover(settingsFile, settings);
-                    Log.Write("Settings", "Recovery complete");
-                    await SetSettings(settings);
-                }
+                await SetSettings(settings);
             }
             else
             {

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -325,7 +325,7 @@ namespace OpenTabletDriver.Daemon
             var dst = Path.Join(AppInfo.Current.AppDataDirectory, dstFileName);
 
             Log.Write("MoveSettingsFile", $"Moving settings file at '{src}' to '{dst}'", LogLevel.Debug);
-            File.Move(src,dst);
+            File.Move(src, dst);
         }
 
         private void SetOutputModeElements(InputDeviceTree dev, IOutputMode outputMode, Profile profile, BindingHandler bindingHandler)

--- a/OpenTabletDriver.Desktop/Settings.cs
+++ b/OpenTabletDriver.Desktop/Settings.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using System.IO;
+using System.Reflection;
 using Newtonsoft.Json;
 using OpenTabletDriver.Desktop.Profiles;
 using OpenTabletDriver.Desktop.Reflection;
@@ -13,6 +14,14 @@ namespace OpenTabletDriver.Desktop
         private ProfileCollection profiles = new ProfileCollection();
         private bool lockUsableAreaDisplay, lockUsableAreaTablet;
         private PluginSettingStoreCollection tools = new PluginSettingStoreCollection();
+        private string revision = Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+
+        [JsonProperty("Revision")]
+        public string Revision
+        {
+            set => this.RaiseAndSetIfChanged(ref revision, value);
+            get => revision;
+        }
 
         [JsonProperty("Profiles")]
         public ProfileCollection Profiles

--- a/OpenTabletDriver.Desktop/Settings.cs
+++ b/OpenTabletDriver.Desktop/Settings.cs
@@ -14,7 +14,7 @@ namespace OpenTabletDriver.Desktop
         private ProfileCollection profiles = new ProfileCollection();
         private bool lockUsableAreaDisplay, lockUsableAreaTablet;
         private PluginSettingStoreCollection tools = new PluginSettingStoreCollection();
-        private string revision = Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        private string revision = GetVersion();
 
         [JsonProperty("Revision")]
         public string Revision
@@ -94,6 +94,11 @@ namespace OpenTabletDriver.Desktop
                 using (var jr = new JsonTextReader(sr))
                     return serializer.Deserialize<Settings>(jr);
             }
+        }
+
+        public static string GetVersion()
+        {
+            return Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
         }
 
         [Obsolete("Unused and deprecated")]

--- a/OpenTabletDriver.Desktop/Settings.cs
+++ b/OpenTabletDriver.Desktop/Settings.cs
@@ -96,6 +96,7 @@ namespace OpenTabletDriver.Desktop
             }
         }
 
+        [Obsolete("Unused and deprecated")]
         public static void Recover(FileInfo file, Settings settings)
         {
             using (var stream = file.OpenRead())


### PR DESCRIPTION
This PR changes the behavior when encountering invalid settings.

This drops usage of `Setting`'s `Recover(FileInfo, Settings)` which was deemed to be mostly confusing in place of moving the file elsewhere.

Pre-PR:

- `master`/`avalonia` branch configurations are incorrectly parsed, causing weird issues (exception on startup with tablet plugged in, stack overflow when plugging in tablet while daemon active)
- Configs that wouldn't deserialize without an exception would still be attempted to be "populated" on top of a default configuration as introduced in #699 (which seems less relevant with #2808 in place)

Post-PR:

- Settings file now has a `Revision` field matching `avalonia`
- `avalonia` branch configurations are detected and rejected (by matching value `0.7.0.0` for `Revision` field in settings), improvements for this are welcome.
- Rejected/invalid configs are now moved to a new file (currently `settings_bak-${currentUTCtimeInEpoch}.json`)

TL;DR: Bad configs would sometimes magically work before. Now known bad configs never work and will be rejected.

The primary purpose of this PR is to ensure that the `opentabletdriver-git` AUR package can be migrated to 0.6.x without causing havoc in behavior

Please test thoroughly - this will likely go in 0.6.5.2