### PR TITLE
[Avalonia] workflows/release: Don't run Nuget release on workflow dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   nuget:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     name: NuGet Deploy Release (Ubuntu Host)
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes #4180

(cherry picked from commit 7f5301462c09d0ced6c0864d59f68946d261ee63 from #4179)