### PR TITLE
Add support for XP-Pen Artist 12 3rd Generation

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12 (3rd Gen).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12 (3rd Gen).json
@@ -1,0 +1,31 @@
+{
+  "Name": "XP-Pen Artist 12 (3rd Gen)",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 264.00,
+      "Height": 149.00,
+      "MaxX": 52638,
+      "MaxY": 29616
+    },
+    "Pen": {
+      "MaxPressure": 16384,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 8
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 10429,
+      "ProductID": 2429,
+      "InputReportLength": 12,
+      "OutputReportLength": 33,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenOffsetPressureReportParser",
+      "OutputInitReport": ["ArAE"]
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12 (3rd Gen).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12 (3rd Gen).json
@@ -4,8 +4,8 @@
     "Digitizer": {
       "Width": 264.00,
       "Height": 149.00,
-      "MaxX": 52638,
-      "MaxY": 29616
+      "MaxX": 52694,
+      "MaxY": 29697
     },
     "Pen": {
       "MaxPressure": 16383,
@@ -27,9 +27,9 @@
     {
       "VendorID": 10429,
       "ProductID": 2429,
-      "InputReportLength": 13,
-      "OutputReportLength": 9,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenOffsetPressureReportParser",
+      "InputReportLength": 14,
+      "OutputReportLength": 14,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenGen2ReportParser",
       "OutputInitReport": ["ArAE"]
     }
   ],

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12 (3rd Gen).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12 (3rd Gen).json
@@ -8,7 +8,7 @@
       "MaxY": 29616
     },
     "Pen": {
-      "MaxPressure": 16384,
+      "MaxPressure": 16383,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12 (3rd Gen).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Artist 12 (3rd Gen).json
@@ -13,14 +13,22 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
+    },
+    "Wheel": {
+      "StepCount": 24,
+      "IsRelative": true,
+      "AngleOfZeroReading": 0.0,
+      "Buttons": {
+        "ButtonCount": 0
+      }
     }
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 10429,
       "ProductID": 2429,
-      "InputReportLength": 12,
-      "OutputReportLength": 33,
+      "InputReportLength": 13,
+      "OutputReportLength": 9,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenOffsetPressureReportParser",
       "OutputInitReport": ["ArAE"]
     }

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -151,7 +151,7 @@
 | XENX X1-640                        |     Supported     |
 | XP-Pen Artist 10 (2nd Gen)         |     Supported     |
 | XP-Pen Artist 12 (2nd Gen)         |     Supported     |
-| XP-Pen Artist 12 (3rd Gen)         |     Supported     |
+| XP-Pen Artist 12 (3rd Gen)         |  Missing Features | Both wheels function as a single wheel.
 | XP-Pen Artist 13 (2nd Gen)         |     Supported     |
 | XP-Pen Artist 13.3                 |     Supported     |
 | XP-Pen Artist 13.3 Pro V2          |     Supported     |

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -151,6 +151,7 @@
 | XENX X1-640                        |     Supported     |
 | XP-Pen Artist 10 (2nd Gen)         |     Supported     |
 | XP-Pen Artist 12 (2nd Gen)         |     Supported     |
+| XP-Pen Artist 12 (3rd Gen)         |     Supported     |
 | XP-Pen Artist 13 (2nd Gen)         |     Supported     |
 | XP-Pen Artist 13.3                 |     Supported     |
 | XP-Pen Artist 13.3 Pro V2          |     Supported     |


### PR DESCRIPTION
Hello!

This is a draft PR to help add support for the XP-Pen Artist 12 3rd Gen, and the format is based on the Artist 12 2nd Gen's configuration.

Some missing information:

- [ ] **Digitizer**
     - [ ]  Width (Official Specs Added)
     - [ ]  Height (Official Specs Added)
     - [ ] MaxX
     - [ ] MaxY
- [x] **Pen**
     - [x] MaxPressure (Official Added)
     - [X] ButtonCount (Official Added)
- [x] **Wheel 1**
     - [x] Step Count
     - [x] IsRelative
     - [x] Angle of Zero Reading
     - [X] Buttons
- [ ] **Wheel 2**
     - [ ] Step Count
     - [ ] IsRelative
     - [ ] Angle of Zero Reading
     - [X] Buttons
- [X] **AuxiliaryButtons**
     - [X] ButtonCount (Official Added)
- [ ] **DigitizerIdentifiers**
     - [X] VendorID (Added via lsusb)
     - [X] ProductID (Added via lsusb)
     - [x] InputReportLength
     - [x] OutputReportLength
     - [x] ReportParser
     - [x] OutputInitReport
- [x] Attributes
     - [x] libinputoverride (unsure if correct)
     
 I am unsure of the width, height, nor maxPressure being correct as the values for the 2nd generation were slightly off from their official values. Unfortunately despite having the tablet I am struggling to get anything to be read from it using OpenTabletDriver. I know there is a guide on the wiki but I don't know where I am supposed to get access to the parser and such. Apologies for the amateur PR but I hope to be able to help add support for this tablet in any way. 