### PR TITLE
[0.6.x] MacOS: Add experimental ARM64 build and release support

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         build: [windows, macos, BinaryTarBall, RedHat, Debian, Simple]
-        runtime-suffix: [x64]
+        runtime-suffix: [x64, arm64]
         include:
           - build: BinaryTarBall
             os: ubuntu-latest
@@ -32,11 +32,17 @@ jobs:
             os: ubuntu-latest
             runtime-prefix: linux-
           - build: macos
-            os: ubuntu-latest
+            os: macos-15
             runtime-prefix: osx-
+            pre-command: brew install coreutils bash; echo "$(brew --prefix coreutils)/libexec/gnubin" >> $GITHUB_PATH
           - build: windows
             os: windows-latest
             runtime-prefix: win-
+        exclude:
+          - build: RedHat
+            runtime-suffix: arm64
+          - build: Debian
+            runtime-suffix: arm64
     # TODO: release or debug build
     name: ${{ matrix.build }} ${{ matrix.runtime-prefix }}${{ matrix.runtime-suffix }} Publish
     runs-on: ${{ matrix.os }}
@@ -44,6 +50,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Pre-requisites
+        if: ${{ matrix.pre-command }}
+        run: |
+          echo "Running pre-command setup..."
+          eval "${{ matrix.pre-command }}"
       - uses: ./.github/actions/build-wrapper
         with:
           runtime: ${{ matrix.runtime-prefix }}${{ matrix.runtime-suffix }}

--- a/OpenTabletDriver.UX.MacOS/OpenTabletDriver.UX.MacOS.csproj
+++ b/OpenTabletDriver.UX.MacOS/OpenTabletDriver.UX.MacOS.csproj
@@ -3,16 +3,25 @@
   <PropertyGroup Label="Project Properties">
     <OutputType>Exe</OutputType>
     <TargetFramework>$(FrameworkBase)</TargetFramework>
-    <RuntimeIdentifiers>osx-x64</RuntimeIdentifiers>
     <AutoreleasePoolSupport>true</AutoreleasePoolSupport>
+    <UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup Label="NuGet Packages">
-    <PackageReference Include="Eto.Platform.Mac64" Version="2.5.10" />
+    <PackageReference Include="Eto.Platform.Mac64" Version="2.11.0" />
   </ItemGroup>
   
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\OpenTabletDriver.UX\OpenTabletDriver.UX.csproj" />
   </ItemGroup>
   
+  <ItemGroup Label="Project Resources">
+    <Content Include="../eng/bash/macos/Icon.icns" />
+    <None Include="../eng/bash/macos/Info.plist" />
+  </ItemGroup>
+
+  <Target Name="AdhocCodeSign" AfterTargets="MacFinishBundle" Condition="$([MSBuild]::IsOsPlatform(OSX))">
+    <Exec Command="codesign  -s - -f --deep &quot;$(OutputAppPath)&quot;" />
+  </Target>
+
 </Project>

--- a/eng/bash/macos/package.sh
+++ b/eng/bash/macos/package.sh
@@ -17,6 +17,13 @@ mkdir -p "${pkg_root}/Contents/Resources"
 cp "${pkg_script_root}/Icon.icns" "${pkg_root}/Contents/Resources/"
 cp "${pkg_script_root}/Info.plist" "${pkg_root}/Contents/"
 
+if type -p codesign; then
+    echo "Signing ${NET_RUNTIME} MacOS App..."
+    codesign  -s - -f --deep "${pkg_root}"
+else
+    echo "Skipping signing ${NET_RUNTIME} MacOS App..."
+fi
+
 echo "Creating tarball..."
 create_binary_tarball "${pkg_root}" "${OUTPUT}/${PKG_FILE}"
 

--- a/eng/bash/package.sh
+++ b/eng/bash/package.sh
@@ -81,6 +81,7 @@ if [[ "${NET_RUNTIME}" =~ ^osx-.*$ ]]; then
   # the following vars are imported from old packaging script
   SINGLE_FILE="false"
   SELF_CONTAINED="true"
+  extra_args=("-p:MacBuildBundle=false ${extra_args[@]}")
 
   PACKAGE_GEN=${PACKAGE_GEN:-"macos"}
   PROJECTS+=('OpenTabletDriver.UX.MacOS')


### PR DESCRIPTION
  This commit introduces comprehensive support for building, testing, and releasing OpenTabletDriver natively for macOS on the ARM64 architecture (Apple Silicon).
  Key changes include:
  CI/CD:
  
  Added a macospublish-arm64 job to dotnet.yml to build and upload ARM64 artifacts.
  Added a macos_arm64 job to release.yml to create and upload ARM64 release packages.
  
  Build System:
  
  The eng/macos/package.sh script now auto-detects the architecture (arm64 or x64) and builds for the corresponding runtime.
  
  The script performs ad-hoc codesigning on the application bundle for both ARM64 and x64 binaries.
  Codesigning is required for ARM64 binaries to run on Apple Silicon but is not required for x64 binaries; however, codesigning is applied to both for consistency.
  
  An earlier version of Eto had a bug where the automatic bundle was not generated when an output folder was specified.
  This bug has been fixed in Eto version 2.10.2, which now generates the bundle automatically.
  Since we manually create the application bundle, this commit disables Eto's automatic .app creation during publishing in the build script to prevent nested bundle creation.
  
  Project Configuration:
  
  Upgraded Eto.Platform.Mac64 to version 2.10.2.
  This version includes critical fixes for UI rendering, stability, universal binary compatibility on ARM64, and resolves the issue with extraneous bundle creation.
  
  Updated OpenTabletDriver.UX.MacOS.csproj to include resources like the app icon and Info.plist for Eto's automatic bundle generation.
  
  Added UseCurrentRuntimeIdentifier to the project configuration to allow Rider to build and execute using the host's architecture.