### PR TITLE
workflows/dotnet: Run apt update before apt install

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,7 +14,7 @@ jobs:
     name: Linux Publish
     steps:
       - name: Install required packages for Debian
-        run: sudo apt install -y debhelper dotnet-sdk-8.0 build-essential
+        run: sudo apt update && sudo apt install -y debhelper dotnet-sdk-8.0 build-essential
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Fixes apt install 404 errors if the runner uses an outdated package list.

Fixes failing tests in [#4126](https://github.com/OpenTabletDriver/OpenTabletDriver/pull/4126)