### PR TITLE
[0.6.x] Replace bad subtraction with bitmask in XP-Pen offset parsers

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenPressureOffsetTiltTabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenPressureOffsetTiltTabletReport.cs
@@ -15,7 +15,7 @@ namespace OpenTabletDriver.Configurations.Parsers.XP_Pen
                 X = Unsafe.ReadUnaligned<ushort>(ref report[2]),
                 Y = Unsafe.ReadUnaligned<ushort>(ref report[4])
             };
-            Pressure = (uint)(Unsafe.ReadUnaligned<ushort>(ref report[6]) - 8192);
+            Pressure = (uint)(Unsafe.ReadUnaligned<ushort>(ref report[6]) & 0x1FFF);
             Eraser = report[1].IsBitSet(3);
 
             PenButtons = new bool[]

--- a/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenTabletPressureOffsetOverflowReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenTabletPressureOffsetOverflowReport.cs
@@ -15,7 +15,7 @@ namespace OpenTabletDriver.Configurations.Parsers.XP_Pen
                 X = Unsafe.ReadUnaligned<ushort>(ref report[2]) | report[10] << 16,
                 Y = Unsafe.ReadUnaligned<ushort>(ref report[4]) | report[11] << 16
             };
-            Pressure = (uint)(Unsafe.ReadUnaligned<ushort>(ref report[6]) - 8192);
+            Pressure = (uint)(Unsafe.ReadUnaligned<ushort>(ref report[6]) & 0x1FFF);
             Eraser = report[1].IsBitSet(3);
 
             PenButtons = new bool[]


### PR DESCRIPTION
I am hereby banning subtraction in parsers. (seriously though this is the second time this has happened and it wasn't my fault this time lol)

There are two variants of these tablets that send either "dirty" pressure bytes of "clean" pressure bytes:
`Dirty`: 0 pressure `00 20`, 8191 pressure `FF 3F`
`Clean`: 0 pressure `00 00`, 8191 pressure `FF 1F`
(note that these are unaligned, the byte order is reversed for parsing)

The lingering `00 20` causes the pressure in the dirty variant to need to be 8192 less. But doing this with subtraction causes the clean variant to underflow the uint.