### PR TITLE
Fix a few incorrect pressure maxes

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Genius/G-Pen 560.json
+++ b/OpenTabletDriver.Configurations/Configurations/Genius/G-Pen 560.json
@@ -8,7 +8,7 @@
       "MaxY": 8999
     },
     "Pen": {
-      "MaxPressure": 1024,
+      "MaxPressure": 1023,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-1300.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-1300.json
@@ -8,7 +8,7 @@
       "MaxY": 34200
     },
     "Pen": {
-      "MaxPressure": 2048,
+      "MaxPressure": 2047,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-2200.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTK-2200.json
@@ -8,7 +8,7 @@
       "MaxY": 54260
     },
     "Pen": {
-      "MaxPressure": 2048,
+      "MaxPressure": 2047,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {


### PR DESCRIPTION
Genius G-Pen 560: Pressure never verified, unlikely it's 1024. Might not even be 1023 either but 1023 is much more likely.

Wacom Cintiq 22HD (DTK-2200): The DTH-2200 which is the same as this but with touch has 2047 max and it is extremely unlikely this tablet randomly has one extra level.

Wacom Cintiq 13HD (DTK-1300): I own one of these, it is 2047.