### PR TITLE
PluginSettingStoreCollection: Check upper bounds

### DIFF
--- a/OpenTabletDriver.Desktop/Reflection/PluginSettingStoreCollection.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginSettingStoreCollection.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
+using OpenTabletDriver.Plugin;
 
 namespace OpenTabletDriver.Desktop.Reflection
 {
@@ -29,8 +31,21 @@ namespace OpenTabletDriver.Desktop.Reflection
 
         public PluginSettingStoreCollection SetExpectedCount(int expectedCount)
         {
+            int trimmed = 0;
+
             while (Count < expectedCount)
                 Add(null);
+
+            while (Count > expectedCount)
+            {
+                var me = this[Count - 1];
+                Log.Write(nameof(PluginSettingStoreCollection), $"Removing '{me.GetHumanReadableString()}'", LogLevel.Debug);
+                trimmed++;
+                RemoveAt(Count - 1);
+            }
+
+            if (trimmed > 0)
+                Log.WriteNotify(nameof(PluginSettingStoreCollection), $"Too many buttons configured for associated device - trimmed {trimmed} plugin settings for consistency. Some settings may have been lost.", LogLevel.Warning);
 
             return this;
         }


### PR DESCRIPTION
This should make settings and UI a bit more consistent in case a tablet has its button count reduced.

Otherwise, a user having 3 bindings on a 1 binding tablet would still show 3 bindings in the UI, even if the binding is cleared.

It also helps with development in case the developer adds more fields than needed.

The settings aren't auto-saved after displaying the error, so the user has the option to manually back up before saving.