### PR TITLE
[06x] Refactor tests

### DIFF
--- a/OpenTabletDriver.Tests/ConfigurationTest.cs
+++ b/OpenTabletDriver.Tests/ConfigurationTest.cs
@@ -22,7 +22,7 @@ using Xunit.Abstractions;
 
 namespace OpenTabletDriver.Tests
 {
-    public class ConfigurationTest(ITestOutputHelper _testOutputHelper)
+    public class ConfigurationTest(ITestOutputHelper testOutputHelper)
     {
         [Fact]
         public void Configurations_Have_ExistentParsers()
@@ -43,11 +43,11 @@ namespace OpenTabletDriver.Tests
                 try
                 {
                     var parser = parserProvider.GetReportParser(parserType);
-                    _testOutputHelper.WriteLine(parser.ToString());
+                    testOutputHelper.WriteLine(parser.ToString());
                 }
                 catch
                 {
-                    _testOutputHelper.WriteLine($"Unable to find report parser '{parserType}'");
+                    testOutputHelper.WriteLine($"Unable to find report parser '{parserType}'");
                     failed = true;
                 }
             }
@@ -248,7 +248,7 @@ namespace OpenTabletDriver.Tests
             catch (Exception e)
             {
                 if (errors.Any())
-                    _testOutputHelper.WriteLine($"Schema errors in {tabletFilename}: " + string.Join(",", errors));
+                    testOutputHelper.WriteLine($"Schema errors in {tabletFilename}: " + string.Join(",", errors));
 
                 throw;
             }
@@ -331,8 +331,8 @@ namespace OpenTabletDriver.Tests
 
             if (diff.HasDifferences)
             {
-                _testOutputHelper.WriteLine($"'{ttc.File.Name}' did not match linting:");
-                PrintDiff(_testOutputHelper, diff);
+                testOutputHelper.WriteLine($"'{ttc.File.Name}' did not match linting:");
+                PrintDiff(testOutputHelper, diff);
                 Assert.True(false);
             }
         }

--- a/OpenTabletDriver.Tests/ConfigurationTest.cs
+++ b/OpenTabletDriver.Tests/ConfigurationTest.cs
@@ -23,15 +23,8 @@ using Xunit.Abstractions;
 
 namespace OpenTabletDriver.Tests
 {
-    public partial class ConfigurationTest
+    public partial class ConfigurationTest(ITestOutputHelper _testOutputHelper)
     {
-        private readonly ITestOutputHelper _testOutputHelper;
-
-        public ConfigurationTest(ITestOutputHelper testOutputHelper)
-        {
-            _testOutputHelper = testOutputHelper;
-        }
-
         [Fact]
         public void Configurations_Have_ExistentParsers()
         {

--- a/OpenTabletDriver.Tests/ConfigurationTest.cs
+++ b/OpenTabletDriver.Tests/ConfigurationTest.cs
@@ -24,35 +24,11 @@ namespace OpenTabletDriver.Tests
 {
     public class ConfigurationTest(ITestOutputHelper testOutputHelper)
     {
-        [Fact]
-        public void Configurations_Have_ExistentParsers()
+        [Theory]
+        [MemberData(nameof(ConfigurationTestData.ParsersInConfigs), MemberType = typeof(ConfigurationTestData))]
+        public void Configurations_Have_ExistentParsers(string parserName)
         {
-            var serviceProvider = new DriverServiceCollection().BuildServiceProvider();
-            var parserProvider = serviceProvider.GetRequiredService<IReportParserProvider>();
-            var configurationProvider = serviceProvider.GetRequiredService<IDeviceConfigurationProvider>();
-
-            var parsers = from configuration in configurationProvider.TabletConfigurations
-                          from identifier in configuration.DigitizerIdentifiers.Concat(configuration.AuxiliaryDeviceIdentifiers ?? Enumerable.Empty<DeviceIdentifier>())
-                          orderby identifier.ReportParser
-                          select identifier.ReportParser;
-
-            var failed = false;
-
-            foreach (var parserType in parsers.Where(p => p != null).Distinct())
-            {
-                try
-                {
-                    var parser = parserProvider.GetReportParser(parserType);
-                    testOutputHelper.WriteLine(parser.ToString());
-                }
-                catch
-                {
-                    testOutputHelper.WriteLine($"Unable to find report parser '{parserType}'");
-                    failed = true;
-                }
-            }
-
-            Assert.False(failed);
+            ConfigurationTestData.ReportParserProvider.GetReportParser(parserName);
         }
 
         [Fact]

--- a/OpenTabletDriver.Tests/Data/ConfigurationTestData.cs
+++ b/OpenTabletDriver.Tests/Data/ConfigurationTestData.cs
@@ -21,7 +21,7 @@ namespace OpenTabletDriver.Tests.Data
     {
         public required Lazy<TabletConfiguration> Configuration { get; init; }
         public required FileInfo File { get; init; }
-        public required Lazy<string> FileContents  { get; init; }
+        public required Lazy<string> FileContents { get; init; }
     }
 
     public static class Extensions
@@ -66,9 +66,9 @@ namespace OpenTabletDriver.Tests.Data
         public static IDeviceConfigurationProvider DeviceConfigurationProvider => GetRequiredService<IDeviceConfigurationProvider>();
 
         private static IEnumerable<string> parsersInConfigs => from configuration in DeviceConfigurationProvider.TabletConfigurations
-            from identifier in configuration.DigitizerIdentifiers.Concat(configuration.AuxiliaryDeviceIdentifiers ?? Enumerable.Empty<DeviceIdentifier>())
-            orderby identifier.ReportParser
-            select identifier.ReportParser;
+                                                               from identifier in configuration.DigitizerIdentifiers.Concat(configuration.AuxiliaryDeviceIdentifiers ?? Enumerable.Empty<DeviceIdentifier>())
+                                                               orderby identifier.ReportParser
+                                                               select identifier.ReportParser;
 
         public static TheoryData<string> ParsersInConfigs => parsersInConfigs.Distinct().ToTheoryData();
 

--- a/OpenTabletDriver.Tests/Data/ConfigurationTestData.cs
+++ b/OpenTabletDriver.Tests/Data/ConfigurationTestData.cs
@@ -74,8 +74,8 @@ namespace OpenTabletDriver.Tests.Data
 
         #region Schema
 
-        private static JSchema _tabletConfigurationSchema;
-        public static JSchema TabletConfigurationSchema => _tabletConfigurationSchema ??= GetTabletConfigSchema();
+        private static JSchema? tabletConfigurationSchema;
+        public static JSchema TabletConfigurationSchema => tabletConfigurationSchema ??= GetTabletConfigSchema();
 
         static JSchema GetTabletConfigSchema()
         {

--- a/OpenTabletDriver.Tests/Data/ConfigurationTestData.cs
+++ b/OpenTabletDriver.Tests/Data/ConfigurationTestData.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -18,6 +19,17 @@ namespace OpenTabletDriver.Tests.Data
         public required Lazy<TabletConfiguration> Configuration { get; init; }
         public required FileInfo File { get; init; }
         public required Lazy<string> FileContents  { get; init; }
+    }
+
+    public static class Extensions
+    {
+        public static TheoryData<T> ToTheoryData<T>(this IEnumerable<T> enumerable)
+        {
+            var result = new TheoryData<T>();
+            foreach (var element in enumerable)
+                result.Add(element);
+            return result;
+        }
     }
 
     public static partial class ConfigurationTestData

--- a/OpenTabletDriver.Tests/Data/ConfigurationTestData.cs
+++ b/OpenTabletDriver.Tests/Data/ConfigurationTestData.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Schema;
+using Newtonsoft.Json.Schema.Generation;
+using OpenTabletDriver.Desktop;
+using OpenTabletDriver.Plugin.Tablet;
+using Xunit;
+
+namespace OpenTabletDriver.Tests.Data
+{
+    public record TestTabletConfiguration
+    {
+        public required Lazy<TabletConfiguration> Configuration { get; init; }
+        public required FileInfo File { get; init; }
+        public required Lazy<string> FileContents  { get; init; }
+    }
+
+    public static partial class ConfigurationTestData
+    {
+        public static TheoryData<TestTabletConfiguration> TestTabletConfigurations =>
+            GetTestTabletConfigurations();
+
+        private static TheoryData<TestTabletConfiguration> GetTestTabletConfigurations()
+        {
+            var result = new TheoryData<TestTabletConfiguration>();
+            foreach (var configFile in Directory.EnumerateFiles(GetConfigDir(), "*.json", SearchOption.AllDirectories))
+            {
+                FileInfo configFileInfo = new FileInfo(configFile);
+                var ttc = new TestTabletConfiguration
+                {
+                    Configuration = new Lazy<TabletConfiguration>(() => Deserialize(configFileInfo)),
+                    File = configFileInfo,
+                    FileContents = new Lazy<string>(() => configFileInfo.OpenText().ReadToEnd())
+                };
+                result.Add(ttc);
+            }
+
+            return result;
+        }
+
+        private static string GetConfigDir([CallerFilePath] string sourceFilePath = "") =>
+            Path.GetFullPath(Path.Join(sourceFilePath, "../../../OpenTabletDriver.Configurations/Configurations"));
+
+        private static TabletConfiguration Deserialize(FileInfo configFileInfo) => Serialization.Deserialize<TabletConfiguration>(configFileInfo);
+
+        [GeneratedRegex(@"^OpenTabletDriver\.Tablet\..*$", RegexOptions.Compiled)]
+        public static partial Regex AvaloniaReportParserPathRegex();
+    }
+}

--- a/OpenTabletDriver.Tests/ReportParserProviderTest.cs
+++ b/OpenTabletDriver.Tests/ReportParserProviderTest.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using OpenTabletDriver.Configurations.Parsers.XP_Pen;
 using OpenTabletDriver.Plugin.Components;
 using OpenTabletDriver.Plugin.Tablet;
+using OpenTabletDriver.Tests.Data;
 using Xunit;
 
 namespace OpenTabletDriver.Tests
@@ -28,6 +29,12 @@ namespace OpenTabletDriver.Tests
             var reportParserType = reportParserProvider.GetReportParser(reportParserName).GetType();
 
             Assert.Equal(expectedReportParserType, reportParserType);
+        }
+
+        [Fact]
+        public void InvalidParser_Throws()
+        {
+            Assert.ThrowsAny<Exception>(() => ConfigurationTestData.ReportParserProvider.GetReportParser("Invalid parser"));
         }
     }
 }


### PR DESCRIPTION
This simplifies some `[Fact]` tests that iterate over tablet configurations into `[Theory]` tests, properly making individual tests per tested object. This should also speed up the time it takes to run the full test suite, as configurations should only be evaluated a single time per test start, instead of on every individual `[Fact]` test start.

Rewritten the following tests to use `[Theory]` with `[MemberData]`:
- `Configurations_Have_ExistentParsers`
- `Configurations_Verify_Configs_With_Schema`
- `Configurations_Are_Linted`

It also flips the diff side of `Configurations_Are_Linted` as this previously indicated the more useless side of the diff.

It also changes the object types to be of `TheoryData<T>` instead of `IEnumerable<object[]?>`, as suggested in more recent xunit documentation.