### PR TITLE
[06x] Console: Fix invalid call in SetOutputMode

### DIFF
--- a/OpenTabletDriver.Console/Program.Commands.cs
+++ b/OpenTabletDriver.Console/Program.Commands.cs
@@ -167,11 +167,11 @@ namespace OpenTabletDriver.Console
             await ModifyProfile(tablet, p => p.AbsoluteModeSettings.LockAspectRatio = isEnabled);
         }
 
-        private static async Task SetOutputMode(string tablet, string mode)
+        private static async Task SetOutputMode(string tablet, string path)
         {
-            var outputMode = PluginSettingStore.FromPath(mode);
+            var outputMode = PluginSettingStore.FromPath(path);
             if (outputMode == null)
-                await Out.WriteLineAsync($"Invalid output mode '{mode}'. Use paths like in '{nameof(ListOutputModes).ToLower()}'");
+                await Out.WriteLineAsync($"Invalid output mode '{path}'. Use paths like in '{nameof(ListOutputModes).ToLower()}'");
             else
                 await ModifyProfile(tablet, p => p.OutputMode = outputMode);
         }

--- a/OpenTabletDriver.Console/Program.Commands.cs
+++ b/OpenTabletDriver.Console/Program.Commands.cs
@@ -169,7 +169,7 @@ namespace OpenTabletDriver.Console
 
         private static async Task SetOutputMode(string tablet, string mode)
         {
-            await ModifyProfile(tablet, p => p.OutputMode = new PluginSettingStore(mode));
+            await ModifyProfile(tablet, p => p.OutputMode = PluginSettingStore.FromPath(mode));
         }
 
         private static async Task SetFilters(string tablet, params string[] filters)

--- a/OpenTabletDriver.Console/Program.Commands.cs
+++ b/OpenTabletDriver.Console/Program.Commands.cs
@@ -169,7 +169,11 @@ namespace OpenTabletDriver.Console
 
         private static async Task SetOutputMode(string tablet, string mode)
         {
-            await ModifyProfile(tablet, p => p.OutputMode = PluginSettingStore.FromPath(mode));
+            var outputMode = PluginSettingStore.FromPath(mode);
+            if (outputMode == null)
+                await Out.WriteLineAsync($"Invalid output mode '{mode}'. Use paths like in '{nameof(ListOutputModes).ToLower()}'");
+            else
+                await ModifyProfile(tablet, p => p.OutputMode = outputMode);
         }
 
         private static async Task SetFilters(string tablet, params string[] filters)


### PR DESCRIPTION
Resolves #1952

Note that the full path name of the plugin must be used - not simply "Relative Mode"