### PR TITLE
[06x] Huion Q620M: Add variant to DeviceString

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/Q620M.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Q620M.json
@@ -22,7 +22,7 @@
       "InputReportLength": 12,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
       "DeviceStrings": {
-        "201": "HUION_T18d_\\d{6}$"
+        "201": "HUION_T(222|18d)_\\d{6}$"
       },
       "InitializationStrings": [
         200


### PR DESCRIPTION
As seen in https://github.com/OpenTabletDriver/OpenTabletDriver/issues/2815#issuecomment-2250397410

Fixes #2815

Targeting milestone for 0.6.7 since it is untested.