### PR TITLE
[06x] CI/shell tests: Emit passed tablet configs

### DIFF
--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -30,10 +30,13 @@ jobs:
         if: github.event_name != 'workflow_dispatch'
         env:
           GET_CONFIGS_FROM_CI: defined
+          VERBOSE: y
         run: |
           ./tests/test_tabletconfigs_present_in_tabletsmd.sh
 
       - name: Compare all names in tablet configs with TABLETS.md
         if: github.event_name == 'workflow_dispatch'
+        env:
+          VERBOSE: y
         run: |
           ./tests/test_tabletconfigs_present_in_tabletsmd.sh


### PR DESCRIPTION
This enables, for CI, the shell test check for tablets.md<->config json naming to output tablet configurations that passes test.

# Pre-PR:

A full pass emits nothing in checks

# Post-PR

Each file that passes the test should now be output to stdout:
https://github.com/OpenTabletDriver/OpenTabletDriver/blob/b99b3bb4a0cff3c3d77ea9ff31e3cd2f4765e580/tests/test_tabletconfigs_present_in_tabletsmd.sh#L30-L32