### PR TITLE
Add CI workflow to verify new tablet names in PRs

### DIFF
--- a/.github/workflows/verify-tablet-names.yml
+++ b/.github/workflows/verify-tablet-names.yml
@@ -1,0 +1,33 @@
+name: Verify Correct Tablet Names
+
+on:
+  pull_request:
+
+jobs:
+  verify-names:
+    runs-on: ubuntu-latest
+    name: Verify Tablet Names
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get changed tablet configs
+        id: delta
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c
+        with:
+          files: OpenTabletDriver.Configurations/Configurations/**/*.json
+          separator: ","
+
+      - name: Check changed configs match TABLETS.md
+        if: steps.delta.outputs.any_changed == 'true'
+        env:
+          TABLETS: TABLETS.md
+          CONFIGS: ${{ steps.delta.outputs.all_changed_files }}
+        run: |
+          IFS=","
+          for CONF in $CONFIGS; do
+            NAME=$(cat $CONF| jq -r '.Name')
+            if ! grep -q "| $NAME " $TABLETS; then
+              echo "Failure: '$NAME' was not found in $TABLETS - was it spelt correctly?"
+              fi
+          done


### PR DESCRIPTION
Closes #4045.

Adds a basic CI workflow -- activated by any PR -- that checks if there were changes to the tablet configs (e.g. a modified or new config), and if there were, makes sure its `Name` exists (exactly) in `TABLETS.md`. This would prevent a tablet config with a mismatched `TABLETS.md` entry or vice versa.