### PR TITLE
Add support for Genius G-Pen F509

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Genius/G-Pen F509.json
+++ b/OpenTabletDriver.Configurations/Configurations/Genius/G-Pen F509.json
@@ -1,0 +1,31 @@
+{
+  "Name": "Genius G-Pen F509",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 227.584,
+      "Height": 136.5504,
+      "MaxX": 17920,
+      "MaxY": 10752
+    },
+    "Pen": {
+      "MaxPressure": 1023,
+      "ButtonCount": 2
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 5935,
+      "ProductID": 56,
+      "InputReportLength": 64,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Genius.GeniusReportParserV2",
+      "FeatureInitReport": [
+        "AgQA",
+        "AgIA",
+        "AhAB"
+      ]
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -182,6 +182,7 @@
 | Gaomon S56K                        |    Has Quirks     | Windows: Might need Zadig's WinUSB to be installed on interface 0 or 1
 | Gaomon S630                        |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0
 | Gaomon S830                        |    Has Quirks     | User may have to replug their tablet until it is detected.
+| Genius G-Pen F509                  |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed
 | Genius i405x                       |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed
 | Genius i608x                       |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed
 | Huion 420                          |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0


### PR DESCRIPTION
Verification: https://discord.com/channels/615607687467761684/1422309218329038878/1422662921967894589
Diag: [diagnostic.json](https://github.com/user-attachments/files/22626335/diagnostic.json)
Diag Detected: [working.json](https://github.com/user-attachments/files/22626341/working.json)

This tablet is 2000 lpi (about 78.74 lpmm). One interface only.