### PR TITLE
Update to .NET 10.0

### DIFF
--- a/.github/actions/build-bash/action.yml
+++ b/.github/actions/build-bash/action.yml
@@ -13,12 +13,12 @@ runs:
     - name: Install required packages for Debian
       if: inputs.package-name == 'Debian'
       shell: bash
-      run: sudo apt update && sudo apt install -y debhelper dotnet-sdk-8.0 build-essential
+      run: sudo apt update && sudo apt install -y debhelper dotnet-sdk-10.0 build-essential
 
     - name: Install required packages for RedHat/Fedora
       if: inputs.package-name == 'RedHat'
       shell: bash
-      run: sudo dnf install -y rpm-build systemd-rpm-macros libicu openssl-libs zlib krb5-libs dotnet-sdk-8.0 tree jq
+      run: sudo dnf install -y rpm-build systemd-rpm-macros libicu openssl-libs zlib krb5-libs dotnet-sdk-10.0 tree jq
 
     # re-checkout repository prior to build to ensure git root is initialized (causes OpenTabletDriver#3774 if not done)
     - uses: actions/checkout@v6

--- a/.github/actions/setup-dotnet/action.yml
+++ b/.github/actions/setup-dotnet/action.yml
@@ -3,7 +3,7 @@ description: 'Sets up .NET with the preferred OpenTabletDriver defaults'
 inputs:
   dotnet-version:
     description: "The .NET version to use. See actions/setup-dotnet"
-    default: '8.0'
+    default: '10.0'
     required: false
     type: string
 runs:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,8 +6,8 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "Build Daemon",
-            "cwd": "${workspaceFolder}/OpenTabletDriver.Daemon/bin/Debug/net8.0",
-            "program": "${workspaceFolder}/OpenTabletDriver.Daemon/bin/Debug/net8.0/OpenTabletDriver.Daemon.dll",
+            "cwd": "${workspaceFolder}/OpenTabletDriver.Daemon/bin/Debug/net10.0",
+            "program": "${workspaceFolder}/OpenTabletDriver.Daemon/bin/Debug/net10.0/OpenTabletDriver.Daemon.dll",
             "args": [
               "--appdata",
               "${workspaceFolder}/bin/userdata"
@@ -25,16 +25,16 @@
             "console": "internalConsole",
             "stopAtEntry": false,
             "windows": {
-                "cwd": "${workspaceFolder}/OpenTabletDriver.UX.Wpf/bin/Debug/net8.0-windows",
-                "program": "${workspaceFolder}/OpenTabletDriver.UX.Wpf/bin/Debug/net8.0-windows/OpenTabletDriver.UX.Wpf.dll",
+                "cwd": "${workspaceFolder}/OpenTabletDriver.UX.Wpf/bin/Debug/net10.0-windows",
+                "program": "${workspaceFolder}/OpenTabletDriver.UX.Wpf/bin/Debug/net10.0-windows/OpenTabletDriver.UX.Wpf.dll",
             },
             "linux": {
-                "cwd": "${workspaceFolder}/OpenTabletDriver.UX.Gtk/bin/Debug/net8.0/",
-                "program": "${workspaceFolder}/OpenTabletDriver.UX.Gtk/bin/Debug/net8.0/OpenTabletDriver.UX.Gtk.dll",
+                "cwd": "${workspaceFolder}/OpenTabletDriver.UX.Gtk/bin/Debug/net10.0/",
+                "program": "${workspaceFolder}/OpenTabletDriver.UX.Gtk/bin/Debug/net10.0/OpenTabletDriver.UX.Gtk.dll",
             },
             "osx": {
-                "cwd": "${workspaceFolder}/OpenTabletDriver.UX.MacOS/bin/Debug/net8.0/OpenTabletDriver.UX.MacOS.app/Contents/MacOS/",
-                "program": "${workspaceFolder}/OpenTabletDriver.UX.MacOS/bin/Debug/net8.0/OpenTabletDriver.UX.MacOS.app/Contents/MacOS/OpenTabletDriver.UX.MacOS.dll",
+                "cwd": "${workspaceFolder}/OpenTabletDriver.UX.MacOS/bin/Debug/net10.0/OpenTabletDriver.UX.MacOS.app/Contents/MacOS/",
+                "program": "${workspaceFolder}/OpenTabletDriver.UX.MacOS/bin/Debug/net10.0/OpenTabletDriver.UX.MacOS.app/Contents/MacOS/OpenTabletDriver.UX.MacOS.dll",
             }
         },
         {

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionBase>0.6.7</VersionBase>
-    <FrameworkBase>net8.0</FrameworkBase>
+    <FrameworkBase>net10.0</FrameworkBase>
     <VersionPrefix>$(VersionBase)</VersionPrefix>
     <Version Condition="$(VersionSuffix.StartsWith('+'))">$(VersionPrefix)$(VersionSuffix)</Version>
     <Version Condition="$(VersionSuffix.StartsWith('-'))">$(VersionPrefix)$(VersionSuffix)</Version>

--- a/eng/bash/lib.sh
+++ b/eng/bash/lib.sh
@@ -93,7 +93,7 @@ fi
 
 ### Build Requirements
 
-DOTNET_VERSION="8.0"
+DOTNET_VERSION="10.0"
 
 # could do away with declare -g, but did it anyway for all of them for consistency
 # with NET_RUNTIME (a global variable without initial value in lib.sh)

--- a/eng/windows/package.ps1
+++ b/eng/windows/package.ps1
@@ -1,7 +1,7 @@
 param (
     $output = "dist",
     $config = "Release",
-    $framework = "net8.0",
+    $framework = "net10.0",
     $netRuntime = "win-x64",
     $isRelease = $true,
     $isPackage = $true,

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.0",
+    "rollForward": "latestMinor",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
Like #3368 but for .NET 10.0

Also adds a `global.json` to properly define our `rollForward` approach. This should make building on CI more predictable in case actions change (or we move provider). A bit overly defensive, but it seems recommended that a `global.json` file is used when CI is involved with the codebase according to its page: https://learn.microsoft.com/en-us/dotnet/core/tools/global-json

Targets a later release while any potential upstream bugs are ironed out, and users can use this as a patch if they need (or want to test) 10.0 before we start supporting it.

My testing has been "It builds and the daemon indeed moves my cursor", so YMMV