### PR TITLE
[06x] github/pr-labeler: Add support for 'packaging' label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -51,12 +51,18 @@ meta:
     - any-glob-to-any-file:
       - '.github/**'
       - '*'
-      - 'eng/**'
       - 'OpenTabletDriver.Benchmarks/**'
     - all-globs-to-all-files:
       - '!.github/workflows'
       - '!README.md'
       - '!TABLETS.md'
+      - 'build.sh'
+
+packaging:
+- changed-files:
+  - any-glob-to-any-file:
+    - 'eng/**'
+    - 'build.sh'
 
 plugins:
 - changed-files:


### PR DESCRIPTION
Stops packaging changes from being labeled as `meta`. I don't think we had this label when the labeler structure was written.