### PR TITLE
[06x] Desktop/PresetManager: Fix '.json' overreplacement

### DIFF
--- a/OpenTabletDriver.Desktop/PresetManager.cs
+++ b/OpenTabletDriver.Desktop/PresetManager.cs
@@ -34,7 +34,7 @@ namespace OpenTabletDriver.Desktop
             {
                 if (Settings.TryDeserialize(preset, out var settings))
                 {
-                    Presets.Add(new Preset(preset.Name.Replace(preset.Extension, string.Empty), settings));
+                    Presets.Add(new Preset(preset.Name.Remove(preset.Name.Length - 5), settings));
                     Log.Write("Settings", $"Loaded preset '{preset.Name}'", LogLevel.Info);
                 }
                 else


### PR DESCRIPTION
This should now support Presets with .json somewhere in the filename

Fixes #4154
Fixes #4152