### PR TITLE
[06x] github/pr-labeler: Don't label arbitrary sh files as Linux

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -75,8 +75,9 @@ tests:
   - any-glob-to-any-file:
     - 'OpenTabletDriver.Native/Linux/**'
     - 'OpenTabletDriver.UX.Gtk/**'
+    - 'generate-rules.sh'
+    - 'update-deps.sh'
     - '**/*Linux*' # TODO: verify that this works 1/3
-    - '**/*.sh' # TODO: verify that this also affects './generate-rules.sh' etc
     - '**/*.nix'
     - '**/flake.lock'
 


### PR DESCRIPTION
Fixes #4187