### PR TITLE
[0.6.x] Fix XP-Pen Artist 12 init for newer revision

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12.json
@@ -25,7 +25,8 @@
       "OutputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
       "OutputInitReport": [
-        "ArAE"
+        "ArAE",
+        "ArAC"
       ]
     }
   ],


### PR DESCRIPTION
This is a new variant of the tablet with all the same identifiers except a different init. XP-Pen driver sends `ArAC` instead of `ArAE`. 

Sending `ArAE` alone allows the tablet to function but it does not disable the windows pnp endpoint so the user will get a double cursor. There does not appear to be any other way to disable this endpoint (editing device drivers caused the main endpoint OTD reads from to break too).

This new variant has no issues accepting both `ArAE` and `ArAC`. I could not find any information on the old variant at all. It's possible it isn't a variant and was simply tested by a Linux user and thus windows pnp was not an issue. It seems likely that even if it is a variant, it will also do fine with both `ArAE` and `ArAC` instead of just `ArAE` since theyre rather standard XP-Pen inits.

`ArAE` tends to mean "init and dont worry about aux". `ArAC` tends to mean "init everything". Although it isn't known for sure.

Strings pulled by XP-Pen driver for future reference:

| Index | Output |
|----------|----------|
| `4` | `V1.1` |
| `5` | `V1.1` |
| `100` | `\u6420\u3852\u0003\u1FFF\u09EC` |
| `110` | `0` |
| `131` | `V1.1` |

Pcap: [checked.zip](https://github.com/user-attachments/files/22101506/checked.zip)

Verification: https://discord.com/channels/615607687467761684/615611007951306863/1412501412696559628