### PR TITLE
[06x] Add MacOS UI & Daemon Config and Update Build Instructions

### DIFF
--- a/.run/MacOS UI & Daemon.run.xml
+++ b/.run/MacOS UI & Daemon.run.xml
@@ -1,0 +1,43 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="MacOS UI &amp; Daemon" type="com.intellij.execution.configurations.multilaunch" factoryName="MultiLaunchConfiguration">
+    <rows>
+      <ExecutableRowSnapshot>
+        <option name="condition">
+          <ConditionSnapshot>
+            <option name="type" value="immediately" />
+          </ConditionSnapshot>
+        </option>
+        <option name="executable">
+          <ExecutableSnapshot>
+            <option name="id" value="buildSolution:" />
+          </ExecutableSnapshot>
+        </option>
+      </ExecutableRowSnapshot>
+      <ExecutableRowSnapshot>
+        <option name="condition">
+          <ConditionSnapshot>
+            <option name="type" value="afterPreviousFinished" />
+          </ConditionSnapshot>
+        </option>
+        <option name="executable">
+          <ExecutableSnapshot>
+            <option name="id" value="runConfig:.NET Project.OpenTabletDriver.Daemon" />
+          </ExecutableSnapshot>
+        </option>
+      </ExecutableRowSnapshot>
+      <ExecutableRowSnapshot>
+        <option name="condition">
+          <ConditionSnapshot>
+            <option name="type" value="afterPreviousStarted" />
+          </ConditionSnapshot>
+        </option>
+        <option name="executable">
+          <ExecutableSnapshot>
+            <option name="id" value="runConfig:.NET Launch Settings Profile.OpenTabletDriver.UX.MacOS: MacOS UI" />
+          </ExecutableSnapshot>
+        </option>
+      </ExecutableRowSnapshot>
+    </rows>
+    <method v="2" />
+  </configuration>
+</component>

--- a/OpenTabletDriver.UX.MacOS/Properties/launchSettings.json
+++ b/OpenTabletDriver.UX.MacOS/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "MacOS UI": {
+      "commandName": "Executable",
+      "executablePath": "$(MSBuildProjectDirectory)/$(OutputAppPath)/Contents/MacOS/OpenTabletDriver.UX.MacOS"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ The generic binary tarball is designed to be extracted from the root directory.
 
 #### MacOS [Experimental]
 
-Run `./eng/macos/package.sh --package true`.
+A newer version of Bash and Coreutils is required to build OpenTabletDriver. You can install them using Homebrew.
+Run `PATH="$(brew --prefix coreutils)/libexec/gnubin:$PATH" $(brew --prefix)/bin/bash ./eng/macos/package.sh --package true`.
 
 # Features
 


### PR DESCRIPTION
Introduce Rider run configuration for MacOS UI & Daemon, add launch settings for OpenTabletDriver.UX.MacOS, and update README with Homebrew coreutils build instructions for MacOS.

supersede #3662