### PR TITLE
[06x] tests: Add check for Tablet Config names in tablets.md

### DIFF
--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -15,3 +15,25 @@ jobs:
       - name: Test paths
         run: |
           ./tests/test_labeler_yaml.sh
+
+  test_tabletconfigs_present_in_tabletsmd:
+    runs-on: ubuntu-latest
+    name: Test for presence of added/changed configuration files in TABLETS.md
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full git history is needed to get a proper list of changed files
+          fetch-depth: 0
+
+      - name: Compare names of changed tablet configs with TABLETS.md
+        if: github.event_name != 'workflow_dispatch'
+        env:
+          GET_CONFIGS_FROM_CI: defined
+        run: |
+          ./tests/test_tabletconfigs_present_in_tabletsmd.sh
+
+      - name: Compare all names in tablet configs with TABLETS.md
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          ./tests/test_tabletconfigs_present_in_tabletsmd.sh

--- a/tests/test_tabletconfigs_present_in_tabletsmd.sh
+++ b/tests/test_tabletconfigs_present_in_tabletsmd.sh
@@ -32,6 +32,8 @@ if [ ${#configs[@]} -ne 0 ]; then
       fi
     fi
   done
+else
+  echo 'Pass: No configs to check'
 fi
 
 IFS="$oldifs"

--- a/tests/test_tabletconfigs_present_in_tabletsmd.sh
+++ b/tests/test_tabletconfigs_present_in_tabletsmd.sh
@@ -11,9 +11,7 @@ if [ ! -z "$GET_CONFIGS_FROM_CI" ]; then
   # git diff command uses a github action runner quirk where the diff between
   # HEAD^ and HEAD is equal to diffing commit merge base with pr tip
   mapfile -t configs < <(git diff --name-only --diff-filter=AM HEAD^ HEAD | grep '^OpenTabletDriver\.Configurations/Configurations/.*\.json')
-fi
-
-if [ -z "$configs" ]; then
+elif [ -z "$configs" ]; then
   # if still undefined, grab all configurations
   mapfile -t configs < <(find OpenTabletDriver.Configurations/Configurations/ -type f -iname '*.json')
 fi

--- a/tests/test_tabletconfigs_present_in_tabletsmd.sh
+++ b/tests/test_tabletconfigs_present_in_tabletsmd.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+oldifs="$IFS"
+IFS=$'\n'
+
+cd "$(dirname ${BASH_SOURCE[0]})"/..
+
+if [ ! -z "$GET_CONFIGS_FROM_CI" ]; then
+  # git diff command uses a github action runner quirk where the diff between
+  # HEAD^ and HEAD is equal to diffing commit merge base with pr tip
+  mapfile -t configs < <(git diff --name-only --diff-filter=AM HEAD^ HEAD | grep '^OpenTabletDriver\.Configurations/Configurations/.*\.json')
+fi
+
+if [ -z "$configs" ]; then
+  # if still undefined, grab all configurations
+  mapfile -t configs < <(find OpenTabletDriver.Configurations/Configurations/ -type f -iname '*.json')
+fi
+
+TABLETS="${TABLETS:-TABLETS.md}"
+
+unset failed
+
+if [ ${#configs[@]} -ne 0 ]; then
+  for conf in "${configs[@]}"; do
+    name=$(cat $conf| jq -r '.Name')
+    if ! grep -q "| $name " $TABLETS; then
+      echo "Failure: '$name' was not found in $TABLETS - was it spelled correctly?"
+      failed=y
+    else
+      if [ ! -z "$VERBOSE" ]; then
+        echo "Pass: '$name'"
+      fi
+    fi
+  done
+fi
+
+IFS="$oldifs"
+unset oldifs
+
+if [ ! -z "$failed" ]; then
+  exit 1
+fi


### PR DESCRIPTION
This adds a dedicated script to check for tablet names present in configs being absent from TABLETS.md

Should only check changed files on pull requests, but a `workflow_dispatch` handler was added to be run on-demand for all configuration files.

Can also be run locally with `./tests/test_tabletconfigs_present_in_tabletsmd.sh`

Logic stolen from OpenTabletDriver/OpenTabletDriver#4047

Alternative to #4063

Fix before merge:
- [x] Test for this PR should not test all configs. Logic needs to be double checked.