### PR TITLE
Add support for XP-Pen Artist Pro 24 (Gen2)

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist Pro 24 (Gen2).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist Pro 24 (Gen2).json
@@ -1,0 +1,30 @@
+{
+  "Name": "XP-Pen Artist Pro 24 (Gen2)",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 526.08,
+      "Height": 295.91,
+      "MaxX": 105216,
+      "MaxY": 59182
+    },
+    "Pen": {
+      "MaxPressure": 16383,
+      "ButtonCount": 2
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 10429,
+      "ProductID": 2396,
+      "InputReportLength": 14,
+      "OutputReportLength": 14,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenGen2ReportParser",
+      "OutputInitReport": [
+        "ArAE"
+      ]
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -142,6 +142,7 @@
 | XP-Pen Artist 24              |     Supported     |
 | XP-Pen Artist Pro 14 (Gen2)   |     Supported     |
 | XP-Pen Artist Pro 16 (Gen2)   |     Supported     |
+| XP-Pen Artist Pro 24 (Gen2)   |     Supported     |
 | XP-Pen Deco 01                |     Supported     |
 | XP-Pen Deco 01 V2             |     Supported     |
 | XP-Pen Deco 01 V2 (Variant 2) |     Supported     |


### PR DESCRIPTION
Config made mostly by a user in #config-creation on discord.

Verification: https://discord.com/channels/615607687467761684/1400566020153933874/1402863286453534720

No diag from user with tablet detected. More info requested from user in discord.