### PR TITLE
Add new variant for Monoprice 10594

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Monoprice/10594.json
+++ b/OpenTabletDriver.Configurations/Configurations/Monoprice/10594.json
@@ -33,6 +33,19 @@
     {
       "VendorID": 9580,
       "ProductID": 110,
+      "InputReportLength": 16,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "DeviceStrings": {
+        "6": "^10594\\x00\\x00et\\x00$"
+      },
+      "InitializationStrings": [
+        100,
+        123
+      ]
+    },
+    {
+      "VendorID": 9580,
+      "ProductID": 110,
       "InputReportLength": 8,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
       "DeviceStrings": {


### PR DESCRIPTION
Verification: https://discord.com/channels/615607687467761684/615611007951306863/1424211292633305149
Diag: [geese diagnostics.json](https://github.com/user-attachments/files/22705123/geese.diagnostics.json)
String dump: [string dump.txt](https://github.com/user-attachments/files/22705124/string.dump.txt)

Not adding this onto the existing identifier with string check 6 since string 121 is empty on this variant. Not adding it on to string 6 and allowing string 121 to be empty on the existing identifier since that could potentially have unintended side effects.