### PR TITLE
[06x] Refactor and prettify about window

### DIFF
--- a/OpenTabletDriver.UX/Windows/AboutWindow.cs
+++ b/OpenTabletDriver.UX/Windows/AboutWindow.cs
@@ -44,12 +44,12 @@ namespace OpenTabletDriver.UX.Windows
             tabControl.Pages.Add(GenerateLicenseTabPage());
             tabControl.Pages.Add(_memoriamTabPage = GenerateMemoriamTabPage());
 
-            this.Content = tabControl;
+            Content = tabControl;
 
-            this.KeyDown += (sender, args) =>
+            KeyDown += (_, args) =>
             {
                 if (args.Key == Keys.Escape)
-                    this.Close();
+                    Close();
                 if (args.Key == Keys.J)
                     ShowMemoriamTab();
             };
@@ -87,12 +87,12 @@ namespace OpenTabletDriver.UX.Windows
                     new LinkButton
                     {
                         Text = "OpenTabletDriver Github Repository",
-                        Command = new Command((s, e) => Application.Instance.Open(App.Website.ToString())),
+                        Command = new Command((_, _) => Application.Instance.Open(App.Website.ToString())),
                     },
                     new CommandLabel
                     {
                         Text = "In memory of jamesbt365",
-                        Command = new Command((s, e) => ShowMemoriamTab()),
+                        Command = new Command((_, _) => ShowMemoriamTab()),
                     },
                 }
             };
@@ -200,7 +200,7 @@ namespace OpenTabletDriver.UX.Windows
                                 {
                                     Text = "jamesbt365",
                                     TextAlignment = TextAlignment.Center,
-                                    Command = new Command((s, e) => ShowMemoriamTab()),
+                                    Command = new Command((_, _) => ShowMemoriamTab()),
                                 }
                             ])
                             {
@@ -244,15 +244,15 @@ namespace OpenTabletDriver.UX.Windows
 
         protected override void OnMouseEnter(MouseEventArgs e)
         {
-            this.Font = SystemFonts.Bold();
-            this.Cursor = _pointerCursor;
+            Font = SystemFonts.Bold();
+            Cursor = _pointerCursor;
             base.OnMouseEnter(e);
         }
 
         protected override void OnMouseLeave(MouseEventArgs e)
         {
-            this.Font = SystemFonts.Default();
-            this.Cursor = _defaultCursor;
+            Font = SystemFonts.Default();
+            Cursor = _defaultCursor;
             base.OnMouseLeave(e);
         }
     }

--- a/OpenTabletDriver.UX/Windows/AboutWindow.cs
+++ b/OpenTabletDriver.UX/Windows/AboutWindow.cs
@@ -110,7 +110,7 @@ namespace OpenTabletDriver.UX.Windows
 
             var creditsTabContent = new StackLayout
             {
-                HorizontalContentAlignment = HorizontalAlignment.Stretch,
+                HorizontalContentAlignment = HorizontalAlignment.Center,
                 VerticalContentAlignment = VerticalAlignment.Stretch,
                 Padding = SPACING,
                 Spacing = SPACING / 2,
@@ -131,6 +131,8 @@ namespace OpenTabletDriver.UX.Windows
                             Orientation = Orientation.Horizontal,
                             HorizontalContentAlignment = HorizontalAlignment.Stretch,
                             VerticalContentAlignment = VerticalAlignment.Stretch,
+                            Padding = SPACING,
+                            Spacing = SPACING / 2,
                             Items =
                             {
                                 new StackLayoutItem

--- a/OpenTabletDriver.UX/Windows/AboutWindow.cs
+++ b/OpenTabletDriver.UX/Windows/AboutWindow.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Eto.Drawing;
@@ -135,92 +136,9 @@ namespace OpenTabletDriver.UX.Windows
                             Spacing = SPACING / 2,
                             Items =
                             {
-                                new StackLayoutItem
-                                {
-                                    Expand = true,
-                                    Control = new StackLayout
-                                    {
-                                        HorizontalContentAlignment = HorizontalAlignment.Stretch,
-                                        VerticalContentAlignment = VerticalAlignment.Stretch,
-                                        Items =
-                                        {
-                                            new Label
-                                            {
-                                                Text = "Developers",
-                                                VerticalAlignment = VerticalAlignment.Center,
-                                                TextAlignment = TextAlignment.Center,
-                                                Font = SystemFonts.Bold(FONTSIZE),
-                                            },
-                                            new LabelList(Developers, [
-                                                    new CommandLabel {
-                                                        Text = "jamesbt365",
-                                                        VerticalAlignment = VerticalAlignment.Center,
-                                                        TextAlignment = TextAlignment.Center,
-                                                        Command = new Command((s, e) => ShowMemoriamTab()),
-                                                    }
-                                                ])
-                                            {
-                                                HorizontalContentAlignment = HorizontalAlignment.Stretch,
-                                                VerticalContentAlignment = VerticalAlignment.Stretch,
-                                            }
-                                        }
-                                    }
-                                },
-                                new StackLayoutItem
-                                {
-                                    Expand = true,
-                                    Control = new StackLayout
-                                    {
-                                        HorizontalContentAlignment = HorizontalAlignment.Stretch,
-                                        VerticalContentAlignment = VerticalAlignment.Stretch,
-                                        Items =
-                                        {
-                                            new Label
-                                            {
-                                                Text = "Designers",
-                                                VerticalAlignment = VerticalAlignment.Center,
-                                                TextAlignment = TextAlignment.Center,
-                                                Font = SystemFonts.Bold(FONTSIZE),
-                                            },
-                                            new LabelList(Designers, [])
-                                            {
-                                                HorizontalContentAlignment = HorizontalAlignment.Stretch,
-                                                VerticalContentAlignment = VerticalAlignment.Stretch,
-                                            },
-                                        }
-                                    }
-                                },
-                                new StackLayoutItem
-                                {
-                                    Expand = true,
-                                    Control = new StackLayout
-                                    {
-                                        HorizontalContentAlignment = HorizontalAlignment.Stretch,
-                                        VerticalContentAlignment = VerticalAlignment.Stretch,
-                                        Items =
-                                        {
-                                            new Label
-                                            {
-                                                Text = "Documenters",
-                                                VerticalAlignment = VerticalAlignment.Center,
-                                                TextAlignment = TextAlignment.Center,
-                                                Font = SystemFonts.Bold(FONTSIZE),
-                                            },
-                                            new LabelList(Documenters, [
-                                                    new CommandLabel {
-                                                        Text = "jamesbt365",
-                                                        VerticalAlignment = VerticalAlignment.Center,
-                                                        TextAlignment = TextAlignment.Center,
-                                                        Command = new Command((s, e) => ShowMemoriamTab()),
-                                                    }
-                                                ])
-                                            {
-                                                HorizontalContentAlignment = HorizontalAlignment.Stretch,
-                                                VerticalContentAlignment = VerticalAlignment.Stretch,
-                                            }
-                                        }
-                                    }
-                                },
+                                GenerateContributor(Developers, nameof(Developers)),
+                                GenerateContributor(Designers, nameof(Designers)),
+                                GenerateContributor(Documenters, nameof(Documenters)),
                             }
                         }
                     }
@@ -274,6 +192,40 @@ namespace OpenTabletDriver.UX.Windows
             Debug.Assert(_memoriamTabPage != null);
             _memoriamTabPage.Visible = true;
         }
+
+        private StackLayoutItem GenerateContributor(IEnumerable<string> contributors, string title) =>
+            new()
+            {
+                Expand = true,
+                Control = new StackLayout
+                {
+                    HorizontalContentAlignment = HorizontalAlignment.Stretch,
+                    VerticalContentAlignment = VerticalAlignment.Stretch,
+                    Items =
+                    {
+                        new Label
+                        {
+                            Text = title,
+                            VerticalAlignment = VerticalAlignment.Center,
+                            TextAlignment = TextAlignment.Center,
+                            Font = SystemFonts.Bold(FONTSIZE),
+                        },
+                        new LabelList(contributors, [
+                            new CommandLabel
+                            {
+                                Text = "jamesbt365",
+                                VerticalAlignment = VerticalAlignment.Center,
+                                TextAlignment = TextAlignment.Center,
+                                Command = new Command((s, e) => ShowMemoriamTab()),
+                            }
+                        ])
+                        {
+                            HorizontalContentAlignment = HorizontalAlignment.Stretch,
+                            VerticalContentAlignment = VerticalAlignment.Stretch,
+                        }
+                    }
+                }
+            };
     }
     class CommandLabel : Label
     {
@@ -302,7 +254,7 @@ namespace OpenTabletDriver.UX.Windows
 
     class LabelList : StackLayout
     {
-        public LabelList(string[] textArray, CommandLabel[] commandLabels)
+        public LabelList(IEnumerable<string> textArray, CommandLabel[] commandLabels)
         {
             foreach (string text in textArray)
             {

--- a/OpenTabletDriver.UX/Windows/AboutWindow.cs
+++ b/OpenTabletDriver.UX/Windows/AboutWindow.cs
@@ -133,7 +133,7 @@ namespace OpenTabletDriver.UX.Windows
                             HorizontalContentAlignment = HorizontalAlignment.Stretch,
                             VerticalContentAlignment = VerticalAlignment.Stretch,
                             Padding = SPACING,
-                            Spacing = SPACING / 2,
+                            Spacing = SPACING,
                             Items =
                             {
                                 GenerateContributor(Developers, nameof(Developers)),
@@ -203,25 +203,24 @@ namespace OpenTabletDriver.UX.Windows
                     VerticalContentAlignment = VerticalAlignment.Stretch,
                     Items =
                     {
-                        new Label
+                        new GroupBox
                         {
                             Text = title,
-                            VerticalAlignment = VerticalAlignment.Center,
-                            TextAlignment = TextAlignment.Center,
-                            Font = SystemFonts.Bold(FONTSIZE),
-                        },
-                        new LabelList(contributors, [
-                            new CommandLabel
+                            Font = SystemFonts.Bold(LARGE_FONTSIZE),
+                            Padding = SPACING,
+                            Content = new LabelList(contributors, [
+                                new CommandLabel
+                                {
+                                    Text = "jamesbt365",
+                                    VerticalAlignment = VerticalAlignment.Center,
+                                    TextAlignment = TextAlignment.Center,
+                                    Command = new Command((s, e) => ShowMemoriamTab()),
+                                }
+                            ])
                             {
-                                Text = "jamesbt365",
-                                VerticalAlignment = VerticalAlignment.Center,
-                                TextAlignment = TextAlignment.Center,
-                                Command = new Command((s, e) => ShowMemoriamTab()),
+                                HorizontalContentAlignment = HorizontalAlignment.Stretch,
+                                VerticalContentAlignment = VerticalAlignment.Stretch,
                             }
-                        ])
-                        {
-                            HorizontalContentAlignment = HorizontalAlignment.Stretch,
-                            VerticalContentAlignment = VerticalAlignment.Stretch,
                         }
                     }
                 }

--- a/OpenTabletDriver.UX/Windows/AboutWindow.cs
+++ b/OpenTabletDriver.UX/Windows/AboutWindow.cs
@@ -12,6 +12,7 @@ namespace OpenTabletDriver.UX.Windows
         const int LARGE_FONTSIZE = 14;
         const int FONTSIZE = LARGE_FONTSIZE - 4;
         const int SPACING = 10;
+        const int TAB_CONTENT_WIDTH = 500;
 
         private readonly string[] Developers = ["InfinityGhost", "X9VoiD", "gonX", "jamesbt365", "Kuuube", "AkiSakurai"];
         private readonly string[] Designers = ["InfinityGhost"];
@@ -62,7 +63,7 @@ namespace OpenTabletDriver.UX.Windows
             var aboutTabContent = new StackLayout
             {
                 HorizontalContentAlignment = HorizontalAlignment.Center,
-                Width = 500,
+                Width = TAB_CONTENT_WIDTH,
                 Padding = SPACING,
                 Spacing = SPACING / 2,
                 Items =
@@ -107,6 +108,7 @@ namespace OpenTabletDriver.UX.Windows
                 HorizontalContentAlignment = HorizontalAlignment.Center,
                 Padding = SPACING,
                 Spacing = SPACING / 2,
+                Width = TAB_CONTENT_WIDTH
             };
 
             var creditsTabContentControl = new StackLayout
@@ -137,6 +139,7 @@ namespace OpenTabletDriver.UX.Windows
                 VerticalContentAlignment = VerticalAlignment.Stretch,
                 Padding = SPACING,
                 Spacing = SPACING / 2,
+                Width = TAB_CONTENT_WIDTH
             };
 
             var licenseTabContentControl = new TextArea
@@ -159,6 +162,7 @@ namespace OpenTabletDriver.UX.Windows
                 HorizontalContentAlignment = HorizontalAlignment.Stretch,
                 Padding = SPACING,
                 Spacing = SPACING / 2,
+                Width = TAB_CONTENT_WIDTH
             };
 
             var memoriamTabContentControl = new Label

--- a/OpenTabletDriver.UX/Windows/AboutWindow.cs
+++ b/OpenTabletDriver.UX/Windows/AboutWindow.cs
@@ -228,6 +228,7 @@ namespace OpenTabletDriver.UX.Windows
             });
         }
     }
+
     internal class CommandLabel : Label
     {
         public required Command Command;

--- a/OpenTabletDriver.UX/Windows/AboutWindow.cs
+++ b/OpenTabletDriver.UX/Windows/AboutWindow.cs
@@ -51,7 +51,7 @@ namespace OpenTabletDriver.UX.Windows
                         Text = "In Memory of James",
                         VerticalAlignment = VerticalAlignment.Center,
                         TextAlignment = TextAlignment.Center,
-                        Font = SystemFonts.Bold(FONTSIZE),
+                        Font = SystemFonts.Bold(LARGE_FONTSIZE),
                     },
                     new StackLayoutItem
                     {
@@ -121,7 +121,7 @@ namespace OpenTabletDriver.UX.Windows
                         Text = $"OpenTabletDriver v{App.Version} Credits",
                         VerticalAlignment = VerticalAlignment.Center,
                         TextAlignment = TextAlignment.Center,
-                        Font = SystemFonts.Bold(FONTSIZE),
+                        Font = SystemFonts.Bold(LARGE_FONTSIZE),
                     },
                     new StackLayoutItem
                     {
@@ -238,7 +238,7 @@ namespace OpenTabletDriver.UX.Windows
                         Text = $"OpenTabletDriver v{App.Version} License",
                         VerticalAlignment = VerticalAlignment.Center,
                         TextAlignment = TextAlignment.Center,
-                        Font = SystemFonts.Bold(FONTSIZE),
+                        Font = SystemFonts.Bold(LARGE_FONTSIZE),
                     },
                     new StackLayoutItem {
                         Expand = true,

--- a/OpenTabletDriver.UX/Windows/AboutWindow.cs
+++ b/OpenTabletDriver.UX/Windows/AboutWindow.cs
@@ -62,7 +62,6 @@ namespace OpenTabletDriver.UX.Windows
             var aboutTabContent = new StackLayout
             {
                 HorizontalContentAlignment = HorizontalAlignment.Center,
-                VerticalContentAlignment = VerticalAlignment.Stretch,
                 Width = 500,
                 Padding = SPACING,
                 Spacing = SPACING / 2,
@@ -75,18 +74,15 @@ namespace OpenTabletDriver.UX.Windows
                     new Label
                     {
                         Text = "OpenTabletDriver",
-                        VerticalAlignment = VerticalAlignment.Center,
                         Font = SystemFonts.Bold(LARGE_FONTSIZE),
                     },
                     new Label
                     {
                         Text = $"v{App.Version}",
-                        VerticalAlignment = VerticalAlignment.Center,
                     },
                     new Label
                     {
                         Text = "Open source, cross-platform tablet configurator",
-                        VerticalAlignment = VerticalAlignment.Center,
                     },
                     new LinkButton
                     {
@@ -96,7 +92,6 @@ namespace OpenTabletDriver.UX.Windows
                     new CommandLabel
                     {
                         Text = "In memory of jamesbt365",
-                        VerticalAlignment = VerticalAlignment.Center,
                         Command = new Command((s, e) => ShowMemoriamTab()),
                     },
                 }
@@ -110,7 +105,6 @@ namespace OpenTabletDriver.UX.Windows
             var creditsTabContent = new StackLayout
             {
                 HorizontalContentAlignment = HorizontalAlignment.Center,
-                VerticalContentAlignment = VerticalAlignment.Stretch,
                 Padding = SPACING,
                 Spacing = SPACING / 2,
             };
@@ -118,8 +112,6 @@ namespace OpenTabletDriver.UX.Windows
             var creditsTabContentControl = new StackLayout
             {
                 Orientation = Orientation.Horizontal,
-                HorizontalContentAlignment = HorizontalAlignment.Stretch,
-                VerticalContentAlignment = VerticalAlignment.Stretch,
                 Padding = SPACING,
                 Spacing = SPACING,
                 Items =
@@ -165,7 +157,6 @@ namespace OpenTabletDriver.UX.Windows
             var memoriamTabContent = new StackLayout
             {
                 HorizontalContentAlignment = HorizontalAlignment.Stretch,
-                VerticalContentAlignment = VerticalAlignment.Center,
                 Padding = SPACING,
                 Spacing = SPACING / 2,
             };
@@ -197,8 +188,6 @@ namespace OpenTabletDriver.UX.Windows
                 Expand = true,
                 Control = new StackLayout
                 {
-                    HorizontalContentAlignment = HorizontalAlignment.Stretch,
-                    VerticalContentAlignment = VerticalAlignment.Stretch,
                     Items =
                     {
                         new GroupBox
@@ -210,14 +199,12 @@ namespace OpenTabletDriver.UX.Windows
                                 new CommandLabel
                                 {
                                     Text = "jamesbt365",
-                                    VerticalAlignment = VerticalAlignment.Center,
                                     TextAlignment = TextAlignment.Center,
                                     Command = new Command((s, e) => ShowMemoriamTab()),
                                 }
                             ])
                             {
                                 HorizontalContentAlignment = HorizontalAlignment.Stretch,
-                                VerticalContentAlignment = VerticalAlignment.Stretch,
                             }
                         }
                     }
@@ -284,7 +271,6 @@ namespace OpenTabletDriver.UX.Windows
                 {
                     Items.Add(new Label
                     {
-                        VerticalAlignment = VerticalAlignment.Center,
                         TextAlignment = TextAlignment.Center,
                         Text = text,
                     });

--- a/OpenTabletDriver.UX/Windows/AboutWindow.cs
+++ b/OpenTabletDriver.UX/Windows/AboutWindow.cs
@@ -39,24 +39,6 @@ namespace OpenTabletDriver.UX.Windows
 
             var tabControl = new TabControl();
 
-            var memoriamTabContent = new StackLayout
-            {
-                HorizontalContentAlignment = HorizontalAlignment.Stretch,
-                VerticalContentAlignment = VerticalAlignment.Center,
-                Padding = SPACING,
-                Spacing = SPACING / 2,
-            };
-
-            var memoriamTabContentControl = new Label
-            {
-                TextAlignment = TextAlignment.Center,
-                Text = _jamesText
-            };
-
-            GenerateGenericStackLayoutItems(ref memoriamTabContent,
-                "In Memory of James",
-                memoriamTabContentControl);
-
             var aboutTabContent = new StackLayout
             {
                 HorizontalContentAlignment = HorizontalAlignment.Center,
@@ -144,6 +126,24 @@ namespace OpenTabletDriver.UX.Windows
             GenerateGenericStackLayoutItems(ref licenseTabContent,
                 $"OpenTabletDriver v{App.Version} License",
                 licenseTabContentControl);
+
+            var memoriamTabContent = new StackLayout
+            {
+                HorizontalContentAlignment = HorizontalAlignment.Stretch,
+                VerticalContentAlignment = VerticalAlignment.Center,
+                Padding = SPACING,
+                Spacing = SPACING / 2,
+            };
+
+            var memoriamTabContentControl = new Label
+            {
+                TextAlignment = TextAlignment.Center,
+                Text = _jamesText
+            };
+
+            GenerateGenericStackLayoutItems(ref memoriamTabContent,
+                "In Memory of James",
+                memoriamTabContentControl);
 
             tabControl.Pages.Add(new TabPage(aboutTabContent) { Text = "About" });
             tabControl.Pages.Add(new TabPage(creditsTabContent) { Text = "Credits" });

--- a/OpenTabletDriver.UX/Windows/AboutWindow.cs
+++ b/OpenTabletDriver.UX/Windows/AboutWindow.cs
@@ -230,6 +230,9 @@ namespace OpenTabletDriver.UX.Windows
     {
         public required Command Command;
 
+        private static readonly Cursor _pointerCursor = new(CursorType.Pointer);
+        private static readonly Cursor _defaultCursor = new(CursorType.Default);
+
         protected override void OnMouseDown(MouseEventArgs e)
         {
             Command.Execute();
@@ -239,14 +242,14 @@ namespace OpenTabletDriver.UX.Windows
         protected override void OnMouseEnter(MouseEventArgs e)
         {
             this.Font = SystemFonts.Bold();
-            this.Cursor = new Cursor(CursorType.Pointer);
+            this.Cursor = _pointerCursor;
             base.OnMouseEnter(e);
         }
 
         protected override void OnMouseLeave(MouseEventArgs e)
         {
             this.Font = SystemFonts.Default();
-            this.Cursor = new Cursor(CursorType.Default);
+            this.Cursor = _defaultCursor;
             base.OnMouseLeave(e);
         }
     }

--- a/OpenTabletDriver.UX/Windows/AboutWindow.cs
+++ b/OpenTabletDriver.UX/Windows/AboutWindow.cs
@@ -45,26 +45,17 @@ namespace OpenTabletDriver.UX.Windows
                 VerticalContentAlignment = VerticalAlignment.Center,
                 Padding = SPACING,
                 Spacing = SPACING / 2,
-                Items =
-                {
-                    new Label
-                    {
-                        Text = "In Memory of James",
-                        VerticalAlignment = VerticalAlignment.Center,
-                        TextAlignment = TextAlignment.Center,
-                        Font = SystemFonts.Bold(LARGE_FONTSIZE),
-                    },
-                    new StackLayoutItem
-                    {
-                        Expand = true,
-                        Control = new Label
-                        {
-                            TextAlignment = TextAlignment.Center,
-                            Text = _jamesText
-                        }
-                    }
-                }
             };
+
+            var memoriamTabContentControl = new Label
+            {
+                TextAlignment = TextAlignment.Center,
+                Text = _jamesText
+            };
+
+            GenerateGenericStackLayoutItems(ref memoriamTabContent,
+                "In Memory of James",
+                memoriamTabContentControl);
 
             var aboutTabContent = new StackLayout
             {
@@ -115,35 +106,26 @@ namespace OpenTabletDriver.UX.Windows
                 VerticalContentAlignment = VerticalAlignment.Stretch,
                 Padding = SPACING,
                 Spacing = SPACING / 2,
+            };
+
+            var creditsTabContentControl = new StackLayout
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalContentAlignment = HorizontalAlignment.Stretch,
+                VerticalContentAlignment = VerticalAlignment.Stretch,
+                Padding = SPACING,
+                Spacing = SPACING,
                 Items =
                 {
-                    new Label
-                    {
-                        Text = $"OpenTabletDriver v{App.Version} Credits",
-                        VerticalAlignment = VerticalAlignment.Center,
-                        TextAlignment = TextAlignment.Center,
-                        Font = SystemFonts.Bold(LARGE_FONTSIZE),
-                    },
-                    new StackLayoutItem
-                    {
-                        Expand = true,
-                        Control = new StackLayout
-                        {
-                            Orientation = Orientation.Horizontal,
-                            HorizontalContentAlignment = HorizontalAlignment.Stretch,
-                            VerticalContentAlignment = VerticalAlignment.Stretch,
-                            Padding = SPACING,
-                            Spacing = SPACING,
-                            Items =
-                            {
-                                GenerateContributor(Developers, nameof(Developers)),
-                                GenerateContributor(Designers, nameof(Designers)),
-                                GenerateContributor(Documenters, nameof(Documenters)),
-                            }
-                        }
-                    }
+                    GenerateContributor(Developers, nameof(Developers)),
+                    GenerateContributor(Designers, nameof(Designers)),
+                    GenerateContributor(Documenters, nameof(Documenters)),
                 }
             };
+
+            GenerateGenericStackLayoutItems(ref creditsTabContent,
+                $"OpenTabletDriver v{App.Version} Credits",
+                creditsTabContentControl);
 
             var licenseTabContent = new StackLayout
             {
@@ -151,25 +133,17 @@ namespace OpenTabletDriver.UX.Windows
                 VerticalContentAlignment = VerticalAlignment.Stretch,
                 Padding = SPACING,
                 Spacing = SPACING / 2,
-                Items =
-                {
-                    new Label
-                    {
-                        Text = $"OpenTabletDriver v{App.Version} License",
-                        VerticalAlignment = VerticalAlignment.Center,
-                        TextAlignment = TextAlignment.Center,
-                        Font = SystemFonts.Bold(LARGE_FONTSIZE),
-                    },
-                    new StackLayoutItem {
-                        Expand = true,
-                        Control = new TextArea
-                        {
-                            ReadOnly = true,
-                            Text = App.License,
-                        }
-                    }
-                }
             };
+
+            var licenseTabContentControl = new TextArea
+            {
+                ReadOnly = true,
+                Text = App.License,
+            };
+
+            GenerateGenericStackLayoutItems(ref licenseTabContent,
+                $"OpenTabletDriver v{App.Version} License",
+                licenseTabContentControl);
 
             tabControl.Pages.Add(new TabPage(aboutTabContent) { Text = "About" });
             tabControl.Pages.Add(new TabPage(creditsTabContent) { Text = "Credits" });
@@ -225,6 +199,23 @@ namespace OpenTabletDriver.UX.Windows
                     }
                 }
             };
+
+        private static void GenerateGenericStackLayoutItems(ref StackLayout stackLayout, string title, Control control)
+        {
+            stackLayout.Items.Add(new Label
+            {
+                Text = title,
+                VerticalAlignment = VerticalAlignment.Center,
+                TextAlignment = TextAlignment.Center,
+                Font = SystemFonts.Bold(LARGE_FONTSIZE)
+            });
+
+            stackLayout.Items.Add(new StackLayoutItem
+            {
+                Expand = true,
+                Control = control
+            });
+        }
     }
     class CommandLabel : Label
     {

--- a/OpenTabletDriver.UX/Windows/AboutWindow.cs
+++ b/OpenTabletDriver.UX/Windows/AboutWindow.cs
@@ -228,7 +228,7 @@ namespace OpenTabletDriver.UX.Windows
             });
         }
     }
-    class CommandLabel : Label
+    internal class CommandLabel : Label
     {
         public required Command Command;
 
@@ -256,7 +256,7 @@ namespace OpenTabletDriver.UX.Windows
         }
     }
 
-    class LabelList : StackLayout
+    internal class LabelList : StackLayout
     {
         public LabelList(IEnumerable<string> textArray, CommandLabel[] commandLabels)
         {

--- a/OpenTabletDriver.UX/Windows/AboutWindow.cs
+++ b/OpenTabletDriver.UX/Windows/AboutWindow.cs
@@ -39,6 +39,26 @@ namespace OpenTabletDriver.UX.Windows
 
             var tabControl = new TabControl();
 
+            tabControl.Pages.Add(GenerateAboutTabPage());
+            tabControl.Pages.Add(GenerateCreditsTabPage());
+            tabControl.Pages.Add(GenerateLicenseTabPage());
+            tabControl.Pages.Add(_memoriamTabPage = GenerateMemoriamTabPage());
+
+            this.Content = tabControl;
+
+            this.KeyDown += (sender, args) =>
+            {
+                if (args.Key == Keys.Escape)
+                    this.Close();
+                if (args.Key == Keys.J)
+                    ShowMemoriamTab();
+            };
+        }
+
+        #region Tab Pages
+
+        private TabPage GenerateAboutTabPage()
+        {
             var aboutTabContent = new StackLayout
             {
                 HorizontalContentAlignment = HorizontalAlignment.Center,
@@ -82,6 +102,11 @@ namespace OpenTabletDriver.UX.Windows
                 }
             };
 
+            return new TabPage(aboutTabContent) { Text = "About" };
+        }
+
+        private TabPage GenerateCreditsTabPage()
+        {
             var creditsTabContent = new StackLayout
             {
                 HorizontalContentAlignment = HorizontalAlignment.Center,
@@ -109,6 +134,11 @@ namespace OpenTabletDriver.UX.Windows
                 $"OpenTabletDriver v{App.Version} Credits",
                 creditsTabContentControl);
 
+            return new TabPage(creditsTabContent) { Text = "Credits" };
+        }
+
+        private static TabPage GenerateLicenseTabPage()
+        {
             var licenseTabContent = new StackLayout
             {
                 HorizontalContentAlignment = HorizontalAlignment.Stretch,
@@ -127,6 +157,11 @@ namespace OpenTabletDriver.UX.Windows
                 $"OpenTabletDriver v{App.Version} License",
                 licenseTabContentControl);
 
+            return new TabPage(licenseTabContent) { Text = "License" };
+        }
+
+        private static TabPage GenerateMemoriamTabPage()
+        {
             var memoriamTabContent = new StackLayout
             {
                 HorizontalContentAlignment = HorizontalAlignment.Stretch,
@@ -145,21 +180,10 @@ namespace OpenTabletDriver.UX.Windows
                 "In Memory of James",
                 memoriamTabContentControl);
 
-            tabControl.Pages.Add(new TabPage(aboutTabContent) { Text = "About" });
-            tabControl.Pages.Add(new TabPage(creditsTabContent) { Text = "Credits" });
-            tabControl.Pages.Add(new TabPage(licenseTabContent) { Text = "License" });
-            tabControl.Pages.Add(_memoriamTabPage = new TabPage(memoriamTabContent) { Text = "Memoriam", Visible = false });
-
-            this.Content = tabControl;
-
-            this.KeyDown += (sender, args) =>
-            {
-                if (args.Key == Keys.Escape)
-                    this.Close();
-                if (args.Key == Keys.J)
-                    ShowMemoriamTab();
-            };
+            return new TabPage(memoriamTabContent) { Text = "Memoriam", Visible = false };
         }
+
+        #endregion Tab Pages
 
         private void ShowMemoriamTab()
         {

--- a/OpenTabletDriver.UX/Windows/AboutWindow.cs
+++ b/OpenTabletDriver.UX/Windows/AboutWindow.cs
@@ -82,7 +82,7 @@ namespace OpenTabletDriver.UX.Windows
                     {
                         Text = "OpenTabletDriver",
                         VerticalAlignment = VerticalAlignment.Center,
-                        Font = SystemFonts.Bold(FONTSIZE),
+                        Font = SystemFonts.Bold(LARGE_FONTSIZE),
                     },
                     new Label
                     {


### PR DESCRIPTION
Aside from the kitchen sink refactor of the About Page, these are the most notable changes:

- Use larger font for program title on first page
- Use larger font sizes for page headers
- Keeps content on Credits page closer together, otherwise it goes too wide
- Extracts some commonly used class properties into functions
- Uses a GroupBox instead of Label for the credits

Further details can be seen in the commits

Default size:

<img width="500" height="439" alt="image" src="https://github.com/user-attachments/assets/1b9075a3-8e73-44de-9e78-7399f5ca7276" />
<img width="500" height="439" alt="image" src="https://github.com/user-attachments/assets/c3082cf1-9603-44c1-906d-f8b84bf0ecf5" />
<img width="500" height="439" alt="image" src="https://github.com/user-attachments/assets/db6b64cc-cdc6-4703-91d0-49622caee64a" />
<img width="500" height="439" alt="image" src="https://github.com/user-attachments/assets/43fe46bd-c402-4c6e-b27a-f99d908fc912" />

Wide:
<img width="1234" height="703" alt="image" src="https://github.com/user-attachments/assets/3b5a36b5-0194-403e-b7b9-fc88e5588d8f" />
<img width="1234" height="703" alt="image" src="https://github.com/user-attachments/assets/c5f1c900-37d7-45b7-b99b-e92cb59c0373" />
<img width="1234" height="703" alt="image" src="https://github.com/user-attachments/assets/89eee02a-0112-4a34-89ee-0dea14f94753" />
<img width="1234" height="703" alt="image" src="https://github.com/user-attachments/assets/a7f32a3e-b30c-450c-8537-e080f3ad496f" />

