### PR TITLE
[06x] PR Labeler: Fix constant `meta` tag application

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -49,6 +49,7 @@ meta:
 - changed-files:
   - any-glob-to-any-file:
     - '.github/**'
+    - '*'
     - 'eng/**'
     - 'OpenTabletDriver.Benchmarks/**'
   - all-globs-to-all-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -46,16 +46,17 @@ gui:
     - 'OpenTabletDriver.UX.Wpf/**'
 
 meta:
-- changed-files:
-  - any-glob-to-any-file:
-    - '.github/**'
-    - '*'
-    - 'eng/**'
-    - 'OpenTabletDriver.Benchmarks/**'
-  - all-globs-to-all-files:
-    - '!.github/workflows'
-    - '!README.md'
-    - '!TABLETS.md'
+- all:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '.github/**'
+      - '*'
+      - 'eng/**'
+      - 'OpenTabletDriver.Benchmarks/**'
+    - all-globs-to-all-files:
+      - '!.github/workflows'
+      - '!README.md'
+      - '!TABLETS.md'
 
 plugins:
 - changed-files:


### PR DESCRIPTION
The default behavior is to default to `any`, which results in any PR not touching the 3 files defined (`README.md`, `TABLETS.md`, and `.github/workflows`) would tag the PR as `meta`.

This reverts #4026 - as with this PR, all files in project root, except for those 3, should now get tagged correctly again.