### PR TITLE
[0.6.X] Order Filters & Tools by Name

### DIFF
--- a/OpenTabletDriver.UX/Controls/PluginSettingStoreCollectionEditor.cs
+++ b/OpenTabletDriver.UX/Controls/PluginSettingStoreCollectionEditor.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
+using System.Reflection;
 using Eto.Drawing;
 using Eto.Forms;
 using OpenTabletDriver.Desktop;
@@ -79,12 +81,15 @@ namespace OpenTabletDriver.UX.Controls
         private void RefreshContent()
         {
             var types = AppInfo.PluginManager.GetChildTypes<TSource>();
+            var sortedTypes = new ReadOnlyCollection<TypeInfo>([.. types.OrderBy(t => t.Name)]);
+
+            var oldSelected = sourceSelector.SelectedItem;
+            var newSelected = sortedTypes.FirstOrDefault(t => t.FullName == oldSelected?.FullName);
 
             // Update DataStore to new types, this refreshes the editor.
-            var prevIndex = sourceSelector.SelectedIndex;
-            sourceSelector.SelectedIndex = -1;
-            sourceSelector.DataStore = types;
-            sourceSelector.SelectedIndex = prevIndex;
+            sourceSelector.SelectedItem = null;
+            sourceSelector.DataStore = sortedTypes;
+            sourceSelector.SelectedItem = newSelected;
 
             this.Content = types.Any() ? mainContent : placeholder;
         }

--- a/OpenTabletDriver.UX/Controls/PluginSettingStoreCollectionEditor.cs
+++ b/OpenTabletDriver.UX/Controls/PluginSettingStoreCollectionEditor.cs
@@ -81,7 +81,7 @@ namespace OpenTabletDriver.UX.Controls
         private void RefreshContent()
         {
             var types = AppInfo.PluginManager.GetChildTypes<TSource>();
-            var sortedTypes = new ReadOnlyCollection<TypeInfo>([.. types.OrderBy(t => t.Name)]);
+            var sortedTypes = new ReadOnlyCollection<TypeInfo>([.. types.OrderBy(t => t.GetFriendlyName())]);
 
             var oldSelected = sourceSelector.SelectedItem;
             var newSelected = sortedTypes.FirstOrDefault(t => t.FullName == oldSelected?.FullName);


### PR DESCRIPTION
Closes #1972

Also fixes a bug with the selection not being set back to the previously selected plugin.