### PR TITLE
[06x] Resolution Change Handler

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -51,8 +51,7 @@ namespace OpenTabletDriver.Daemon
             {
                 if (args.Additions.Any())
                 {
-                    await DetectTablets();
-                    await SetSettings(Settings);
+                    await ResetDaemon();
                 }
             };
 
@@ -88,9 +87,15 @@ namespace OpenTabletDriver.Daemon
                     return;
 
                 Log.Write(nameof(DriverDaemon), "Sleep detected...", LogLevel.Info);
+                await ResetDaemon();
+            };
+            return;
+
+            async Task ResetDaemon()
+            {
                 await DetectTablets();
                 await SetSettings(Settings);
-            };
+            }
         }
 
         public event EventHandler<LogMessage>? Message;

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -241,12 +241,12 @@ namespace OpenTabletDriver.Daemon
                     Log.Write("Settings", "Failed to apply settings. Attempted recovery. Some settings may have been lost.", LogLevel.Error, true);
                 }
 
-                Resynchronize?.Invoke(this, EventArgs.Empty);
                 return Task.CompletedTask;
             }
             finally
             {
                 InjectServices();
+                ForceResynchronize();
             }
         }
 

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -128,10 +128,13 @@ namespace OpenTabletDriver.Daemon
 
             AppInfo.PluginManager.Load();
 
-            // Add services to inject on plugin construction
+            return Task.CompletedTask;
+        }
+
+        private Task InjectServices()
+        {
             AppInfo.PluginManager.AddService<IDriver>(() => this.Driver);
             AppInfo.PluginManager.AddService<IDriverDaemon>(() => this);
-
             return Task.CompletedTask;
         }
 
@@ -233,6 +236,10 @@ namespace OpenTabletDriver.Daemon
 
                 Resynchronize?.Invoke(this, EventArgs.Empty);
                 return Task.CompletedTask;
+            }
+            finally
+            {
+                InjectServices();
             }
         }
 

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -184,6 +184,8 @@ namespace OpenTabletDriver.Daemon
                 foreach (var dev in Driver.InputDevices)
                     dev.OutputMode?.Dispose();
 
+                DesktopInterop.InvalidateServices();
+
                 Settings = settings ??= Settings.GetDefaults();
 
                 foreach (InputDeviceTree? dev in Driver.InputDevices)

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -89,7 +89,6 @@ namespace OpenTabletDriver.Daemon
                 Log.Write(nameof(DriverDaemon), "Sleep detected...", LogLevel.Info);
                 await ResetDaemon();
             };
-            return;
 
             _outputChangedDetector.Changed += async () =>
             {
@@ -98,6 +97,7 @@ namespace OpenTabletDriver.Daemon
                 Log.WriteNotify(nameof(DriverDaemon),
                     "Your Monitor Layout has changed. Please verify that the OpenTabletDriver tablet output settings are correct");
             };
+            return;
 
             async Task ResetDaemon()
             {

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -91,6 +91,14 @@ namespace OpenTabletDriver.Daemon
             };
             return;
 
+            _outputChangedDetector.Changed += async () =>
+            {
+                Log.Write(nameof(DriverDaemon), "Monitor output change detected...", LogLevel.Info);
+                await ResetDaemon();
+                Log.WriteNotify(nameof(DriverDaemon),
+                    "Your Monitor Layout has changed. Please verify that the OpenTabletDriver tablet output settings are correct");
+            };
+
             async Task ResetDaemon()
             {
                 await DetectTablets();
@@ -109,6 +117,7 @@ namespace OpenTabletDriver.Daemon
         private IUpdater Updater = DesktopInterop.Updater;
         private readonly ISleepDetector? SleepDetector = new SleepDetector();
         private Settings? lastValidSettings;
+        private readonly IOutputChangedDetector _outputChangedDetector = new OutputChangedDetector();
 
         private UpdateInfo? _updateInfo;
         private LogFile _logFile;

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -199,6 +199,7 @@ namespace OpenTabletDriver.Daemon
                     dev.OutputMode?.Dispose();
 
                 DesktopInterop.InvalidateServices();
+                InjectServices();
 
                 Settings = settings ??= Settings.GetDefaults();
 
@@ -254,7 +255,6 @@ namespace OpenTabletDriver.Daemon
             }
             finally
             {
-                InjectServices();
                 ForceResynchronize();
             }
         }

--- a/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModeButtonBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModeButtonBinding.cs
@@ -4,6 +4,8 @@ using OpenTabletDriver.Desktop.Interop.Input.Absolute;
 using OpenTabletDriver.Native.Linux.Evdev;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Attributes;
+using OpenTabletDriver.Plugin.DependencyInjection;
+using OpenTabletDriver.Plugin.Platform.Pointer;
 using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
@@ -11,7 +13,8 @@ namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
     [PluginName("Linux Artist Mode"), SupportedPlatform(PluginPlatform.Linux)]
     public class LinuxArtistModeButtonBinding : IStateBinding
     {
-        private readonly EvdevVirtualTablet virtualTablet = (EvdevVirtualTablet)DesktopInterop.VirtualTablet;
+        [Resolved]
+        public readonly IPressureHandler virtualTablet;
 
         public static string[] ValidButtons { get; } = {
             "Pen Button 1",
@@ -42,7 +45,10 @@ namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
                 _ => throw new InvalidOperationException($"Invalid Button '{Button}'")
             };
 
-            virtualTablet.SetKeyState(eventCode, state);
+            if (virtualTablet is EvdevVirtualTablet evdevTablet)
+                evdevTablet.SetKeyState(eventCode, state);
+            else
+                Log.Write(nameof(LinuxArtistModeButtonBinding), $"Attempted to output to invalid output mode", LogLevel.Error);
         }
     }
 }

--- a/OpenTabletDriver.Desktop/Binding/PresetBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/PresetBinding.cs
@@ -37,7 +37,6 @@ namespace OpenTabletDriver.Desktop.Binding
                 if (preset != null && Daemon != null)
                 {
                     Daemon.SetSettings(preset.Settings);
-                    Daemon.ForceResynchronize();
                     Log.Write("Settings", $"Applied preset '{preset.Name}'.");
                 }
                 else

--- a/OpenTabletDriver.Desktop/Interop/DesktopInterop.cs
+++ b/OpenTabletDriver.Desktop/Interop/DesktopInterop.cs
@@ -118,6 +118,19 @@ namespace OpenTabletDriver.Desktop.Interop
             _ => null
         };
 
+        public static void InvalidateServices()
+        {
+            virtualScreen = null;
+            absolutePointer = null;
+            relativePointer = null;
+            virtualTablet = null;
+            virtualKeyboard = null;
+
+            AppInfo.PluginManager.ResetServices();
+
+            Log.Write(nameof(DesktopInterop), "Invalidated virtual screen and output devices", LogLevel.Debug);
+        }
+
         private static IVirtualScreen ConstructLinuxDisplay()
         {
             if (Environment.GetEnvironmentVariable("WAYLAND_DISPLAY") != null)

--- a/OpenTabletDriver.Desktop/Interop/OutputChangedDetector.cs
+++ b/OpenTabletDriver.Desktop/Interop/OutputChangedDetector.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenTabletDriver.Desktop.Reflection;
+using OpenTabletDriver.Plugin;
+
+#nullable enable
+
+namespace OpenTabletDriver.Desktop.Interop
+{
+    public interface IOutputChangedDetector
+    {
+        event Action Changed;
+    }
+
+    public class OutputChangedDetector() : TaskDetector(ResolutionDetector), IOutputChangedDetector
+    {
+        private const int LOOP_DURATION = 10;
+        private static async Task ResolutionDetector(Action? action, CancellationToken ct)
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(LOOP_DURATION), ct);
+
+                if (DesktopInterop.HasDisplayLayoutChanged())
+                {
+                    Log.Write(nameof(OutputChangedDetector), "Display layout changed", LogLevel.Debug);
+                    action?.Invoke();
+                }
+            }
+        }
+
+        public event Action Changed
+        {
+            add => ActionTask += value;
+            remove => ActionTask -= value;
+        }
+    }
+}

--- a/OpenTabletDriver.Desktop/Interop/SleepDetector.cs
+++ b/OpenTabletDriver.Desktop/Interop/SleepDetector.cs
@@ -11,67 +11,15 @@ namespace OpenTabletDriver.Desktop.Interop
         event Action Slept;
     }
 
-    public class SleepDetector : ISleepDetector
+    public class SleepDetector() : TaskDetector(DetectionLoop), ISleepDetector
     {
-        private readonly object sync = new();
-        private Task? task;
-        private CancellationTokenSource? cts;
-        private event Action? slept;
-
         public event Action Slept
         {
-            add
-            {
-                if (slept == null)
-                {
-                    Start();
-                }
-
-                slept += value;
-            }
-
-            remove
-            {
-                slept -= value;
-
-                if (slept == null)
-                {
-                    Stop();
-                }
-            }
+            add => ActionTask += value;
+            remove => ActionTask -= value;
         }
 
-        private void Start()
-        {
-            lock (sync)
-            {
-                if (task != null)
-                    return;
-
-                cts = new();
-                task = DetectionLoop(cts.Token);
-            }
-        }
-
-        private void Stop()
-        {
-            lock (sync)
-            {
-                if (task == null)
-                    return;
-
-                cts!.Cancel();
-#pragma warning disable VSTHRD002
-                task.Wait();
-#pragma warning restore VSTHRD002
-
-                cts.Dispose();
-                cts = null;
-                task = null;
-            }
-        }
-
-        private async Task DetectionLoop(CancellationToken ct)
+        private static async Task DetectionLoop(Action? action, CancellationToken ct)
         {
             var prev = DateTime.UtcNow;
             while (!ct.IsCancellationRequested)
@@ -79,7 +27,7 @@ namespace OpenTabletDriver.Desktop.Interop
                 var elapsed = DateTime.UtcNow;
 
                 if (elapsed - prev > TimeSpan.FromSeconds(8))
-                    slept?.Invoke();
+                    action?.Invoke();
 
                 prev = elapsed;
 

--- a/OpenTabletDriver.Desktop/Interop/TaskDetector.cs
+++ b/OpenTabletDriver.Desktop/Interop/TaskDetector.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace OpenTabletDriver.Desktop.Interop
+{
+    public class TaskDetector(Func<Action?, CancellationToken, Task> detector)
+    {
+        private readonly object _sync = new();
+        private Task? _task;
+        private CancellationTokenSource? _cts;
+
+        private event Action? _ActionTask;
+
+        protected event Action ActionTask
+        {
+            add
+            {
+                if (_ActionTask == null)
+                {
+                    Start(value);
+                }
+
+                _ActionTask += value;
+            }
+
+            remove
+            {
+                _ActionTask -= value;
+
+                if (_ActionTask == null)
+                {
+                    Stop();
+                }
+            }
+        }
+
+        private void Start(Action action)
+        {
+            lock (_sync)
+            {
+                if (_task != null)
+                    return;
+
+                _cts = new CancellationTokenSource();
+                _task = detector(action, _cts.Token);
+            }
+        }
+
+        private void Stop()
+        {
+            lock (_sync)
+            {
+                if (_task == null)
+                    return;
+
+                _cts!.Cancel();
+#pragma warning disable VSTHRD002
+                _task.Wait();
+#pragma warning restore VSTHRD002
+
+                _cts.Dispose();
+                _cts = null;
+                _task = null;
+            }
+        }
+    }
+}

--- a/OpenTabletDriver.Desktop/Reflection/ServiceManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/ServiceManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.DependencyInjection;
 
 namespace OpenTabletDriver.Desktop.Reflection
@@ -9,6 +10,7 @@ namespace OpenTabletDriver.Desktop.Reflection
     public class ServiceManager : IServiceManager
     {
         private readonly IDictionary<Type, Func<object>> services = new Dictionary<Type, Func<object>>();
+        private readonly IDictionary<Type, object> initializedServices = new Dictionary<Type, object>();
 
         /// <summary>
         /// Adds a retrieval method for a service type.
@@ -26,12 +28,21 @@ namespace OpenTabletDriver.Desktop.Reflection
         /// </summary>
         public virtual void ResetServices()
         {
+            foreach (var service in initializedServices)
+            {
+                if (service.Value is not IDisposable disposable) continue;
+                Log.Write("ResetServices", $"Disposing {disposable.GetType().Name}", LogLevel.Debug);
+                disposable.Dispose();
+            }
+            initializedServices.Clear();
             services.Clear();
         }
 
         public object GetService(Type serviceType)
         {
-            return services.ContainsKey(serviceType) ? services[serviceType].Invoke() : null;
+            var rv = services.TryGetValue(serviceType, out Func<object> value) ? value.Invoke() : null;
+            initializedServices.TryAdd(serviceType, rv);
+            return rv;
         }
 
         public T GetService<T>() where T : class => GetService(typeof(T)) as T;

--- a/OpenTabletDriver.Plugin/Output/OutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/OutputMode.cs
@@ -138,6 +138,8 @@ namespace OpenTabletDriver.Plugin.Output
 
         public virtual void Dispose()
         {
+            Log.Write(nameof(OutputMode), "Disposing output mode", LogLevel.Debug);
+
             entryElement = null;
 
             foreach (var obj in Elements ?? [])

--- a/OpenTabletDriver.UX/Controls/ControlPanel.cs
+++ b/OpenTabletDriver.UX/Controls/ControlPanel.cs
@@ -80,6 +80,10 @@ namespace OpenTabletDriver.UX.Controls
             toolEditor.StoreCollectionBinding.Bind(App.Current, a => a.Settings.Tools);
 
             outputModeEditor.SetDisplaySize(DesktopInterop.VirtualScreen.Displays);
+            App.Driver.Resynchronize += (sender, e) =>
+            {
+                outputModeEditor.SetDisplaySize(DesktopInterop.VirtualScreen.Displays);
+            };
 
             Log.Output += (_, message) => Application.Instance.AsyncInvoke(() =>
             {

--- a/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
@@ -308,7 +308,7 @@ namespace OpenTabletDriver.UX.Controls.Output
                 this.ToolTip = "You can right click the area editor to set the area to a display, adjust alignment, or resize the area.";
             }
 
-            protected override void CreateMenu()
+            internal override void CreateMenu()
             {
                 base.CreateMenu();
 
@@ -432,7 +432,7 @@ namespace OpenTabletDriver.UX.Controls.Output
                 }
             }
 
-            protected override void CreateMenu()
+            internal override void CreateMenu()
             {
                 base.CreateMenu();
 

--- a/OpenTabletDriver.UX/Controls/Output/Area/AreaEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/Area/AreaEditor.cs
@@ -193,7 +193,7 @@ namespace OpenTabletDriver.UX.Controls.Output.Area
             return (max - min) / 2;
         }
 
-        protected virtual void CreateMenu()
+        internal virtual void CreateMenu()
         {
             this.ContextMenu = new ContextMenu
             {

--- a/OpenTabletDriver.UX/Controls/Output/Area/RotationAreaEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/Area/RotationAreaEditor.cs
@@ -30,7 +30,7 @@ namespace OpenTabletDriver.UX.Controls.Output.Area
 
         private MaskedTextBox<float> rotation;
 
-        protected override void CreateMenu()
+        internal override void CreateMenu()
         {
             base.CreateMenu();
 

--- a/OpenTabletDriver.UX/Controls/Output/OutputModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/OutputModeEditor.cs
@@ -116,6 +116,7 @@ namespace OpenTabletDriver.UX.Controls.Output
                       where !(disp is IVirtualScreen)
                       select new RectangleF(disp.Position.X, disp.Position.Y, disp.Width, disp.Height);
             absoluteModeEditor.displayAreaEditor.AreaBounds = bgs;
+            absoluteModeEditor.displayAreaEditor.CreateMenu();
         }
 
         private void UpdateOutputMode(PluginSettingStore store)

--- a/OpenTabletDriver.UX/Controls/TabletSwitcherPanel.cs
+++ b/OpenTabletDriver.UX/Controls/TabletSwitcherPanel.cs
@@ -120,7 +120,12 @@ namespace OpenTabletDriver.UX.Controls
 
             public void HandleTabletsChanged(object sender, IList<TabletReference> tablets)
             {
+                Profile oldProfile = null;
+                if (SelectedIndex >= 0)
+                    oldProfile = (Profile)DataStore.ElementAt(SelectedIndex);
+
                 visibleProfiles.Clear();
+
                 if (tablets.Any())
                 {
                     var tabletsWithoutProfile = from tablet in tablets
@@ -135,7 +140,8 @@ namespace OpenTabletDriver.UX.Controls
 
                     if (this.SelectedIndex < 0)
                     {
-                        this.SelectedIndex = 0;
+                        int pendingIndex = oldProfile != null ? visibleProfiles.IndexOf(visibleProfiles.FirstOrDefault(x => x.Tablet == oldProfile.Tablet)) : 0;
+                        this.SelectedIndex = pendingIndex >= 0 ? pendingIndex : 0;
                         this.OnSelectedValueChanged(EventArgs.Empty);
                     }
 

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -381,6 +381,10 @@ namespace OpenTabletDriver.UX
 
             // Synchronize settings
             await SyncSettings();
+            Driver.Resynchronize += (sender, e) =>
+            {
+                DesktopInterop.InvalidateServices();
+            };
             Driver.Resynchronize += async (sender, e) => await SyncSettings();
 
             // Set window content


### PR DESCRIPTION
Monitor Layout changes (such as monitor addition/removal, or other layout/dimension change) is now handled

# Features Added

- Resetting the Daemon services without restarting the entire daemon
- Polling for resolution changes
- Correctly disposing services provided via Dependency Injection

# Issues Solved

- Fixes #1143
- Fixes #3055
- Likely provides a workaround for #3171 (re-applying settings should re-enable the tablet)
- Probably #2957 
- more?

# Known Defects that already existed, but may be more obvious now:

- Output mode coordinates are hardcoded and not assigned to a monitor, which means that the resolution change event may not remap the tablet as intended on some setups. But in cases of simply adding or removing a monitor that is rightwards or downwards from the origin, it should work as intended.

# Known Defects introduced by this PR

- `DeviceReader`'s may throw `ObjectDisposedException` on daemon reset, but this causes a harmless debug log message, as this exception is already specifically handled.

# Needs fixing before merge:

- [x] UI state on internal daemon restart is not properly synchronized (can be confusing for end users, but seems fixable)
  - Basically, the UI likely doesn't know that it needs to reset its internal state
- [x] Selected tablet is reset on resolution change, breaking UX
- [x] Suggested debounce of resolution changed event (only process the resolution change once readings stabilize), solved for example by ensuring that the desktop layout is "unchanged" following a resolution change event, before firing the internal reset.