### PR TITLE
[0.6.x] Move addition of Daemon service to LoadPlugins

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -91,8 +91,6 @@ namespace OpenTabletDriver.Daemon
                 await DetectTablets();
                 await SetSettings(Settings);
             };
-
-            AppInfo.PluginManager.AddService<IDriverDaemon>(() => this);
         }
 
         public event EventHandler<LogMessage>? Message;
@@ -132,6 +130,7 @@ namespace OpenTabletDriver.Daemon
 
             // Add services to inject on plugin construction
             AppInfo.PluginManager.AddService<IDriver>(() => this.Driver);
+            AppInfo.PluginManager.AddService<IDriverDaemon>(() => this);
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
Didn't notice that `IDriver`'s instance was inserted in `LoadPlugins`.
Moved the addition of the daemon service there to maintain consistency.