### PR TITLE
[06x] BindingSettings: Use new ButtonCount property (fix deprecation warnings)

### DIFF
--- a/OpenTabletDriver.Desktop/Profiles/BindingSettings.cs
+++ b/OpenTabletDriver.Desktop/Profiles/BindingSettings.cs
@@ -128,7 +128,7 @@ namespace OpenTabletDriver.Desktop.Profiles
 
         private void AddPenButtons(TabletSpecifications tabletSpecifications)
         {
-            uint buttonCount = tabletSpecifications.Pen?.Buttons?.ButtonCount ?? 0;
+            uint buttonCount = tabletSpecifications.Pen.ButtonCount;
             if (buttonCount >= 1)
                 PenButtons.Add(new PluginSettingStore(new AdaptiveBinding(PenAction.BarrelButton1)));
             if (buttonCount >= 2)


### PR DESCRIPTION
The old property was obsoleted, and it was obsoleted in another commit while these lines were added

Removes all current remaining deprecation warnings.