### PR TITLE
Add support for Monoprice 21826

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Monoprice/21826.json
+++ b/OpenTabletDriver.Configurations/Configurations/Monoprice/21826.json
@@ -2,9 +2,9 @@
   "Name": "Monoprice 21826",
   "Specifications": {
     "Digitizer": {
-      "Width": 327.675,
+      "Width": 344.17,
       "Height": 193.55,
-      "MaxX": 65535,
+      "MaxX": 68834,
       "MaxY": 38710
     },
     "Pen": {
@@ -20,7 +20,7 @@
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 64,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
       "DeviceStrings": {
         "201": "OEM00_M166_\\d{6}$"
       },

--- a/OpenTabletDriver.Configurations/Configurations/Monoprice/21826.json
+++ b/OpenTabletDriver.Configurations/Configurations/Monoprice/21826.json
@@ -1,0 +1,36 @@
+{
+  "Name": "Monoprice 21826",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 327.675,
+      "Height": 193.55,
+      "MaxX": 65535,
+      "MaxY": 38710
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 10
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 9580,
+      "ProductID": 110,
+      "InputReportLength": 64,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
+      "DeviceStrings": {
+        "201": "OEM00_M166_\\d{6}$"
+      },
+      "InitializationStrings": [
+        100,
+        200
+      ]
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -213,6 +213,7 @@
 | Huion WH1409 V2 (Variant 2)        |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0
 | KENTING K5540                      |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed
 | Monoprice 10594                    |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0
+| Monoprice 21826                    |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0
 | Parblo A610                        |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0
 | Parblo Ninos M                     |    Has Quirks     | Aux buttons are not in order. Physical dimensions are unconfirmed. If you have this tablet please help us update the dimensions.
 | Parblo Ninos N7B                   |    Has Quirks     | Physical dimensions are unconfirmed - both axes have mismatching LPI's and neither LPI's are commonly seen. If you have this tablet please help us update the dimensions.


### PR DESCRIPTION
Verification: https://discord.com/channels/615607687467761684/1422424645625319597/1467694091541418105, https://discord.com/channels/615607687467761684/1422424645625319597/1469453964629114892
Strings: [StringDump.txt](https://github.com/user-attachments/files/25139588/StringDump.txt)
Diag (detected): [Diag.json](https://github.com/user-attachments/files/25139589/Diag.json)

Don't mind the huion driver detected in this diag. Winusb *is* required here and previous attempts without it (and without diag showing huion driver) didn't go anywhere.