### PR TITLE
[06x] Console: Use proper function for looking up plugin paths

### DIFF
--- a/OpenTabletDriver.Console/Program.Commands.cs
+++ b/OpenTabletDriver.Console/Program.Commands.cs
@@ -178,7 +178,7 @@ namespace OpenTabletDriver.Console
             {
                 var collection = new PluginSettingStoreCollection();
                 foreach (var path in filters)
-                    collection.Add(new PluginSettingStore(path));
+                    collection.Add(PluginSettingStore.FromPath(path));
 
                 s.Filters = collection;
             });
@@ -190,7 +190,7 @@ namespace OpenTabletDriver.Console
             {
                 var collection = new PluginSettingStoreCollection();
                 foreach (var path in tools)
-                    collection.Add(new PluginSettingStore(path));
+                    collection.Add(PluginSettingStore.FromPath(path));
 
                 s.Tools = collection;
             });


### PR DESCRIPTION
Solves a bug where the returned element would always be of the 'String' type, since it was hitting the 'object' constructor, and not doing what was intended.

Fixes #4157 but the command still doesn't work due to #4149