### PR TITLE
Add support for BOSTO BST-Y3 pen tablet

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Bosto/BT-13HD.json
+++ b/OpenTabletDriver.Configurations/Configurations/Bosto/BT-13HD.json
@@ -1,0 +1,33 @@
+{
+  "Name": "Bosto BT-13HD",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 293.0,
+      "Height": 165.0,
+      "MaxX": 58420,
+      "MaxY": 32512
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 8
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 3793,
+      "ProductID": 30753,
+      "InputReportLength": 10,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Bosto.Bosto13HDReportParser",
+      "DeviceStrings": {
+        "3": "^A02017120201$"
+      },
+      "InitializationStrings": []
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Bosto/Bosto13HDReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Bosto/Bosto13HDReportParser.cs
@@ -1,0 +1,36 @@
+using System.Diagnostics.CodeAnalysis;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Bosto
+{
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    public class Bosto13HDReportParser : IReportParser<IDeviceReport>
+    {
+        public IDeviceReport Parse(byte[] data)
+        {
+            var reportType = data[0];
+            
+            if (reportType == 0x01)
+            {
+                var penReport = data[1];
+
+                if (penReport.IsBitSet(4))
+                {
+                    return new Bosto13HDTabletReport(data);
+                }
+                else
+                {
+                    return new OutOfRangeReport(data);
+                }
+            }
+            else if (reportType == 0x04)
+            {
+                return new BostoAuxReport(data);
+            }
+            else
+            {
+                return new DeviceReport(data);
+            }
+        }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Bosto/Bosto13HDTabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Bosto/Bosto13HDTabletReport.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Bosto
+{
+    public struct Bosto13HDTabletReport : ITabletReport, IProximityReport
+    {
+         // tablet raw limits
+        private const float MAX_X = 17920f;
+        private const float MAX_Y = 10240f;
+
+        // default calibration
+        private const float X_OFFSET = 20300f;
+        private const float Y_OFFSET = 11200f;
+
+        private const float X_STRETCH = 3.25f;
+        private const float Y_STRETCH = 3.115f;
+
+
+        // Centers
+        private const float CX = MAX_X / 2f;
+        private const float CY = MAX_Y / 2f;
+
+        public Bosto13HDTabletReport(byte[] report)
+        {
+            Raw = report;
+
+            ushort x_raw = Unsafe.ReadUnaligned<ushort>(ref report[2]);
+            ushort y_raw = Unsafe.ReadUnaligned<ushort>(ref report[4]);
+
+            Position = new Vector2
+            {
+                X = MathF.Round((x_raw - CX) * X_STRETCH + CX + X_OFFSET),
+                Y = MathF.Round((y_raw - CY) * Y_STRETCH + CY + Y_OFFSET)
+            };
+
+            Pressure = Unsafe.ReadUnaligned<ushort>(ref report[6]);
+
+            PenButtons =
+            [
+                report[1].IsBitSet(5),
+                report[1].IsBitSet(1),
+            ];
+
+            NearProximity = report[1].IsBitSet(4);
+            HoverDistance = 0;
+        }
+
+        public byte[] Raw { set; get; }
+        public Vector2 Position { set; get; }
+        public uint Pressure { set; get; }
+        public bool[] PenButtons { set; get; }
+        public bool NearProximity { set; get; }
+        public uint HoverDistance { set; get; }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Bosto/BostoAuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Bosto/BostoAuxReport.cs
@@ -1,0 +1,28 @@
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Bosto
+{
+    public struct BostoAuxReport : IAuxReport
+    {
+        public BostoAuxReport(byte[] report)
+        {
+            Raw = report;
+
+            var auxByte = report[4];
+            AuxButtons =
+            [
+                auxByte.IsBitSet(0),
+                auxByte.IsBitSet(1),
+                auxByte.IsBitSet(2),
+                auxByte.IsBitSet(3),
+                auxByte.IsBitSet(4),
+                auxByte.IsBitSet(5),
+                auxByte.IsBitSet(6),
+                auxByte.IsBitSet(7),
+            ];
+        }
+
+        public byte[] Raw { set; get; }
+        public bool[] AuxButtons { set; get; }
+    }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -4,6 +4,7 @@
 | Acepen AP1060                      |     Supported     |
 | Adesso Cybertablet K8              |     Supported     |
 | Artisul D22S                       |     Supported     |
+| Bosto BT-13HD                      |     Supported     |
 | Gaomon 1060 Pro                    |     Supported     |
 | Gaomon GM116HD                     |     Supported     |
 | Gaomon GM156HD                     |     Supported     |


### PR DESCRIPTION
On tablet rear, additional model name : BT-13HDK
Missing features: auxiliary buttons do not appear in GUI

Raw tablet data when pressing aux buttons (buttons on the left side, from top to bottom):

1 - 04 00 00 00 01 00 00 00
2 - 04 00 00 00 02 00 00 00
3 - 04 00 00 00 04 00 00 00
4 - 04 00 00 00 08 00 00 00
5 - 04 00 00 00 10 00 00 00
6 - 04 00 00 00 20 00 00 00
7 - 04 00 00 00 40 00 00 00
8 - 04 00 00 00 80 00 00 00

Discord verification: https://discord.com/channels/615607687467761684/1352379675007258696/1459266420243173506