### PR TITLE
Fix Plugin manager Metadata Desynchronization

### DIFF
--- a/OpenTabletDriver.UX/Windows/Plugins/MetadataViewer.cs
+++ b/OpenTabletDriver.UX/Windows/Plugins/MetadataViewer.cs
@@ -49,7 +49,7 @@ namespace OpenTabletDriver.UX.Windows.Plugins
             );
 
             var updateableBinding = new DelegateBinding<bool>(
-                () => IsUpdated,
+                () => IsOutdated,
                 addChangeEvent: (e) => MetadataChanged += e,
                 removeChangeEvent: (e) => MetadataChanged -= e
             );
@@ -233,7 +233,7 @@ namespace OpenTabletDriver.UX.Windows.Plugins
             this.ParentWindow.Enabled = true;
         }
 
-        private bool IsUpdated => GetUpdatedMetadatas(PluginMetadataList.Repository, Metadata, CurrentDriverVersion).Any();
+        private bool IsOutdated => GetUpdatedMetadatas(PluginMetadataList.Repository, Metadata, CurrentDriverVersion).Any();
 
         private static IEnumerable<PluginMetadata> GetUpdatedMetadatas(PluginMetadataCollection repo, PluginMetadata Metadata, Version CurrentDriverVersion)
         {
@@ -244,7 +244,7 @@ namespace OpenTabletDriver.UX.Windows.Plugins
                    where PluginMetadata.Match(meta, Metadata)
                    where meta.PluginVersion > Metadata.PluginVersion
                    where CurrentDriverVersion >= meta.SupportedDriverVersion
-                   where CurrentDriverVersion <= meta.MaxSupportedDriverVersion
+                   where meta.MaxSupportedDriverVersion == null || CurrentDriverVersion <= meta.MaxSupportedDriverVersion
                    orderby meta.PluginVersion descending
                    select meta;
         }

--- a/OpenTabletDriver.UX/Windows/Plugins/MetadataViewer.cs
+++ b/OpenTabletDriver.UX/Windows/Plugins/MetadataViewer.cs
@@ -223,7 +223,11 @@ namespace OpenTabletDriver.UX.Windows.Plugins
         {
             this.ParentWindow.Enabled = false;
 
-            await RequestPluginInstall?.Invoke(Metadata);
+            // Get the plugin's updated metadata from the repo
+            var updatedMetadata = PluginMetadataList.Repository.FirstOrDefault(m => PluginMetadata.Match(m, Metadata));
+
+            if (metadata != null)
+                await RequestPluginInstall?.Invoke(updatedMetadata);
 
             this.ParentWindow.Enabled = true;
         }

--- a/OpenTabletDriver.UX/Windows/Plugins/MetadataViewer.cs
+++ b/OpenTabletDriver.UX/Windows/Plugins/MetadataViewer.cs
@@ -52,8 +52,8 @@ namespace OpenTabletDriver.UX.Windows.Plugins
                 () =>
                 {
                     // Get the plugin's updated metadata from the repo
-                    updatedMetadata = GetUpdatedMetadatas(PluginMetadataList.Repository, Metadata, CurrentDriverVersion).FirstOrDefault();
-                    return updatedMetadata != null;
+                    updatedMetadata = GetUpdatedMetadatas(PluginMetadataList.Repository, Metadata, CurrentDriverVersion).FirstOrDefault() ?? Metadata;
+                    return updatedMetadata != Metadata;
                 },
                 addChangeEvent: (e) => MetadataChanged += e,
                 removeChangeEvent: (e) => MetadataChanged -= e
@@ -188,10 +188,6 @@ namespace OpenTabletDriver.UX.Windows.Plugins
         {
             MetadataChanged?.Invoke(this, new EventArgs());
 
-            var contexts = AppInfo.PluginManager.GetLoadedPlugins();
-
-            bool isInstalled = contexts.Any(t => PluginMetadata.Match(t.GetMetadata(), metadata));
-
             this.Content = Metadata != null ? content : placeholder ??= new Placeholder
             {
                 Text = "No plugin selected."
@@ -221,8 +217,7 @@ namespace OpenTabletDriver.UX.Windows.Plugins
         {
             this.ParentWindow.Enabled = false;
 
-            if (updatedMetadata != null)
-                await RequestPluginInstall?.Invoke(updatedMetadata);
+            await RequestPluginInstall?.Invoke(metadata);
 
             this.ParentWindow.Enabled = true;
         }

--- a/OpenTabletDriver.UX/Windows/Plugins/MetadataViewer.cs
+++ b/OpenTabletDriver.UX/Windows/Plugins/MetadataViewer.cs
@@ -244,6 +244,7 @@ namespace OpenTabletDriver.UX.Windows.Plugins
                    where PluginMetadata.Match(meta, Metadata)
                    where meta.PluginVersion > Metadata.PluginVersion
                    where CurrentDriverVersion >= meta.SupportedDriverVersion
+                   where CurrentDriverVersion <= meta.MaxSupportedDriverVersion
                    orderby meta.PluginVersion descending
                    select meta;
         }

--- a/OpenTabletDriver.UX/Windows/Plugins/MetadataViewer.cs
+++ b/OpenTabletDriver.UX/Windows/Plugins/MetadataViewer.cs
@@ -217,7 +217,7 @@ namespace OpenTabletDriver.UX.Windows.Plugins
         {
             this.ParentWindow.Enabled = false;
 
-            await RequestPluginInstall?.Invoke(metadata);
+            await RequestPluginInstall?.Invoke(updatedMetadata);
 
             this.ParentWindow.Enabled = true;
         }

--- a/OpenTabletDriver.UX/Windows/Plugins/MetadataViewer.cs
+++ b/OpenTabletDriver.UX/Windows/Plugins/MetadataViewer.cs
@@ -49,7 +49,12 @@ namespace OpenTabletDriver.UX.Windows.Plugins
             );
 
             var updateableBinding = new DelegateBinding<bool>(
-                () => IsOutdated,
+                () =>
+                {
+                    // Get the plugin's updated metadata from the repo
+                    updatedMetadata = GetUpdatedMetadatas(PluginMetadataList.Repository, Metadata, CurrentDriverVersion).FirstOrDefault();
+                    return updatedMetadata != null;
+                },
                 addChangeEvent: (e) => MetadataChanged += e,
                 removeChangeEvent: (e) => MetadataChanged -= e
             );
@@ -165,6 +170,7 @@ namespace OpenTabletDriver.UX.Windows.Plugins
         public event Func<PluginMetadata, Task<bool>> RequestPluginInstall;
         public event Func<PluginMetadata, Task<bool>> RequestPluginUninstall;
 
+        private PluginMetadata updatedMetadata;
         private PluginMetadata metadata;
         public PluginMetadata Metadata
         {
@@ -215,9 +221,6 @@ namespace OpenTabletDriver.UX.Windows.Plugins
         {
             this.ParentWindow.Enabled = false;
 
-            // Get the plugin's updated metadata from the repo
-            var updatedMetadata = GetUpdatedMetadatas(PluginMetadataList.Repository, Metadata, CurrentDriverVersion).FirstOrDefault();
-
             if (updatedMetadata != null)
                 await RequestPluginInstall?.Invoke(updatedMetadata);
 
@@ -232,8 +235,6 @@ namespace OpenTabletDriver.UX.Windows.Plugins
 
             this.ParentWindow.Enabled = true;
         }
-
-        private bool IsOutdated => GetUpdatedMetadatas(PluginMetadataList.Repository, Metadata, CurrentDriverVersion).Any();
 
         private static IEnumerable<PluginMetadata> GetUpdatedMetadatas(PluginMetadataCollection repo, PluginMetadata Metadata, Version CurrentDriverVersion)
         {

--- a/OpenTabletDriver.UX/Windows/Plugins/MetadataViewer.cs
+++ b/OpenTabletDriver.UX/Windows/Plugins/MetadataViewer.cs
@@ -226,7 +226,7 @@ namespace OpenTabletDriver.UX.Windows.Plugins
             // Get the plugin's updated metadata from the repo
             var updatedMetadata = PluginMetadataList.Repository.FirstOrDefault(m => PluginMetadata.Match(m, Metadata));
 
-            if (metadata != null)
+            if (updatedMetadata != null)
                 await RequestPluginInstall?.Invoke(updatedMetadata);
 
             this.ParentWindow.Enabled = true;


### PR DESCRIPTION
This fixes an issue where even after updating the plugin, it wouldn't save the metadata to a file & the UX wouldn't load the updated metadata.

Closes #720