### PR TITLE
Touch support

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-451.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-451.json
@@ -21,6 +21,12 @@
       "Buttons": {
         "ButtonCount": 1
       }
+    },
+    "Touch": {
+      "Width": 157.48,
+      "Height": 98.425,
+      "MaxX": 4095,
+      "MaxY": 4095
     }
   },
   "DigitizerIdentifiers": [

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-651.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-651.json
@@ -21,6 +21,12 @@
       "Buttons": {
         "ButtonCount": 1
       }
+    },
+    "Touch": {
+      "Width": 223.52,
+      "Height": 139.7,
+      "MaxX": 4095,
+      "MaxY": 4095
     }
   },
   "DigitizerIdentifiers": [

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-851.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-851.json
@@ -14,6 +14,12 @@
     "AuxiliaryButtons": {
       "ButtonCount": 8
     },
+    "Touch": {
+      "Width": 325.12,
+      "Height": 203.2,
+      "MaxX": 4095,
+      "MaxY": 4095
+    },
     "Wheel": {
       "StepCount": 71,
       "IsRelative": false,

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-851.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-851.json
@@ -14,12 +14,6 @@
     "AuxiliaryButtons": {
       "ButtonCount": 8
     },
-    "Touch": {
-      "Width": 325.12,
-      "Height": 203.2,
-      "MaxX": 4095,
-      "MaxY": 4095
-    },
     "Wheel": {
       "StepCount": 71,
       "IsRelative": false,
@@ -27,6 +21,12 @@
       "Buttons": {
         "ButtonCount": 1
       }
+    },
+    "Touch": {
+      "Width": 325.12,
+      "Height": 203.2,
+      "MaxX": 4095,
+      "MaxY": 4095
     }
   },
   "DigitizerIdentifiers": [

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/WacomTouchReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/WacomTouchReport.cs
@@ -73,6 +73,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom
         public byte[] Raw { set; get; }
         public bool[] AuxButtons { set; get; }
         public TouchPoint[] Touches { set; get; }
-        public bool ShouldSerializeTouches() => true;
+        // can this be deleted?
+        // public bool ShouldSerializeTouches() => true;
     }
 }

--- a/OpenTabletDriver.Desktop/Interop/DesktopInterop.cs
+++ b/OpenTabletDriver.Desktop/Interop/DesktopInterop.cs
@@ -5,6 +5,7 @@ using OpenTabletDriver.Desktop.Interop.Display;
 using OpenTabletDriver.Desktop.Interop.Input.Absolute;
 using OpenTabletDriver.Desktop.Interop.Input.Keyboard;
 using OpenTabletDriver.Desktop.Interop.Input.Relative;
+using OpenTabletDriver.Desktop.Interop.Input.Touch;
 using OpenTabletDriver.Desktop.Interop.Timer;
 using OpenTabletDriver.Desktop.Updater;
 using OpenTabletDriver.Interop;
@@ -99,6 +100,12 @@ namespace OpenTabletDriver.Desktop.Interop
         public static IPressureHandler VirtualTablet => CurrentPlatform switch
         {
             PluginPlatform.Linux => virtualTablet ??= new EvdevVirtualTablet(),
+            _ => null
+        };
+
+        public static ITouchPointer TouchPointer => CurrentPlatform switch
+        {
+            PluginPlatform.Linux => new EvdevTouchDevice(),
             _ => null
         };
 

--- a/OpenTabletDriver.Desktop/Interop/Input/Touch/EvdevTouchDevice.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Touch/EvdevTouchDevice.cs
@@ -1,0 +1,162 @@
+using System;
+using OpenTabletDriver.Native.Linux;
+using OpenTabletDriver.Native.Linux.Evdev;
+using OpenTabletDriver.Native.Linux.Evdev.Structs;
+using OpenTabletDriver.Plugin;
+using OpenTabletDriver.Plugin.Platform.Pointer;
+using OpenTabletDriver.Plugin.Tablet.Touch;
+
+namespace OpenTabletDriver.Desktop.Interop.Input.Touch
+{
+    public class EvdevTouchDevice : ITouchPointer, ISynchronousPointer, IDisposable
+    {
+        // a lot of implementation details gathered from:
+        // https://www.kernel.org/doc/html/latest/input/multi-touch-protocol.html
+        //
+        // Unsupported until later, as it needs further additions to the OpenTabletDriver core stack:
+        // - ABS_MT_TOUCH_MAJOR
+        // - ABS_MT_TOUCH_MINOR
+        // - ABS_MT_PRESSURE
+        //
+        // Unsupported in OpenTabletDriver core and not yet seen in the wild:
+        // - ABS_MT_WIDTH_MAJOR
+        // - ABS_MT_WIDTH_MINOR
+        // - ABS_MT_DISTANCE
+        // - ABS_MT_ORIENTATION (value is signed quarter rotation of a revolution around the touch center)
+        //
+        // some notes on wacom driver behavior:
+        // - first finger always updates ABS_X/ABS_Y
+        // - ABS_MT_TRACKING_ID corresponds to a unique finger position that increments monotonically for every new finger
+        //   - this must be precluded by an ABS_MT_SLOT event to indicate the slot being modified
+        // - sends ABS_MT_TRACKING_ID -1 on last finger out and sets tools (TOUCH + TOOL_FINGER) to 0
+        // - incrementing finger counts releases the last tool type specified
+
+        public const int DeviceDimension = ushort.MaxValue;
+
+        public static EventCode? FingerCountToTool(int fingerCount) => fingerCount switch
+        {
+            0 => null,
+            1 => EventCode.BTN_TOOL_FINGER,
+            2 => EventCode.BTN_TOOL_DOUBLETAP,
+            3 => EventCode.BTN_TOOL_TRIPLETAP,
+            4 => EventCode.BTN_TOOL_QUADTAP,
+            < 32 and >= 5 => EventCode.BTN_TOOL_QUINTTAP, // cap at 32 in case things go weird
+            _ => throw new ArgumentOutOfRangeException(nameof(fingerCount), fingerCount, "An unexpected amount of fingers was requested") // overly failsafe
+        };
+
+        private EventCode? _lastToolSent = null;
+
+        private EvdevDevice Device { set; get; }
+
+        public unsafe EvdevTouchDevice()
+        {
+            Device = new EvdevDevice("OpenTabletDriver Virtual Touch");
+
+            // INPUT_PROP_DIRECT intentionally not enabled as docs says that touchpads shouldn't use this
+
+            // TODO: may not need a pointer if used tablet device is a touch screen
+            //   Currently not possible due to TabletReference not being available from here, since we're a singleton
+            //   See https://github.com/OpenTabletDriver/OpenTabletDriver/issues/4036
+            Device.EnableProperty(InputProperty.INPUT_PROP_POINTER);
+
+            Device.EnableType(EventType.EV_ABS);
+
+            var xAbs = new input_absinfo
+            {
+                maximum = DeviceDimension,
+                resolution = 1000
+            };
+            input_absinfo* xPtr = &xAbs;
+            Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_X, (IntPtr)xPtr);
+
+            var yAbs = new input_absinfo
+            {
+                maximum = DeviceDimension,
+                resolution = 1000
+            };
+            input_absinfo* yPtr = &yAbs;
+            Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_Y, (IntPtr)yPtr);
+
+            Device.EnableTypeCodes(
+                EventType.EV_KEY,
+                EventCode.BTN_TOUCH,
+                EventCode.BTN_TOOL_FINGER
+                // TODO: when multitouch gets ready
+                //EventCode.BTN_TOOL_DOUBLETAP,
+                //EventCode.BTN_TOOL_TRIPLETAP,
+                //EventCode.BTN_TOOL_QUADTAP,
+                //EventCode.BTN_TOOL_QUINTTAP
+            );
+
+            var result = Device.Initialize();
+            switch (result)
+            {
+                case ERRNO.NONE:
+                    Log.Debug("Evdev", $"Successfully initialized virtual touch tablet. (code {result})");
+                    break;
+                default:
+                    Log.Write("Evdev", $"Failed to initialize virtual touch tablet. (error code {result})", LogLevel.Error);
+                    break;
+            }
+        }
+
+        public void SetPositions(ReadOnlySpan<TouchPoint> positions, int maxX, int maxY)
+        {
+            // TODO: handle remaining fingers
+            bool firstIteration = true;
+            int fingersTouched = 0;
+            int firstPositionX = 0, firstPositionY = 0;
+            foreach (var touchPoint in positions)
+            {
+                if (touchPoint == null) continue;
+                fingersTouched++;
+
+                float normalizedPosX = touchPoint.Position.X / maxX;
+                float normalizedPosY = touchPoint.Position.Y / maxY;
+
+                if (firstIteration)
+                {
+                    firstPositionX = (int)(normalizedPosX * DeviceDimension);
+                    firstPositionY = (int)(normalizedPosY * DeviceDimension);
+                    firstIteration = false;
+                }
+
+                // TODO: send ABS_MT_POSITION_X etc here
+            }
+
+            if (fingersTouched > 0)
+                Device.Write(EventType.EV_KEY, EventCode.BTN_TOUCH, 1);
+
+            // TODO: use this line instead when multi-touch is ready
+            //var toolToSend = FingerCountToTool(fingersTouched);
+            EventCode? toolToSend = fingersTouched > 0 ? EventCode.BTN_TOOL_FINGER : null;
+            if (_lastToolSent.HasValue && (!toolToSend.HasValue || _lastToolSent.Value != toolToSend.Value))
+                Device.Write(EventType.EV_KEY, _lastToolSent.Value, 0);
+            if (toolToSend.HasValue)
+                Device.Write(EventType.EV_KEY, toolToSend.Value, 1);
+            _lastToolSent = toolToSend;
+
+            if (fingersTouched > 0)
+            {
+                Device.Write(EventType.EV_ABS, EventCode.ABS_X, firstPositionX);
+                Device.Write(EventType.EV_ABS, EventCode.ABS_Y, firstPositionY);
+            }
+        }
+
+        public void Reset()
+        {
+            Device.Write(EventType.EV_KEY, EventCode.BTN_TOUCH, 0);
+            if (_lastToolSent.HasValue)
+                Device.Write(EventType.EV_KEY, _lastToolSent.Value, 0);
+            // TODO: reset multi-touch slots
+        }
+
+        public void Flush() => Device.Sync();
+
+        public void Dispose()
+        {
+            Device?.Dispose();
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/OpenTabletDriver.Desktop/OpenTabletDriver.Desktop.csproj
+++ b/OpenTabletDriver.Desktop/OpenTabletDriver.Desktop.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="NuGet Packages">
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="StreamJsonRpc" Version="2.6.121" />

--- a/OpenTabletDriver.Desktop/Profiles/Profile.cs
+++ b/OpenTabletDriver.Desktop/Profiles/Profile.cs
@@ -15,6 +15,7 @@ namespace OpenTabletDriver.Desktop.Profiles
         private AbsoluteModeSettings absoluteMode = new AbsoluteModeSettings();
         private RelativeModeSettings relativeMode = new RelativeModeSettings();
         private BindingSettings bindings = new BindingSettings();
+        private TouchSettings touchSettings = new TouchSettings();
         private PluginSettingStoreCollection filters = new PluginSettingStoreCollection();
 
         [JsonProperty("Tablet")]
@@ -59,6 +60,13 @@ namespace OpenTabletDriver.Desktop.Profiles
             get => bindings;
         }
 
+        [JsonProperty(nameof(TouchSettings))]
+        public TouchSettings TouchSettings
+        {
+            set => this.RaiseAndSetIfChanged(ref touchSettings, value);
+            get => touchSettings;
+        }
+
         private static Type DefaultOutputModeType =>
             DesktopInterop.CurrentPlatform switch
             {
@@ -74,7 +82,8 @@ namespace OpenTabletDriver.Desktop.Profiles
                 OutputMode = new PluginSettingStore(DefaultOutputModeType),
                 AbsoluteModeSettings = AbsoluteModeSettings.GetDefaults(tablet.Properties.Specifications.Digitizer),
                 RelativeModeSettings = RelativeModeSettings.GetDefaults(),
-                BindingSettings = BindingSettings.GetDefaults(tablet.Properties.Specifications)
+                BindingSettings = BindingSettings.GetDefaults(tablet.Properties.Specifications),
+                TouchSettings = new TouchSettings(),
             };
         }
     }

--- a/OpenTabletDriver.Desktop/Profiles/TouchSettings.cs
+++ b/OpenTabletDriver.Desktop/Profiles/TouchSettings.cs
@@ -1,0 +1,13 @@
+namespace OpenTabletDriver.Desktop.Profiles
+{
+    public class TouchSettings : ViewModel
+    {
+        private bool _disableTouch;
+
+        public bool DisableTouch
+        {
+            set => this.RaiseAndSetIfChanged(ref this._disableTouch, value);
+            get => this._disableTouch;
+        }
+    }
+}

--- a/OpenTabletDriver.Desktop/Reflection/DesktopPluginManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/DesktopPluginManager.cs
@@ -271,6 +271,7 @@ namespace OpenTabletDriver.Desktop.Reflection
             AddService(() => DesktopInterop.Timer);
             AddService(() => DesktopInterop.AbsolutePointer);
             AddService(() => DesktopInterop.RelativePointer);
+            AddService(() => DesktopInterop.TouchPointer);
             AddService(() => DesktopInterop.VirtualTablet);
             AddService(() => DesktopInterop.VirtualScreen);
             AddService(() => DesktopInterop.VirtualKeyboard);

--- a/OpenTabletDriver.Desktop/TouchHandler.cs
+++ b/OpenTabletDriver.Desktop/TouchHandler.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using OpenTabletDriver.Plugin;
+using OpenTabletDriver.Plugin.Attributes;
+using OpenTabletDriver.Plugin.DependencyInjection;
+using OpenTabletDriver.Plugin.Output;
+using OpenTabletDriver.Plugin.Platform.Pointer;
+using OpenTabletDriver.Plugin.Tablet;
+using OpenTabletDriver.Plugin.Tablet.Touch;
+
+namespace OpenTabletDriver.Desktop
+{
+    [PluginIgnore]
+    public class TouchHandler : IPositionedPipelineElement<IDeviceReport>
+    {
+        private readonly TabletReference _tablet;
+        private readonly ITouchPointer _pointer;
+
+        public TouchHandler(TabletReference tablet, ITouchPointer pointer)
+        {
+            _tablet = tablet;
+            _pointer = pointer;
+        }
+
+        public void Consume(IDeviceReport report)
+        {
+            if (report is ITouchReport touchReport)
+                HandleTouch(touchReport);
+            Emit?.Invoke(report);
+        }
+
+        private void HandleTouch(ITouchReport report)
+        {
+            bool shouldReset = false;
+            if (report.Touches.Any(x => x != null))
+            {
+                _pointer.SetPositions(report.Touches, (int)_tablet.Properties.Specifications.Touch!.MaxX, (int)_tablet.Properties.Specifications.Touch!.MaxY);
+            }
+            else
+                shouldReset = true;
+
+            if (_pointer is ISynchronousPointer syncPointer)
+            {
+                syncPointer.Flush();
+                if (shouldReset)
+                    syncPointer.Reset();
+            }
+        }
+
+        public event Action<IDeviceReport> Emit;
+        public PipelinePosition Position => PipelinePosition.PostTransform;
+    }
+}

--- a/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
@@ -1,7 +1,9 @@
-﻿using System.Numerics;
+﻿using System;
+using System.Numerics;
 using OpenTabletDriver.Plugin.Attributes;
 using OpenTabletDriver.Plugin.Platform.Pointer;
 using OpenTabletDriver.Plugin.Tablet;
+using OpenTabletDriver.Plugin.Tablet.Touch;
 
 namespace OpenTabletDriver.Plugin.Output
 {
@@ -68,13 +70,13 @@ namespace OpenTabletDriver.Plugin.Output
             {
                 var transform = CalculateTransformation(Input, Output, Tablet.Properties.Specifications.Digitizer);
 
-                var halfDisplayWidth = Output?.Width / 2 ?? 0;
-                var halfDisplayHeight = Output?.Height / 2 ?? 0;
+                var halfDisplayWidth = Output.Width / 2;
+                var halfDisplayHeight = Output.Height / 2;
 
-                var minX = Output?.Position.X - halfDisplayWidth ?? 0;
-                var maxX = Output?.Position.X + Output?.Width - halfDisplayWidth ?? 0;
-                var minY = Output?.Position.Y - halfDisplayHeight ?? 0;
-                var maxY = Output?.Position.Y + Output?.Height - halfDisplayHeight ?? 0;
+                var minX = Output.Position.X - halfDisplayWidth;
+                var maxX = Output.Position.X + Output.Width - halfDisplayWidth;
+                var minY = Output.Position.Y - halfDisplayHeight;
+                var maxY = Output.Position.Y + Output.Height - halfDisplayHeight;
 
                 this.min = new Vector2(minX, minY);
                 this.max = new Vector2(maxX, maxY);
@@ -152,6 +154,7 @@ namespace OpenTabletDriver.Plugin.Output
             // make sure to set the position last
             if (report is IAbsolutePositionReport absReport)
                 Pointer.SetPosition(absReport.Position);
+
             if (Pointer is ISynchronousPointer synchronousPointer)
             {
                 if (report is OutOfRangeReport)

--- a/OpenTabletDriver.Plugin/Platform/Pointer/ITouchPointer.cs
+++ b/OpenTabletDriver.Plugin/Platform/Pointer/ITouchPointer.cs
@@ -1,0 +1,19 @@
+using System;
+using OpenTabletDriver.Plugin.Tablet.Touch;
+
+namespace OpenTabletDriver.Plugin.Platform.Pointer
+{
+    public interface ITouchPointer
+    {
+        /// <summary>
+        /// Sets the positions of all finger(s) provided by the touch points from the parser.
+        ///
+        /// Positions must be provided in raw tablet coordinates, as the touch handler will remap itself (for now)
+        /// </summary>
+        /// <param name="positions">For each finger, an absolute position</param>
+        /// <param name="maxX">The maximum positional value able to be reported on the X axis</param>
+        /// <param name="maxY">The maximum positional value able to be reported on the Y axis</param>
+        // TODO: maxX and maxY here should instead come from a tablet reference attached to the output mode (currently not possible as of 0.6.6.2)
+        void SetPositions(ReadOnlySpan<TouchPoint> positions, int maxX, int maxY);
+    }
+}


### PR DESCRIPTION
Works on Linux and only 1 finger is tracked

Currently replicates Wacom behavior, which means that only relative mode touch is supported. Adding absolute mode (fixing #1664) is likely very easy, just tell uinput that the device is a direct device. However, requesting this behavior as the user seems difficult.

Before undraft:

- [ ] Add multitouch
- [ ] Split into meaningful commits
- [ ] Double check all changes