### PR TITLE
Cleanup Temp before plugin install

### DIFF
--- a/OpenTabletDriver.Desktop/Reflection/DesktopPluginManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/DesktopPluginManager.cs
@@ -191,6 +191,8 @@ namespace OpenTabletDriver.Desktop.Reflection
 
             await metadata.DownloadAsync(sourcePath);
 
+            sourceDir.Refresh();
+
             var context = Plugins.FirstOrDefault(ctx => ctx.Directory.FullName == targetDir.FullName);
             var result = targetDir.Exists ? UpdatePlugin(context, sourceDir) : InstallPlugin(targetDir, sourceDir);
 

--- a/OpenTabletDriver.Desktop/Reflection/DesktopPluginManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/DesktopPluginManager.cs
@@ -142,8 +142,12 @@ namespace OpenTabletDriver.Desktop.Reflection
 
             var name = file.Name.Replace(file.Extension, string.Empty);
             var tempDir = new DirectoryInfo(Path.Join(TemporaryDirectory.FullName, name));
-            if (!tempDir.Exists)
-                tempDir.Create();
+
+            // Avoid issues with extracting to an existing directory and installing additional unwanted files
+            if (tempDir.Exists)
+                tempDir.Delete(true);
+
+            tempDir.Create();
 
             var pluginPath = Path.Join(AppInfo.Current.PluginDirectory, name);
             var pluginDir = new DirectoryInfo(pluginPath);
@@ -181,6 +185,9 @@ namespace OpenTabletDriver.Desktop.Reflection
 
             var sourceDir = new DirectoryInfo(sourcePath);
             var targetDir = new DirectoryInfo(targetPath);
+
+            if (sourceDir.Exists)
+                sourceDir.Delete(true);
 
             await metadata.DownloadAsync(sourcePath);
 


### PR DESCRIPTION
This partially fixes the issue mentionned in https://github.com/OpenTabletDriver/OpenTabletDriver/pull/4007#issuecomment-3242695614

Turns out the Temp Directory isn't cleaned up before a plugin install, resulting in more files being installed than intended.

Depends on #4007 being merged beforehand.
(for complete testing purpose)