### PR TITLE
Use concrete type where possible for improved performance

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -36,6 +36,8 @@ dotnet_diagnostic.CA2216.severity = warning
 dotnet_diagnostic.CA1822.severity = warning
 # use compile-time regex
 dotnet_diagnostic.SYSLIB1045.severity = warning
+# use concrete types when possible for improved performance
+dotnet_diagnostic.CA1859.severity = warning
 
 # IDE-only inspections (Rider, etc.)
 resharper_can_simplify_dictionary_lookup_with_try_get_value_highlighting=warning

--- a/OpenTabletDriver.Desktop/Binding/BindingHandler.cs
+++ b/OpenTabletDriver.Desktop/Binding/BindingHandler.cs
@@ -158,9 +158,9 @@ namespace OpenTabletDriver.Desktop.Binding
             MouseScrollUp?.Invoke(tablet, report, report.Scroll.Y > 0);
         }
 
-        private static void HandleBindingCollection(TabletReference tablet, IDeviceReport report, IDictionary<int, BindingState?> bindings, IList<bool> newStates)
+        private static void HandleBindingCollection(TabletReference tablet, IDeviceReport report, Dictionary<int, BindingState?> bindings, bool[] newStates)
         {
-            for (int i = 0; i < newStates.Count; i++)
+            for (int i = 0; i < newStates.Length; i++)
             {
                 if (bindings.TryGetValue(i, out var binding))
                     binding?.Invoke(tablet, report, newStates[i]);

--- a/OpenTabletDriver.Desktop/Binding/MultiKeyBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/MultiKeyBinding.cs
@@ -15,7 +15,7 @@ namespace OpenTabletDriver.Desktop.Binding
         private const string PLUGIN_NAME = "Multi-Key Binding";
         private const char KEYS_SPLITTER = '+';
 
-        private IList<string> keys;
+        private string[] keys;
         private string keysString;
 
         [Resolved]
@@ -34,17 +34,17 @@ namespace OpenTabletDriver.Desktop.Binding
 
         public void Press(TabletReference tablet, IDeviceReport report)
         {
-            if (keys.Count > 0)
+            if (keys.Length > 0)
                 Keyboard.Press(this.keys);
         }
 
         public void Release(TabletReference tablet, IDeviceReport report)
         {
-            if (keys.Count > 0)
+            if (keys.Length > 0)
                 Keyboard.Release(this.keys);
         }
 
-        private IList<string> ParseKeys(string str)
+        private string[] ParseKeys(string str)
         {
             var newKeys = str.Split(KEYS_SPLITTER, StringSplitOptions.TrimEntries);
             return newKeys.All(k => Keyboard.SupportedKeys.Contains(k)) ? newKeys : Array.Empty<string>();

--- a/OpenTabletDriver.Desktop/Interop/Display/XScreen.cs
+++ b/OpenTabletDriver.Desktop/Interop/Display/XScreen.cs
@@ -51,12 +51,14 @@ namespace OpenTabletDriver.Desktop.Interop.Display
 
         public Vector2 Position { private set; get; } = new Vector2(0, 0);
 
-        private unsafe IEnumerable<XRRMonitorInfo> GetXRandrDisplays()
+        private unsafe XRRMonitorInfo[] GetXRandrDisplays()
         {
-            ICollection<XRRMonitorInfo> monitors = new List<XRRMonitorInfo>();
             var xRandrMonitors = XRRGetMonitors(Display, RootWindow, true, out var count);
+            var monitors = new XRRMonitorInfo[count];
+
             for (int i = 0; i < count; i++)
-                monitors.Add(xRandrMonitors[i]);
+                monitors[i] = xRandrMonitors[i];
+
             return monitors;
         }
 

--- a/OpenTabletDriver.Desktop/RPC/RpcHost.cs
+++ b/OpenTabletDriver.Desktop/RPC/RpcHost.cs
@@ -28,7 +28,7 @@ namespace OpenTabletDriver.Desktop.RPC
             }
         }
 
-        private async Task RespondToRpcRequestAsync(T host, Stream stream, CancellationToken ct)
+        private async Task RespondToRpcRequestAsync(T host, NamedPipeServerStream stream, CancellationToken ct)
         {
             try
             {

--- a/OpenTabletDriver.Desktop/Reflection/ServiceManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/ServiceManager.cs
@@ -8,7 +8,7 @@ namespace OpenTabletDriver.Desktop.Reflection
 {
     public class ServiceManager : IServiceManager
     {
-        private readonly IDictionary<Type, Func<object>> services = new Dictionary<Type, Func<object>>();
+        private readonly Dictionary<Type, Func<object>> services = new();
 
         /// <summary>
         /// Adds a retrieval method for a service type.

--- a/OpenTabletDriver.UX/Controls/GeneratedControls.cs
+++ b/OpenTabletDriver.UX/Controls/GeneratedControls.cs
@@ -12,8 +12,7 @@ namespace OpenTabletDriver.UX.Controls
 {
     public static class GeneratedControls
     {
-        private static readonly IReadOnlyDictionary<Type, Func<PropertyInfo, DirectBinding<PluginSetting>, Control>> genericControls
-            = new Dictionary<Type, Func<PropertyInfo, DirectBinding<PluginSetting>, Control>>
+        private static readonly Dictionary<Type, Func<PropertyInfo, DirectBinding<PluginSetting>, Control>> genericControls = new()
         {
             { typeof(sbyte), GetNumericMaskedTextBox<sbyte> },
             { typeof(byte), GetNumericMaskedTextBox<byte> },

--- a/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpoint.cs
+++ b/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpoint.cs
@@ -37,7 +37,7 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
         public IDeviceEndpointStream Open() => device.TryOpen(out var stream) ? new HidSharpEndpointStream(stream) : null;
         public string GetDeviceString(byte index) => device.GetDeviceString(index);
 
-        private static IDictionary<string, string> GetDeviceAttributes(string devicePath, Func<ReportDescriptor> reportDescriptorFunc)
+        private static Dictionary<string, string> GetDeviceAttributes(string devicePath, Func<ReportDescriptor> reportDescriptorFunc)
         {
             var deviceAttributes = new Dictionary<string, string>();
             switch (SystemInterop.CurrentPlatform)

--- a/OpenTabletDriver/Devices/WinUSB/WinUSBInterface.cs
+++ b/OpenTabletDriver/Devices/WinUSB/WinUSBInterface.cs
@@ -241,7 +241,7 @@ namespace OpenTabletDriver.Devices.WinUSB
             }
         }
 
-        private IDictionary<string, string> GetDeviceAttributes()
+        private Dictionary<string, string> GetDeviceAttributes()
         {
             var deviceAttributes = new Dictionary<string, string>
             {

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -184,7 +184,7 @@ namespace OpenTabletDriver
                    select device;
         }
 
-        private static bool DeviceMatchesStrings(IDeviceEndpoint device, IDictionary<byte, string>? deviceStrings)
+        private static bool DeviceMatchesStrings(IDeviceEndpoint device, Dictionary<byte, string>? deviceStrings)
         {
             if (deviceStrings == null || deviceStrings.Count == 0)
                 return true;


### PR DESCRIPTION
Kinda free change - don't use interface types when you can use the class directly, as this causes an interface lookup on use.

Functions that have had their types changed has also had relevant function usages updated (such as `List.Count` -> `Array.Length`)

Also changed the ReSharper severity in editorconfig to a warning

Aside from binding lookup in the binding handler, none of the changed functions are in any hot paths, so only initialization should have a measurable performance change.

I tested most of the code paths, including the X11 changes.

At least 1 of these changes are seen in #4562

---

A note on `IReadOnlyDictionary` that was used in `GeneratedControls.cs`: The closest concrete type I could find would've been `FrozenDictionary`, but looking at benchmarks made by others, performance is exclusively improved on key- or value-only operations, as internally a `FrozenDictionary` allocates key- and value-only arrays to accelerate these types of operation, but the allocation cost means you would also have to read a significant amount of times from the dictionary (and also to be key- or value-only operations) before you'd even start to see the performance tradeoff over time.

Additionally, it seemed that the intention was to signal to developers that the dictionary shouldn't be changed, but I don't think we explicitly need to discourage that.

So I'd rather not waste power initializing a FrozenDictionary on every UX launch, so this just gets converted to a normal `Dictionary`.

The other changes should be self-explanatory. `GetXRandrDisplays` has been converted to an array that gets initialized by the count size, rather than a dynamically allocated list.