### PR TITLE
[0.6.x] Allow matching FeatureReportLength

### DIFF
--- a/OpenTabletDriver.Plugin/Tablet/DeviceIdentifier.cs
+++ b/OpenTabletDriver.Plugin/Tablet/DeviceIdentifier.cs
@@ -32,6 +32,11 @@ namespace OpenTabletDriver.Plugin.Tablet
         public uint? OutputReportLength { set; get; }
 
         /// <summary>
+        /// The maximum feature report length reported by the device.
+        /// </summary>
+        public uint? FeatureReportLength { set; get; }
+
+        /// <summary>
         /// The device report parser used by the detected device.
         /// </summary>
         [RegularExpression(@"^([A-Za-z]+\w*)(\.[A-Za-z]+\w*)+$", ErrorMessage = $"{nameof(ReportParser)} for identifier must match regular expression")]

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -173,6 +173,7 @@ namespace OpenTabletDriver
                    where device.CanOpen
                    where identifier.InputReportLength == null || identifier.InputReportLength == device.InputReportLength
                    where identifier.OutputReportLength == null || identifier.OutputReportLength == device.OutputReportLength
+                   where identifier.FeatureReportLength == null || identifier.FeatureReportLength == device.FeatureReportLength
                    where DeviceMatchesStrings(device, identifier.DeviceStrings)
                    where DeviceMatchesAttribute(device, identifier.Attributes, configuration.Attributes)
                    select device;


### PR DESCRIPTION
Noticed that this isn't allowed to be matched by configs for some reason. While no current configs use it, it seems reasonable to have in here and I imagine it wouldn't be any issue for performance for configs that have null for it anyways.

This value is output in diag and passed around everywhere already just for some reason not allowed in configs.