### PR TITLE
[06x] CLI: Restrict overriding presets with `SavePreset`

### DIFF
--- a/OpenTabletDriver.Console/Program.Commands.cs
+++ b/OpenTabletDriver.Console/Program.Commands.cs
@@ -56,11 +56,7 @@ namespace OpenTabletDriver.Console
 
         private static async Task ApplyPreset(string name)
         {
-            var presetDir = new DirectoryInfo(AppInfo.Current.PresetDirectory);
-
-            if (!presetDir.Exists)
-                presetDir.Create();
-            AppInfo.PresetManager.Refresh();
+            GetAndRefreshPresetDirectory();
 
             var preset = AppInfo.PresetManager.FindPreset(name);
             await ApplySettings(preset.Settings);
@@ -68,10 +64,7 @@ namespace OpenTabletDriver.Console
 
         private static async Task SavePreset(string name)
         {
-            var presetDir = new DirectoryInfo(AppInfo.Current.PresetDirectory);
-
-            if (!presetDir.Exists)
-                presetDir.Create();
+            var presetDir = GetAndRefreshPresetDirectory();
 
             var settings = await GetSettings();
             var file = new FileInfo(Path.Combine(presetDir.FullName, name + ".json"));
@@ -83,6 +76,18 @@ namespace OpenTabletDriver.Console
                 throw new ArgumentException("Preset file name must not traverse directories");
 
             settings.Serialize(file);
+        }
+
+        private static DirectoryInfo GetAndRefreshPresetDirectory()
+        {
+            var presetDir = new DirectoryInfo(AppInfo.Current.PresetDirectory);
+
+            if (!presetDir.Exists)
+                presetDir.Create();
+
+            AppInfo.PresetManager.Refresh();
+
+            return presetDir;
         }
 
         #endregion

--- a/OpenTabletDriver.Console/Program.Commands.cs
+++ b/OpenTabletDriver.Console/Program.Commands.cs
@@ -66,7 +66,6 @@ namespace OpenTabletDriver.Console
         {
             var presetDir = GetAndRefreshPresetDirectory();
 
-            var settings = await GetSettings();
             var file = new FileInfo(Path.Combine(presetDir.FullName, name + ".json"));
 
             if (file.Exists)
@@ -77,6 +76,8 @@ namespace OpenTabletDriver.Console
 
             if (file.Directory.FullName != presetDir.FullName)
                 throw new ArgumentException("Preset file name must not traverse directories");
+
+            var settings = await GetSettings();
 
             settings.Serialize(file);
         }

--- a/OpenTabletDriver.Console/Program.Commands.cs
+++ b/OpenTabletDriver.Console/Program.Commands.cs
@@ -69,6 +69,9 @@ namespace OpenTabletDriver.Console
             var settings = await GetSettings();
             var file = new FileInfo(Path.Combine(presetDir.FullName, name + ".json"));
 
+            if (file.Exists)
+                throw new ArgumentException("Cannot override presets");
+
             if (file.Directory == null)
                 throw new NullReferenceException(nameof(file.Directory));
 


### PR DESCRIPTION
Fixes #4153

Intended preset removal is via file operations. A `DeletePreset` command may come later.

As mentioned in another CLI PR, adding optional flags to commands seems cumbersome with the current structure, otherwise I would've added a `--override` flag or similar.