### PR TITLE
[06x] CLI: Add plugin handling

### DIFF
--- a/OpenTabletDriver.Console/Program.Commands.cs
+++ b/OpenTabletDriver.Console/Program.Commands.cs
@@ -299,6 +299,18 @@ namespace OpenTabletDriver.Console
             await Driver.Instance.DetectTablets();
         }
 
+        private static async Task InstallPlugin(string filePath)
+        {
+            if (!await Driver.Instance.InstallPlugin(filePath))
+                await Out.WriteLineAsync("Unable to install plugin");
+        }
+
+        private static async Task UninstallPlugin(string folderName)
+        {
+            var context = AppInfo.PluginManager.GetLoadedPlugins().First(x => x.Directory.Name == folderName);
+            await Driver.Instance.UninstallPlugin(context.Directory.FullName);
+        }
+
         #endregion
 
         #region Debugging
@@ -339,6 +351,12 @@ namespace OpenTabletDriver.Console
             AppInfo.PresetManager.Refresh();
             foreach (var preset in AppInfo.PresetManager.GetPresets())
                 await Out.WriteLineAsync(preset.Name);
+        }
+
+        private static async Task ListPlugins()
+        {
+            foreach (var dir in AppInfo.PluginManager.PluginDirectory.EnumerateDirectories())
+                await Out.WriteLineAsync(dir.Name);
         }
 
         #endregion

--- a/OpenTabletDriver.Console/Program.cs
+++ b/OpenTabletDriver.Console/Program.cs
@@ -59,7 +59,9 @@ namespace OpenTabletDriver.Console
 
         private static readonly IEnumerable<Command> ActionCommands = new Command[]
         {
-            CreateCommand(Detect, "Detects tablets")
+            CreateCommand(Detect, "Detects tablets"),
+            CreateCommand<string>(InstallPlugin, "Install plugin from specified file path"),
+            CreateCommand<string>(UninstallPlugin, "Install plugin with specified folder name"),
         };
 
         private static readonly IEnumerable<Command> DebugCommands = new Command[]
@@ -96,7 +98,8 @@ namespace OpenTabletDriver.Console
             CreateCommand<string>(GetBindings, "Gets all current bindings"),
             CreateCommand<string>(GetMiscSettings, "Gets other uncategorized settings"),
             CreateCommand<string>(GetFilters, "Gets the currently enabled filters"),
-            CreateCommand(GetTools, "Gets the currently enabled tools")
+            CreateCommand(GetTools, "Gets the currently enabled tools"),
+            CreateCommand(ListPlugins, $"Gets the folder names of installed plugins for use in {nameof(UninstallPlugin)}")
         };
 
         private static readonly IEnumerable<Command> UpdateCommands = new Command[]

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -174,6 +174,7 @@ namespace OpenTabletDriver.Daemon
             return Task.FromResult(AppInfo.PluginManager.InstallPlugin(filePath));
         }
 
+        // FIXME: needs API bump: IDriverDaemon expects friendlyName but this implementation takes a full path
         public Task<bool> UninstallPlugin(string directoryPath)
         {
             var plugins = AppInfo.PluginManager.GetLoadedPlugins();


### PR DESCRIPTION
Adds the following:

- `InstallPlugin` takes a fully qualified path
- `UninstallPlugin` takes a Plugin directory name
- `ListPlugins` lists the plugin directories

Fixes #4209 but does not implement the drag'n'drop functionality (yet)