### PR TITLE
[Avalonia] fix tablets md verification

### DIFF
--- a/.github/workflows/verify-tablet-names.yml
+++ b/.github/workflows/verify-tablet-names.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Full git history is needed to get a proper list of changed files
+          fetch-depth: 0
 
       - name: Check changed configs match TABLETS.md
         env:


### PR DESCRIPTION
Otherwise the 'git diff' returns an error

(cherry picked from commit a8fe19e28b213d1f0f3086d16509c714f00fad26)