### PR TITLE
[06x] workflows/release: Update apt before installing packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       VERSION_SUFFIX: ${{ github.event.inputs.version_suffix }}
     steps:
       - name: Install required packages
-        run: sudo apt install -y debhelper dotnet-sdk-8.0 build-essential
+        run: sudo apt update && apt install -y debhelper dotnet-sdk-8.0 build-essential
 
       - name: Checkout OpenTabletDriver Repository
         uses: actions/checkout@v4
@@ -72,7 +72,7 @@ jobs:
     name: NuGet Deploy (Ubuntu Host)
     steps:
       - name: Install required packages
-        run: sudo apt install -y debhelper dotnet-sdk-8.0 build-essential
+        run: sudo apt update && apt install -y debhelper dotnet-sdk-8.0 build-essential
 
       - name: Checkout OpenTabletDriver Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Like #4127 but for release workflows.

Should prevent apt from giving us 404's on mirrors now and in the future