### PR TITLE
[0.6.x] Add identifier for Huion H580X

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/H580X.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H580X.json
@@ -27,6 +27,18 @@
       "InitializationStrings": [
         200
       ]
+    },
+    {
+      "VendorID": 9580,
+      "ProductID": 109,
+      "InputReportLength": 12,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
+      "DeviceStrings": {
+        "201": "HUION_T(211|224)_\\d{6}$"
+      },
+      "InitializationStrings": [
+        200
+      ]
     }
   ],
   "Attributes": {


### PR DESCRIPTION
Verification: https://discord.com/channels/615607687467761684/615611007951306863/1419798041518411816
Diag: [d.json](https://github.com/user-attachments/files/22478950/d.json)
String 201: `HUION_T211_210401`