### PR TITLE
Add bottom padding on filters & tools list

### DIFF
--- a/OpenTabletDriver.UX/Controls/PluginSettingStoreCollectionEditor.cs
+++ b/OpenTabletDriver.UX/Controls/PluginSettingStoreCollectionEditor.cs
@@ -81,10 +81,10 @@ namespace OpenTabletDriver.UX.Controls
         private void RefreshContent()
         {
             var types = AppInfo.PluginManager.GetChildTypes<TSource>();
-            var sortedTypes = new ReadOnlyCollection<TypeInfo>([.. types.OrderBy(t => t.GetFriendlyName())]);
+            var sortedTypes = new ReadOnlyCollection<TypeInfo>([.. types.OrderBy(t => t.GetFriendlyName()), null]);
 
             var oldSelected = sourceSelector.SelectedItem;
-            var newSelected = sortedTypes.FirstOrDefault(t => t.FullName == oldSelected?.FullName);
+            var newSelected = sortedTypes.FirstOrDefault(t => t?.FullName == oldSelected?.FullName);
 
             // Update DataStore to new types, this refreshes the editor.
             sourceSelector.SelectedItem = null;

--- a/OpenTabletDriver.UX/Controls/PluginSettingStoreCollectionEditor.cs
+++ b/OpenTabletDriver.UX/Controls/PluginSettingStoreCollectionEditor.cs
@@ -81,14 +81,20 @@ namespace OpenTabletDriver.UX.Controls
         private void RefreshContent()
         {
             var types = AppInfo.PluginManager.GetChildTypes<TSource>();
-            var sortedTypes = new ReadOnlyCollection<TypeInfo>([.. types.OrderBy(t => t.GetFriendlyName()), null]);
+            var sortedTypes = types.OrderBy(t => t.GetFriendlyName());
 
+            // On Unix based platforms, the last plugin in the list may be hidden behind an horizontal scrollbar
+            // We add another elements as padding to avoid this.
+            var finalTypes = OperatingSystem.IsWindows() ? new ReadOnlyCollection<TypeInfo>([.. sortedTypes]) :
+                                                           new ReadOnlyCollection<TypeInfo>([.. sortedTypes, null]);
+
+            // Select the last selected plugin, or none if last selected was removed or none were selected.
             var oldSelected = sourceSelector.SelectedItem;
-            var newSelected = sortedTypes.FirstOrDefault(t => t?.FullName == oldSelected?.FullName);
+            var newSelected = finalTypes.FirstOrDefault(t => t?.FullName == oldSelected?.FullName) ?? finalTypes.FirstOrDefault();
 
             // Update DataStore to new types, this refreshes the editor.
             sourceSelector.SelectedItem = null;
-            sourceSelector.DataStore = sortedTypes;
+            sourceSelector.DataStore = finalTypes;
             sourceSelector.SelectedItem = newSelected;
 
             this.Content = types.Any() ? mainContent : placeholder;


### PR DESCRIPTION
From suggestion on discord : https://discord.com/channels/615607687467761684/723399565780189234/1436035336819052617

> Add an empty box below the last item in the plugins list, so that, if you scroll fully downwards, you have no trouble clicking on the last item

This is for unix-based platforms only as their users are the only ones known to be affected by the issue.

Before : 

<img width="323" height="792" alt="image" src="https://github.com/user-attachments/assets/38da5f64-2965-4542-b962-b679113ecff2" />

After : 

<img width="337" height="792" alt="image" src="https://github.com/user-attachments/assets/9853d497-3c71-451a-8140-16d310e4061a" />