### PR TITLE
[06x] DriverDaemon: Create settings file when none are detected

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -312,6 +312,10 @@ namespace OpenTabletDriver.Daemon
             else
             {
                 await ResetSettings();
+
+                // only save fresh settings if a tablet was configured
+                if (Settings!.Profiles.Any())
+                    Settings.Serialize(settingsFile);
             }
         }
 


### PR DESCRIPTION
Does not create a settings file if no tablet is detected. This is to prevent new users missing out on the Setup Wizard in case they start the driver with the tablet not being ready yet, e.g. misconfiguration or just "checking out the driver" before getting the hardware.

Probably fixes some existing issue