### PR TITLE
[06x] Build: Remove LangVersion

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <VersionBase>0.6.5.1</VersionBase>
     <FrameworkBase>net8.0</FrameworkBase>
-    <LangVersion>preview</LangVersion>
     <VersionPrefix>$(VersionBase)</VersionPrefix>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>


### PR DESCRIPTION
This was causing issues on developer machines (mine :rofl:) with newer SDK's resulting in code that would then not compile on CI

This should avoid future code being written that is too new for our targeted version.