### PR TITLE
[06x] Adaptive Bindings

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -396,6 +396,9 @@ namespace OpenTabletDriver.Daemon
             if (pointer is IMouseButtonHandler mouseButtonHandler)
                 bindingServiceProvider.AddService(() => mouseButtonHandler);
 
+            if (pointer is IPenActionHandler penActionHandler)
+                bindingServiceProvider.AddService(() => penActionHandler);
+
             var tip = bindingHandler.Tip = new ThresholdBindingState
             {
                 Binding = settings.TipButton?.Construct<IBinding>(bindingServiceProvider, tabletReference),

--- a/OpenTabletDriver.Desktop/Binding/AdaptiveBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/AdaptiveBinding.cs
@@ -93,6 +93,7 @@ namespace OpenTabletDriver.Desktop.Binding
             { "Eraser", PenAction.Eraser },
             { "Button 1", PenAction.BarrelButton1 },
             { "Button 2", PenAction.BarrelButton2 },
+            { "Button 3", PenAction.BarrelButton3 },
         };
 
         private static string ActionToString(PenAction button) =>

--- a/OpenTabletDriver.Desktop/Binding/AdaptiveBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/AdaptiveBinding.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenTabletDriver.Plugin;
+using OpenTabletDriver.Plugin.Attributes;
+using OpenTabletDriver.Plugin.DependencyInjection;
+using OpenTabletDriver.Plugin.Platform.Pointer;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Desktop.Binding
+{
+    [PluginName(PluginName)]
+    public class AdaptiveBinding : IStateBinding
+    {
+        private const string PluginName = "Adaptive Binding";
+
+        [Resolved] public IPenActionHandler PenActionHandler { set; get; }
+
+        [Resolved] public IMouseButtonHandler MouseButtonHandler { set; get; }
+
+        // ReSharper disable once UnusedMember.Global
+        public AdaptiveBinding()
+        {
+        }
+
+        public AdaptiveBinding(PenAction action)
+        {
+            Binding = ActionToString(action);
+        }
+
+        public static string[] ButtonNames => ValidButtons.Keys.ToArray();
+
+        [Property(nameof(Binding)), PropertyValidated(nameof(ButtonNames))]
+        public string Binding
+        {
+            get;
+            set
+            {
+                if (!ValidButtons.TryGetValue(value, out var button))
+                    throw new ArgumentException("Invalid button name", value);
+
+                _action = button;
+                field = value;
+            }
+        } = string.Empty;
+
+        public void Press(TabletReference tablet, IDeviceReport report)
+        {
+            if (PenActionHandler != null)
+                PenActionHandler.Activate(_action);
+            else if (MouseButtonHandler != null)
+            {
+                var button = ActionToButton(_action);
+                if (button != null)
+                    MouseButtonHandler.MouseDown(button.Value);
+            }
+        }
+
+        public void Release(TabletReference tablet, IDeviceReport report)
+        {
+            if (PenActionHandler != null)
+                PenActionHandler.Deactivate(_action);
+            else if (MouseButtonHandler != null)
+            {
+                var button = ActionToButton(_action);
+                if (button != null)
+                    MouseButtonHandler.MouseUp(button.Value);
+            }
+        }
+
+        public override string ToString() => $"{PluginName}: {Binding}";
+
+        private PenAction _action;
+
+        private static MouseButton? ActionToButton(PenAction action)
+        {
+            return action switch
+            {
+                PenAction.Tip => MouseButton.Left,
+                PenAction.Eraser => MouseButton.Left,
+                PenAction.BarrelButton1 => MouseButton.Right,
+                PenAction.BarrelButton2 => MouseButton.Middle,
+                _ => null
+            };
+
+        }
+
+        private static readonly Dictionary<string, PenAction> ValidButtons = new()
+        {
+            { "Tip", PenAction.Tip },
+            { "Eraser", PenAction.Eraser },
+            { "Button 1", PenAction.BarrelButton1 },
+            { "Button 2", PenAction.BarrelButton2 },
+        };
+
+        private static string ActionToString(PenAction button) =>
+            ValidButtons.Where(x => x.Value == button)
+                .Select(x => x.Key)
+                .FirstOrDefault();
+    }
+}

--- a/OpenTabletDriver.Desktop/Binding/AdaptiveBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/AdaptiveBinding.cs
@@ -30,19 +30,21 @@ namespace OpenTabletDriver.Desktop.Binding
 
         public static string[] ButtonNames => ValidButtons.Keys.ToArray();
 
+        private string _binding = string.Empty;
+
         [Property(nameof(Binding)), PropertyValidated(nameof(ButtonNames))]
         public string Binding
         {
-            get;
+            get => _binding;
             set
             {
                 if (!ValidButtons.TryGetValue(value, out var button))
                     throw new ArgumentException("Invalid button name", value);
 
                 _action = button;
-                field = value;
+                _binding = value;
             }
-        } = string.Empty;
+        }
 
         public void Press(TabletReference tablet, IDeviceReport report)
         {

--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -169,13 +169,13 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
 
         public void Activate(PenAction action)
         {
-            if (GetCode(action) is {} code)
+            if (GetCode(action) is { } code)
                 SetKeyState(code, true);
         }
 
         public void Deactivate(PenAction action)
         {
-            if (GetCode(action) is {} code)
+            if (GetCode(action) is { } code)
                 SetKeyState(code, false);
         }
     }

--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -8,11 +8,13 @@ using OpenTabletDriver.Plugin.Platform.Pointer;
 
 namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
 {
-    public class EvdevVirtualTablet : EvdevVirtualMouse, IAbsolutePointer, IPressureHandler, ITiltHandler, IEraserHandler, IHoverDistanceHandler, ISynchronousPointer
+    public class EvdevVirtualTablet : IAbsolutePointer, IPressureHandler, ITiltHandler, IEraserHandler, IHoverDistanceHandler, ISynchronousPointer, IDisposable
     {
         private const int RESOLUTION = 1000; // subpixels per screen pixel
 
         private bool isEraser;
+
+        private EvdevDevice Device { set; get; }
 
         public unsafe EvdevVirtualTablet()
         {
@@ -130,7 +132,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
             Device.Write(EventType.EV_KEY, eventCode, state ? 1 : 0);
         }
 
-        public sealed override void Reset()
+        public void Reset()
         {
             // Zero out everything except position and tilt
             Device.Write(EventType.EV_KEY, EventCode.BTN_TOOL_RUBBER, 0);
@@ -144,6 +146,15 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
             isEraser = false;
         }
 
-        protected override EventCode? GetCode(MouseButton button) => null;
+        public void Dispose()
+        {
+            Device?.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        public void Flush()
+        {
+            Device.Sync();
+        }
     }
 }

--- a/OpenTabletDriver.Desktop/Profiles/BindingSettings.cs
+++ b/OpenTabletDriver.Desktop/Profiles/BindingSettings.cs
@@ -83,10 +83,10 @@ namespace OpenTabletDriver.Desktop.Profiles
             var bindingSettings = new BindingSettings
             {
                 TipButton = new PluginSettingStore(
-                    new MouseBinding
-                    {
-                        Button = nameof(MouseButton.Left)
-                    }
+                    new AdaptiveBinding(PenAction.Tip)
+                ),
+                EraserButton = new PluginSettingStore(
+                    new AdaptiveBinding(PenAction.Eraser)
                 ),
                 PenButtons = new PluginSettingStoreCollection(),
                 AuxButtons = new PluginSettingStoreCollection(),

--- a/OpenTabletDriver.Desktop/Profiles/BindingSettings.cs
+++ b/OpenTabletDriver.Desktop/Profiles/BindingSettings.cs
@@ -92,6 +92,9 @@ namespace OpenTabletDriver.Desktop.Profiles
                 AuxButtons = new PluginSettingStoreCollection(),
                 MouseButtons = new PluginSettingStoreCollection()
             };
+
+            bindingSettings.AddPenButtons(tabletSpecifications);
+
             bindingSettings.MatchSpecifications(tabletSpecifications);
             return bindingSettings;
         }
@@ -105,6 +108,17 @@ namespace OpenTabletDriver.Desktop.Profiles
             PenButtons = PenButtons.SetExpectedCount(penButtonCount);
             AuxButtons = AuxButtons.SetExpectedCount(auxButtonCount);
             MouseButtons = MouseButtons.SetExpectedCount(mouseButtonCount);
+        }
+
+        private void AddPenButtons(TabletSpecifications tabletSpecifications)
+        {
+            uint buttonCount = tabletSpecifications.Pen?.Buttons?.ButtonCount ?? 0;
+            if (buttonCount >= 1)
+                PenButtons.Add(new PluginSettingStore(new AdaptiveBinding(PenAction.BarrelButton1)));
+            if (buttonCount >= 2)
+                PenButtons.Add(new PluginSettingStore(new AdaptiveBinding(PenAction.BarrelButton2)));
+            if (buttonCount >= 3)
+                PenButtons.Add(new PluginSettingStore(new AdaptiveBinding(PenAction.BarrelButton3)));
         }
     }
 }

--- a/OpenTabletDriver.Plugin/Platform/Pointer/IPenActionHandler.cs
+++ b/OpenTabletDriver.Plugin/Platform/Pointer/IPenActionHandler.cs
@@ -1,0 +1,17 @@
+namespace OpenTabletDriver.Plugin.Platform.Pointer
+{
+    public interface IPenActionHandler
+    {
+        /// <summary>
+        /// Activate (button press) the appropriate action for the output mode
+        /// </summary>
+        /// <param name="action"></param>
+        void Activate(PenAction action);
+
+        /// <summary>
+        /// Deactivate (button release) the appropriate action for the output mode
+        /// </summary>
+        /// <param name="action"></param>
+        void Deactivate(PenAction action);
+    }
+}

--- a/OpenTabletDriver.Plugin/Platform/Pointer/PenAction.cs
+++ b/OpenTabletDriver.Plugin/Platform/Pointer/PenAction.cs
@@ -1,0 +1,53 @@
+namespace OpenTabletDriver.Plugin.Platform.Pointer;
+
+public enum PenAction
+{
+    /// <summary>
+    /// The tip of the pen
+    /// Pressure usually included in the tablet report
+    ///
+    /// Mouse output action: Left click
+    /// Tablet output action: "Pen touches tablet", unless handled by pressure
+    /// </summary>
+    Tip,
+
+    /// <summary>
+    /// The opposite end of the pen
+    /// May include pressure in the tablet report
+    ///
+    /// The significant majority of tablets do not have a dedicated eraser button reading,
+    /// but rather uses a flag in the report, or a separate tool report
+    ///
+    /// Mouse output action: Left click
+    /// Tablet output action: "Pen touches tablet", unless handled by pressure
+    /// </summary>
+    Eraser,
+
+    /// <summary>
+    /// First button on the pen barrel from the tip
+    ///
+    /// Mouse output action: Right click
+    /// Tablet output action: Right click equivalent, or first button
+    /// </summary>
+    BarrelButton1,
+
+    /// <summary>
+    /// Second button on the pen barrel from the tip
+    /// Not always present
+    ///
+    /// Mouse output action: Middle click
+    /// Tablet output action: Middle click equivalent
+    /// </summary>
+    BarrelButton2,
+
+    /// <summary>
+    /// Third button on the pen barrel from the tip
+    ///
+    /// Mouse output action: No-op
+    /// Tablet output action: Undefined
+    ///
+    /// Linux Artist Mode does implement support for this (by sending "tablet button 3"),
+    /// but is not widely supported in end-user software
+    /// </summary>
+    BarrelButton3,
+}


### PR DESCRIPTION
This adds a new type of bindings: Adaptive Bindings

Fixes #2510 for 0.6.x

# Description

See the issue for what "adaptive means", but the gist of it is that tip binding means left click, and barrel buttons send the signal that equates to a right or middle click respectively. E.g. on Linux Artist Mode a right click is `BTN_STYLUS2`.

These new bindings are intended to be used when switching between output modes. These functionally replace the Linux Artist Mode bindings. No more juggling profiles for default use cases when switching between output modes :tada: 

Additionally, daemon defaults now chooses these adaptive bindings as seen here:
<img width="964" height="762" alt="Screenshot from 2025-08-30 at 03_01_27 946971502" src="https://github.com/user-attachments/assets/eaecea9d-d2b3-481b-a8f2-439e1ca3b026" />

# Technical

A new interface `IPenAction` has been added to avoid reusing `IMouseHandler` as originally suggested in the issue we're solving. Without that change, mouse bindings could still be picked up. To keep compatibility with existing output modes implementing `IMouseHandler`, this PR also decides that the first tablet pen button correlates to right click, and the 2nd to middle click.

Please test thoroughly on non-Linux platforms. The 3 primary modes (artist, absolute, and relative) have been tested on Linux, but a double check is always handy.

Plugin developers making their own output modes may want to add support for these bindings (e.g. Windows Ink). The adaptive bindings supports output modes that implement either `IPenActionHandler` or `MouseButtonHandler`, and are injected via DI.