### PR TITLE
Add support for UGEE UE12

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/UGEE/UE12.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/UE12.json
@@ -1,0 +1,30 @@
+{
+  "Name": "UGEE UE12",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 256.32,
+      "Height": 144.18,
+      "MaxX": 32767,
+      "MaxY": 32767
+    },
+    "Pen": {
+      "MaxPressure": 16383,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 8
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 10429,
+      "ProductID": 10506,
+      "InputReportLength": 10,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
+      "OutputInitReport": ["ArAE"]
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/UE12.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/UE12.json
@@ -4,8 +4,8 @@
     "Digitizer": {
       "Width": 256.32,
       "Height": 144.18,
-      "MaxX": 32767,
-      "MaxY": 32767
+      "MaxX": 52644,
+      "MaxY": 29611
     },
     "Pen": {
       "MaxPressure": 16383,
@@ -19,7 +19,8 @@
     {
       "VendorID": 10429,
       "ProductID": 10506,
-      "InputReportLength": 10,
+      "InputReportLength": 12,
+      "OutputReportLength": 20,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
       "OutputInitReport": ["ArAE"]
     }

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/UE12.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/UE12.json
@@ -2,8 +2,8 @@
   "Name": "UGEE UE12",
   "Specifications": {
     "Digitizer": {
-      "Width": 256.32,
-      "Height": 144.18,
+      "Width": 263.22,
+      "Height": 148.055,
       "MaxX": 52644,
       "MaxY": 29611
     },

--- a/OpenTabletDriver.Configurations/Configurations/UGEE/UE12.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/UE12.json
@@ -22,7 +22,9 @@
       "InputReportLength": 12,
       "OutputReportLength": 20,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "OutputInitReport": ["ArAE"]
+      "OutputInitReport": [
+        "ArAE"
+      ]
     }
   ],
   "Attributes": {

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -267,6 +267,7 @@
 | Parblo Intangbo M                  |  Missing Features | Wheel is not yet supported.
 | Parblo Intangbo S                  |  Missing Features | Wheel is not yet supported.
 | UGEE M908                          |  Missing Features | Wheel is not yet supported.
+| UGEE UE12                          |  Missing Features | Tablet buttons are not customizable.
 | UGEE UE16                          |  Missing Features | Wheel is not yet supported.
 | VEIKK A15 Pro                      |  Missing Features | Wheel is not yet supported.
 | VEIKK A30                          |  Missing Features | Touchpad is not yet supported.

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -78,6 +78,7 @@
 | UGEE S1060                         |     Supported     |
 | UGEE U1200                         |     Supported     |
 | UGEE U1600                         |     Supported     |
+| UGEE UE12                          |     Supported     |
 | VEIKK A15                          |     Supported     |
 | VEIKK A15 V2                       |     Supported     |
 | VEIKK S640                         |     Supported     |
@@ -267,7 +268,6 @@
 | Parblo Intangbo M                  |  Missing Features | Wheel is not yet supported.
 | Parblo Intangbo S                  |  Missing Features | Wheel is not yet supported.
 | UGEE M908                          |  Missing Features | Wheel is not yet supported.
-| UGEE UE12                          |  Missing Features | Tablet buttons are not customizable.
 | UGEE UE16                          |  Missing Features | Wheel is not yet supported.
 | VEIKK A15 Pro                      |  Missing Features | Wheel is not yet supported.
 | VEIKK A30                          |  Missing Features | Touchpad is not yet supported.


### PR DESCRIPTION
- Verification: locally on my machine. More information could be provided if devs would like to check further. 
- Diagnosis: [diag-ugee-ue12.json](https://github.com/user-attachments/files/24139086/diag-ugee-ue12.json)
- Stylus only
- It seems that the buttons on the tablet are implemented as HID keyboard. Here's the output of `hid-recorder /dev/hidraw2`: [tablet-keys.txt](https://github.com/user-attachments/files/24139097/tablet-keys.txt). The proprietary driver may configure keys for different use with another usb endpoint. Here's the output of `hid-decode /dev/hidraw5`: [vendor.txt](https://github.com/user-attachments/files/24139107/vendor.txt)

<img width="1920" height="1080" alt="working-with-xournalpp" src="https://github.com/user-attachments/assets/02bb7e50-7bba-4ca2-b015-c3962631b921" />
