### PR TITLE
Add test for tablet configs name matching path

### DIFF
--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -40,3 +40,28 @@ jobs:
           VERBOSE: y
         run: |
           ./tests/test_tabletconfigs_present_in_tabletsmd.sh
+
+  test_tabletconfigs_name_matches_path:
+    runs-on: ubuntu-latest
+    name: Test for tablet name in file matching directory + filename in path
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full git history is needed to get a proper list of changed files
+          fetch-depth: 0
+
+      - name: Compare names of changed tablet configs
+        if: github.event_name != 'workflow_dispatch'
+        env:
+          GET_CONFIGS_FROM_CI: defined
+          VERBOSE: y
+        run: |
+          ./tests/test_tabletconfigs_name_matches_path.sh
+
+      - name: Compare all names in tablet configs
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          VERBOSE: y
+        run: |
+          ./tests/test_tabletconfigs_name_matches_path.sh

--- a/tests/test_tabletconfigs_name_matches_path.sh
+++ b/tests/test_tabletconfigs_name_matches_path.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+oldifs="$IFS"
+IFS=$'\n'
+
+cd "$(dirname ${BASH_SOURCE[0]})"/..
+
+if [ ! -z "$GET_CONFIGS_FROM_CI" ]; then
+  # git diff command uses a github action runner quirk where the diff between
+  # HEAD^ and HEAD is equal to diffing commit merge base with pr tip
+  mapfile -t configs < <(git diff --name-only --diff-filter=AM HEAD^ HEAD | grep '^OpenTabletDriver\.Configurations/Configurations/.*\.json')
+elif [ -z "$configs" ]; then
+  # if still undefined, grab all configurations
+  mapfile -t configs < <(find OpenTabletDriver.Configurations/Configurations/ -type f -iname '*.json')
+fi
+TABLETS="${TABLETS:-TABLETS.md}"
+
+unset failed
+
+if [ ${#configs[@]} -ne 0 ]; then
+  for conf in "${configs[@]}"; do
+    config_name=$(cat $conf| jq -r '.Name')
+    config_name_from_path=$(echo "$conf" | sed -e 's/OpenTabletDriver\.Configurations\/Configurations\///g' -e 's/\.json//g' -e 's/\// /g')
+    if ! [ "$config_name" = "$config_name_from_path" ]; then
+      echo "Failure: Config '$conf' pathname '$config_name_from_path' does not match name in config '$config_name'  - was it spelled correctly?"
+      failed=y
+    else
+      if [ ! -z "$VERBOSE" ]; then
+        echo "Pass: '$config_name'"
+      fi
+    fi
+  done
+else
+  echo 'Pass: No configs to check'
+fi
+
+IFS="$oldifs"
+unset oldifs
+
+if [ ! -z "$failed" ]; then
+  exit 1
+fi


### PR DESCRIPTION
Throwing this out there. Not sure how practical it is but it might be nice to have a test to ensure these match.

Theres a bunch of them that dont match currently:

```
Failure: Config 'OpenTabletDriver.Configurations/Configurations/Lifetec/LT9570.json' pathname 'Lifetec LT9570' does not match name in config 'LifeTec LT9570'  - was it spelled correctly?
Failure: Config 'OpenTabletDriver.Configurations/Configurations/Huion/RTM 500.json' pathname 'Huion RTM 500' does not match name in config 'Huion RTM-500'  - was it spelled correctly?
Failure: Config 'OpenTabletDriver.Configurations/Configurations/Wacom/DTH-271.json' pathname 'Wacom DTH-271' does not match name in config 'Wacom Cintiq Pro 27 (DTH-271)'  - was it spelled correctly?
Failure: Config 'OpenTabletDriver.Configurations/Configurations/Wacom/DTH-2200.json' pathname 'Wacom DTH-2200' does not match name in config 'Wacom Cintiq 22HD Touch (DTH-2200)'  - was it spelled correctly?
Failure: Config 'OpenTabletDriver.Configurations/Configurations/Wacom/DTK-1660.json' pathname 'Wacom DTK-1660' does not match name in config 'Wacom Cintiq 16 (DTK-1660)'  - was it spelled correctly?
Failure: Config 'OpenTabletDriver.Configurations/Configurations/Wacom/DTH-135.json' pathname 'Wacom DTH-135' does not match name in config 'Wacom Movink 13 (DTH-135)'  - was it spelled correctly?
Failure: Config 'OpenTabletDriver.Configurations/Configurations/Wacom/DTK-1300.json' pathname 'Wacom DTK-1300' does not match name in config 'Wacom Cintiq 13HD (DTK-1300)'  - was it spelled correctly?
Failure: Config 'OpenTabletDriver.Configurations/Configurations/Wacom/DTK-2100.json' pathname 'Wacom DTK-2100' does not match name in config 'Wacom Cintiq 21UX (DTK-2100)'  - was it spelled correctly?
Failure: Config 'OpenTabletDriver.Configurations/Configurations/Wacom/DTZ-1200W.json' pathname 'Wacom DTZ-1200W' does not match name in config 'Wacom Cintiq 12WX (DTZ-1200W)'  - was it spelled correctly?
Failure: Config 'OpenTabletDriver.Configurations/Configurations/Wacom/DTZ-2100.json' pathname 'Wacom DTZ-2100' does not match name in config 'Wacom Cintiq 21UX (DTZ-2100)'  - was it spelled correctly?
Failure: Config 'OpenTabletDriver.Configurations/Configurations/Wacom/DTH-227.json' pathname 'Wacom DTH-227' does not match name in config 'Wacom Cintiq Pro 22 (DTH-227)'  - was it spelled correctly?
Failure: Config 'OpenTabletDriver.Configurations/Configurations/Wacom/DTK-2200.json' pathname 'Wacom DTK-2200' does not match name in config 'Wacom Cintiq 22HD (DTK-2200)'  - was it spelled correctly?
Failure: Config 'OpenTabletDriver.Configurations/Configurations/Wacom/PL-800.json' pathname 'Wacom PL-800' does not match name in config 'Wacom Cintiq 18SX (PL-800-U)'  - was it spelled correctly?
Failure: Config 'OpenTabletDriver.Configurations/Configurations/XP-Pen/CT1060.json' pathname 'XP-Pen CT1060' does not match name in config 'XP-Pen Deco Fun L (CT1060)'  - was it spelled correctly?
Failure: Config 'OpenTabletDriver.Configurations/Configurations/XP-Pen/CT430.json' pathname 'XP-Pen CT430' does not match name in config 'XP-Pen Deco Fun XS (CT430)'  - was it spelled correctly?
Failure: Config 'OpenTabletDriver.Configurations/Configurations/XP-Pen/CT640.json' pathname 'XP-Pen CT640' does not match name in config 'XP-Pen Deco Fun S (CT640)'  - was it spelled correctly?
Failure: Config 'OpenTabletDriver.Configurations/Configurations/VEIKK/VO1060.json' pathname 'VEIKK VO1060' does not match name in config 'VEIKK Voila (VO1060)'  - was it spelled correctly?
Failure: Config 'OpenTabletDriver.Configurations/Configurations/Waltop/Slim Tablet.json' pathname 'Waltop Slim Tablet' does not match name in config 'Waltop Slim Tablet 5.8"'  - was it spelled correctly?
```

Do have to be a little careful here though since we cant be naming a file `Waltop Slim Tablet 5.8"` or it will break checking out the repo on windows. And the ones where names and models are given should probably be reversed and instead be model number first then name in parentheses.

Code largely grabbed from the other shell test.