### PR TITLE
[06x] Tests: Add tests for GetFriendlyName() TypeInfo extension function

### DIFF
--- a/OpenTabletDriver.Tests/OpenTabletDriver.Tests.csproj
+++ b/OpenTabletDriver.Tests/OpenTabletDriver.Tests.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\OpenTabletDriver.Desktop\OpenTabletDriver.Desktop.csproj" />
+    <ProjectReference Include="..\OpenTabletDriver.UX\OpenTabletDriver.UX.csproj" />
   </ItemGroup>
 
 </Project>

--- a/OpenTabletDriver.Tests/UXExtensionTests.cs
+++ b/OpenTabletDriver.Tests/UXExtensionTests.cs
@@ -1,0 +1,34 @@
+using System.Reflection;
+using OpenTabletDriver.Plugin.Attributes;
+using Xunit;
+using static OpenTabletDriver.UX.Controls.Generic.Reflection.Extensions;
+
+namespace OpenTabletDriver.Tests
+{
+    public static class PluginNameDefinition
+    {
+        public const string Name = "This is a plugin name";
+    }
+
+    [PluginName(PluginNameDefinition.Name)]
+    public class PluginNameAttributeTest;
+
+    public class UXExtensionTests
+    {
+        [Fact]
+        public void GetFriendlyName_Reads_PluginNameAttribute()
+        {
+            var attributedType = new PluginNameAttributeTest();
+            Assert.Equal(PluginNameDefinition.Name, attributedType.GetType().GetTypeInfo().GetFriendlyName());
+        }
+
+        [Fact]
+        public void GetFriendlyName_Defaults_To_FullName()
+        {
+            var ns = typeof(UXExtensionTests).Namespace;
+            var expected = $"{ns}.{nameof(UXExtensionTests)}";
+            var output = typeof(UXExtensionTests).GetTypeInfo().GetFriendlyName();
+            Assert.Equal(expected, output);
+        }
+    }
+}

--- a/OpenTabletDriver.sln
+++ b/OpenTabletDriver.sln
@@ -22,6 +22,9 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTabletDriver.UX.MacOS", "OpenTabletDriver.UX.MacOS\OpenTabletDriver.UX.MacOS.csproj", "{BF28815D-56CA-443D-8F1E-836C19D94F05}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTabletDriver.Tests", "OpenTabletDriver.Tests\OpenTabletDriver.Tests.csproj", "{B0107F45-E452-40E4-8407-14F99895CE98}"
+	ProjectSection(ProjectDependencies) = postProject
+		{1A9166D9-0B7E-41B6-8210-EC04E17E9C3E} = {1A9166D9-0B7E-41B6-8210-EC04E17E9C3E}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTabletDriver.Desktop", "OpenTabletDriver.Desktop\OpenTabletDriver.Desktop.csproj", "{A72DF3AF-BFA5-4573-B02B-85E186AA428A}"
 EndProject


### PR DESCRIPTION
Adds 2 tests:
- Whether the `PluginName` attribute works correctly
- If the fallback works correctly

Very minor, but increases code coverage slightly
