### PR TITLE
[0.6.x] Report potential driver detection false positives and show process name and filename in log

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -79,13 +79,8 @@ namespace OpenTabletDriver.Daemon
                 if (driverInfo.Status.HasFlag(DriverStatus.Uncertain))
                     message.Append(" It may be a false positive.");
 
-                var processStrings = new List<string>();
-                foreach (var driverProcess in driverInfo.Processes)
-                {
-                    processStrings.Add(driverProcess.ProcessName);
-                }
-
-                message.Append($" Processes found: " + string.Join(", ", processStrings) + ".");
+                var processStrings = safeGetProcessDetails(driverInfo.Processes);
+                message.Append($" Processes found: [" + string.Join(", ", processStrings) + "].");
 
                 if (os != null)
                     message.Append($" If any problems arise, visit '{wikiUrl}'.");
@@ -104,6 +99,36 @@ namespace OpenTabletDriver.Daemon
                 await DetectTablets();
                 await SetSettings(Settings);
             };
+        }
+
+        private List<string> safeGetProcessDetails(Process[] processes)
+        {
+            var processDetails = new List<string>();
+
+            foreach (var driverProcess in processes)
+            {
+                var details = "";
+                try
+                {
+                    details += driverProcess.ProcessName;
+                }
+                catch
+                {
+                    details += "Failed to get ProcessName";
+                }
+
+                try
+                {
+                    details += ": " + driverProcess.MainModule?.FileName;
+                }
+                catch
+                {
+                    details += ": Failed to get FileName";
+                }
+                processDetails.Add(details);
+            }
+
+            return processDetails;
         }
 
         public event EventHandler<LogMessage>? Message;

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -76,6 +76,8 @@ namespace OpenTabletDriver.Daemon
                     message.Append(" It will block detection of tablets.");
                 if (driverInfo.Status.HasFlag(DriverStatus.Flaky))
                     message.Append(" It will cause flaky support to tablets.");
+                if (driverInfo.Status.HasFlag(DriverStatus.Uncertain))
+                    message.Append(" It may be a false positive.");
                 if (os != null)
                     message.Append($" If any problems arise, visit '{wikiUrl}'.");
 

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -101,10 +101,8 @@ namespace OpenTabletDriver.Daemon
             };
         }
 
-        private List<string> safeGetProcessDetails(Process[] processes)
+        private IEnumerable<string> safeGetProcessDetails(Process[] processes)
         {
-            var processDetails = new List<string>();
-
             foreach (var driverProcess in processes)
             {
                 var details = "";
@@ -125,10 +123,9 @@ namespace OpenTabletDriver.Daemon
                 {
                     details += ": Failed to get FileName";
                 }
-                processDetails.Add(details);
+                yield return details;
             }
 
-            return processDetails;
         }
 
         public event EventHandler<LogMessage>? Message;

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -125,7 +125,6 @@ namespace OpenTabletDriver.Daemon
                 }
                 yield return details;
             }
-
         }
 
         public event EventHandler<LogMessage>? Message;

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -78,6 +78,15 @@ namespace OpenTabletDriver.Daemon
                     message.Append(" It will cause flaky support to tablets.");
                 if (driverInfo.Status.HasFlag(DriverStatus.Uncertain))
                     message.Append(" It may be a false positive.");
+
+                var processStrings = new List<string>();
+                foreach (var driverProcess in driverInfo.Processes)
+                {
+                    processStrings.Add(driverProcess.ProcessName);
+                }
+
+                message.Append($" Processes found: " + string.Join(", ", processStrings) + ".");
+
                 if (os != null)
                     message.Append($" If any problems arise, visit '{wikiUrl}'.");
 

--- a/OpenTabletDriver/SystemDrivers/DriverStatus.cs
+++ b/OpenTabletDriver/SystemDrivers/DriverStatus.cs
@@ -19,5 +19,10 @@ namespace OpenTabletDriver.SystemDrivers
         /// The existence of this driver causes OpenTabletDriver to have flaky support to the device.
         /// </summary>
         Flaky = 1 << 2,
+
+        /// <summary>
+        /// A driver may be detected but it could be a false positive.
+        /// </summary>
+        Uncertain = 1 << 3,
     }
 }

--- a/OpenTabletDriver/SystemDrivers/Providers/XPPenDriverInfoProvider.cs
+++ b/OpenTabletDriver/SystemDrivers/Providers/XPPenDriverInfoProvider.cs
@@ -38,15 +38,15 @@ namespace OpenTabletDriver.SystemDrivers.InfoProviders
                 .Where(p => WinProcessNames.Concat(Heuristics)
                 .Any(n => Regex.IsMatch(p.ProcessName, n, RegexOptions.IgnoreCase)));
 
-            var falsePositive = processes.Any(p => Exclusions.Any(ex => Regex.IsMatch(p.ProcessName, ex)));
+            var falsePositive = processes.Any(p => Exclusions.Any(ex => Regex.IsMatch(p.ProcessName, ex))) ? DriverStatus.Uncertain : 0;
 
-            if (processes.Any() && !falsePositive)
+            if (processes.Any())
             {
                 return new DriverInfo
                 {
                     Name = FriendlyName,
                     Processes = processes.ToArray(),
-                    Status = DriverStatus.Active
+                    Status = DriverStatus.Active | falsePositive
                 };
             }
             else


### PR DESCRIPTION
Example logs:
```
[Detect:Warning]	'XP-Pen' driver is detected. Processes found: [XPPenTablet: C:\Program Files\XPPen\XPPenTablet.exe]. If any problems arise, visit 'https://opentabletdriver.net/Wiki/FAQ/Windows'.
```
```
[Detect:Warning]        'XP-Pen' driver is detected. It may be a false positive. Processes found: [XPPenTablet: C:\Program Files\XPPen\XPPenTablet.exe, OpenTabletDriver.Daemon: C:\Users\testuser\Desktop\OpenTabletDriver\bin\OpenTabletDriver.Daemon.exe]. If any problems arise, visit 'https://opentabletdriver.net/Wiki/FAQ/Windows'.
```

Both `ProcessName` and `MainModule?.FileName` can error on accessing them. Although `ProcessName` erroring seems unlikely. `MainModule?.FileName` includes the full absolute filepath for the running process not just the filename.