### PR TITLE
[06x] CLI: Add `disabletabletfilters` and `disabletools`

### DIFF
--- a/OpenTabletDriver.Console/Program.Commands.cs
+++ b/OpenTabletDriver.Console/Program.Commands.cs
@@ -191,14 +191,16 @@ namespace OpenTabletDriver.Console
 
         private static async Task DisableTabletFilters(string tablet, params string[] filters)
         {
-            await ModifyProfile(tablet, s => {
+            await ModifyProfile(tablet, s =>
+            {
                 DisableAllInPluginStoreSettingsCollectionByPaths(s.Filters, filters);
             });
         }
 
         private static async Task DisableTools(string[] tools)
         {
-            await ModifySettings(s => {
+            await ModifySettings(s =>
+            {
                 DisableAllInPluginStoreSettingsCollectionByPaths(s.Tools, tools);
             });
         }

--- a/OpenTabletDriver.Console/Program.Commands.cs
+++ b/OpenTabletDriver.Console/Program.Commands.cs
@@ -189,6 +189,20 @@ namespace OpenTabletDriver.Console
             await ModifySettings(s => AppendPluginStoreSettingsCollectionByPaths<ITool>(s.Tools, tools));
         }
 
+        private static async Task DisableTabletFilters(string tablet, params string[] filters)
+        {
+            await ModifyProfile(tablet, s => {
+                DisableAllInPluginStoreSettingsCollectionByPaths(s.Filters, filters);
+            });
+        }
+
+        private static async Task DisableTools(string[] tools)
+        {
+            await ModifySettings(s => {
+                DisableAllInPluginStoreSettingsCollectionByPaths(s.Tools, tools);
+            });
+        }
+
         #endregion
 
         #region Request Settings

--- a/OpenTabletDriver.Console/Program.Misc.cs
+++ b/OpenTabletDriver.Console/Program.Misc.cs
@@ -100,5 +100,19 @@ namespace OpenTabletDriver.Console
                 }
             }
         }
+
+        static void DisableAllInPluginStoreSettingsCollectionByPaths(PluginSettingStoreCollection pssc, params string[] paths)
+        {
+            foreach (string path in paths)
+            {
+                var plugins = pssc.Where(x => x.Path == path).ToArray();
+
+                if (plugins.Length == 0)
+                    Out.WriteLineAsync("No plugins found matching path");
+
+                foreach (var plugin in plugins)
+                    plugin.Enable = false;
+            }
+        }
     }
 }

--- a/OpenTabletDriver.Console/Program.cs
+++ b/OpenTabletDriver.Console/Program.cs
@@ -71,7 +71,9 @@ namespace OpenTabletDriver.Console
         {
             CreateCommand<string, string>(SetOutputMode, "Sets the output mode"),
             CreateCommand<string, string[]>(EnableTabletFilters, "Enables the specified filters on the specified tablet"),
+            CreateCommand<string, string[]>(DisableTabletFilters, "Disables the specified filters on the specified tablet"),
             CreateCommand<string[]>(EnableTools, "Enables the specified tools"),
+            CreateCommand<string[]>(DisableTools, "Disables the specified tools"),
             CreateCommand<string, float, float, float, float>(SetDisplayArea, "Sets the display area"),
             CreateCommand<string, float, float, float, float, float>(SetTabletArea, "Sets the tablet area"),
             CreateCommand<string, float, float, float>(SetSensitivity, "Sets the relative sensitivity"),
@@ -81,7 +83,7 @@ namespace OpenTabletDriver.Console
             CreateCommand<string, int>(SetResetTime, "Sets the reset time in milliseconds"),
             CreateCommand<string, bool>(SetEnableClipping, "Sets whether inputs should be limited to the specified areas"),
             CreateCommand<string, bool>(SetEnableAreaLimiting, "Sets whether inputs outside of the tablet area should be ignored"),
-            CreateCommand<string, bool>(SetLockAspectRatio, "Sets whether to lock tablet width/height to display width/height ratio")
+            CreateCommand<string, bool>(SetLockAspectRatio, "Sets whether to lock tablet width/height to display width/height ratio"),
         };
 
         private static readonly IEnumerable<Command> RequestCommands = new Command[]


### PR DESCRIPTION
Fixes #4159

Uses same syntax as `setfilters` (`enabletabletfilters` in #4171)