### PR TITLE
Fix libinput eraser not setting sometimes due to not flushing and sending two conflicting tool reports

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -118,6 +118,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
 
             // unset opposite tool (in case tablet never sends us Reset/OutOfRange)
             Device.Write(EventType.EV_KEY, currentTool, 0);
+            Flush();
 
             this.isEraser = isEraser;
         }


### PR DESCRIPTION
Libinput gets angry sometimes when the pen tool is unset and the eraser tool is set in the same sync leading to some wonky behavior.