### PR TITLE
Refactor Linux native methods

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,15 +27,24 @@ csharp_space_after_semicolon_in_for_statement = true
 csharp_space_before_semicolon_in_for_statement = false
 csharp_space_around_declaration_statements = false
 dotnet_sort_system_directives_first = true
+
 # Disposable types
 dotnet_diagnostic.CA1063.severity = warning
 dotnet_diagnostic.CA1816.severity = warning
 dotnet_diagnostic.CA2213.severity = warning
 dotnet_diagnostic.CA2216.severity = warning
+
 # Method can be marked as static
 dotnet_diagnostic.CA1822.severity = warning
+
 # use compile-time regex
 dotnet_diagnostic.SYSLIB1045.severity = warning
+
+# P/Invoke
+## P/Invoke should not be visible, TODO: warn
+dotnet_diagnostic.CA1401.severity = suggestion
+## Use LibraryImport instead of DllImport (LibraryImport source-gen's marshalling code), TODO: warn
+dotnet_diagnostic.SYSLIB1054.severity = suggestion
 
 # IDE-only inspections (Rider, etc.)
 resharper_can_simplify_dictionary_lookup_with_try_get_value_highlighting=warning

--- a/OpenTabletDriver.Desktop/Interop/Display/XScreen.cs
+++ b/OpenTabletDriver.Desktop/Interop/Display/XScreen.cs
@@ -5,6 +5,8 @@ using System.Numerics;
 using OpenTabletDriver.Native.Linux.Xorg;
 using OpenTabletDriver.Plugin.Platform.Display;
 
+#nullable enable
+
 namespace OpenTabletDriver.Desktop.Interop.Display
 {
     using static XLib;
@@ -12,12 +14,12 @@ namespace OpenTabletDriver.Desktop.Interop.Display
 
     public class XScreen : IVirtualScreen, IDisposable
     {
-        public unsafe XScreen()
+        public XScreen()
         {
-            Display = XOpenDisplay(null);
-            RootWindow = XDefaultRootWindow(Display);
+            _display = XOpenDisplay(null);
+            _rootWindow = XDefaultRootWindow(_display);
 
-            var monitors = GetXRandrDisplays().ToList();
+            var monitors = GetXRandrDisplays();
             var primary = monitors.FirstOrDefault(d => d.Primary != 0);
 
             var displays = new List<IDisplay>();
@@ -36,29 +38,19 @@ namespace OpenTabletDriver.Desktop.Interop.Display
             Position = new Vector2(primary.X, primary.Y);
         }
 
-        private IntPtr Display;
-        private IntPtr RootWindow;
+        private XLibDisplayHandle? _display;
+        private XLibWindowHandle? _rootWindow;
 
-        public float Width
-        {
-            get => XDisplayWidth(Display, 0);
-        }
+        public float Width => XDisplayWidth(_display ?? throw new InvalidOperationException("Display unset"), 0);
 
-        public float Height
-        {
-            get => XDisplayHeight(Display, 0);
-        }
+        public float Height => XDisplayHeight(_display ?? throw new InvalidOperationException("Display unset"), 0);
 
-        public Vector2 Position { private set; get; } = new Vector2(0, 0);
+        public Vector2 Position { private set; get; }
 
-        private unsafe IEnumerable<XRRMonitorInfo> GetXRandrDisplays()
-        {
-            ICollection<XRRMonitorInfo> monitors = new List<XRRMonitorInfo>();
-            var xRandrMonitors = XRRGetMonitors(Display, RootWindow, true, out var count);
-            for (int i = 0; i < count; i++)
-                monitors.Add(xRandrMonitors[i]);
-            return monitors;
-        }
+        private List<XRRMonitorInfo> GetXRandrDisplays() =>
+            [..XRRGetMonitors(_display is { IsInvalid: false } ? _display : throw new InvalidOperationException("Invalid Display"),
+                _rootWindow is { IsInvalid: false } ? _rootWindow : throw new InvalidOperationException("Invalid RootWindow"),
+                true, out _)];
 
         public IEnumerable<IDisplay> Displays { private set; get; }
 
@@ -81,12 +73,14 @@ namespace OpenTabletDriver.Desktop.Interop.Display
         {
             if (_isDisposed) return;
 
-            if (Display != IntPtr.Zero)
-            {
-                int result = XCloseDisplay(Display);
-                Display = IntPtr.Zero;
-            }
-            RootWindow = IntPtr.Zero;
+            if (_display is { IsInvalid: false })
+                _display.Dispose();
+            _display = null;
+
+            if (_rootWindow is { IsInvalid: false })
+                _rootWindow.Dispose();
+            _rootWindow = null;
+
             _isDisposed = true;
         }
 

--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevAbsolutePointer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevAbsolutePointer.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Numerics;
 using OpenTabletDriver.Native.Linux;
 using OpenTabletDriver.Native.Linux.Evdev;
@@ -10,28 +9,23 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
 {
     public class EvdevAbsolutePointer : EvdevVirtualMouse, IAbsolutePointer
     {
-        public unsafe EvdevAbsolutePointer()
+        public EvdevAbsolutePointer()
         {
             Device = new EvdevDevice("OpenTabletDriver Virtual Tablet");
-
-            Device.EnableType(EventType.EV_ABS);
-            Device.EnableType(EventType.EV_REL);
 
             var xAbs = new input_absinfo
             {
                 maximum = (int)DesktopInterop.VirtualScreen.Width
             };
-            input_absinfo* xPtr = &xAbs;
-            Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_X, (IntPtr)xPtr);
+            Device.EnableAbsCode(EventCode.ABS_X, xAbs);
 
             var yAbs = new input_absinfo
             {
                 maximum = (int)DesktopInterop.VirtualScreen.Height
             };
-            input_absinfo* yPtr = &yAbs;
-            Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_Y, (IntPtr)yPtr);
+            Device.EnableAbsCode(EventCode.ABS_Y, yAbs);
 
-            Device.EnableTypeCodes(
+            Device.EnableCodes(
                 EventType.EV_KEY,
                 EventCode.BTN_LEFT,
                 EventCode.BTN_MIDDLE,
@@ -40,7 +34,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
                 EventCode.BTN_EXTRA
             );
 
-            Device.EnableTypeCodes(
+            Device.EnableCodes(
                 EventType.EV_REL,
                 EventCode.REL_WHEEL,
                 EventCode.REL_WHEEL_HI_RES,

--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -26,37 +26,32 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
             EventCode.BTN_TOOL_RUBBER,
         ];
 
-        public unsafe EvdevVirtualTablet()
+        public EvdevVirtualTablet()
         {
             Device = new EvdevDevice("OpenTabletDriver Virtual Artist Tablet");
 
             Device.EnableProperty(InputProperty.INPUT_PROP_DIRECT);
             Device.EnableProperty(InputProperty.INPUT_PROP_POINTER);
 
-            Device.EnableType(EventType.EV_ABS);
-
             var xAbs = new input_absinfo
             {
                 maximum = (int)(DesktopInterop.VirtualScreen.Width * RESOLUTION),
                 resolution = 100000
             };
-            input_absinfo* xPtr = &xAbs;
-            Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_X, (IntPtr)xPtr);
+            Device.EnableAbsCode(EventCode.ABS_X, xAbs);
 
             var yAbs = new input_absinfo
             {
                 maximum = (int)(DesktopInterop.VirtualScreen.Height * RESOLUTION),
                 resolution = 100000
             };
-            input_absinfo* yPtr = &yAbs;
-            Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_Y, (IntPtr)yPtr);
+            Device.EnableAbsCode(EventCode.ABS_Y, yAbs);
 
             var pressure = new input_absinfo
             {
                 maximum = MaxPressure
             };
-            input_absinfo* pressurePtr = &pressure;
-            Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_PRESSURE, (IntPtr)pressurePtr);
+            Device.EnableAbsCode(EventCode.ABS_PRESSURE, pressure);
 
             var xTilt = new input_absinfo
             {
@@ -64,8 +59,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
                 maximum = 63,
                 resolution = 57
             };
-            input_absinfo* xTiltPtr = &xTilt;
-            Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_TILT_X, (IntPtr)xTiltPtr);
+            Device.EnableAbsCode(EventCode.ABS_TILT_X, xTilt);
 
             var yTilt = new input_absinfo
             {
@@ -73,10 +67,9 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
                 maximum = 63,
                 resolution = 57
             };
-            input_absinfo* yTiltPtr = &yTilt;
-            Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_TILT_Y, (IntPtr)yTiltPtr);
+            Device.EnableAbsCode(EventCode.ABS_TILT_Y, yTilt);
 
-            Device.EnableTypeCodes(
+            Device.EnableCodes(
                 EventType.EV_KEY,
                 supportedEventCodes
             );

--- a/OpenTabletDriver.Desktop/Interop/Input/Keyboard/EvdevVirtualKeyboard.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Keyboard/EvdevVirtualKeyboard.cs
@@ -14,7 +14,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Keyboard
         {
             Device = new EvdevDevice("OpenTabletDriver Virtual Keyboard");
 
-            Device.EnableTypeCodes(EventType.EV_KEY, EtoKeysymToEventCode.Values.Distinct().ToArray());
+            Device.EnableCodes(EventType.EV_KEY, EtoKeysymToEventCode.Values.Distinct().ToArray());
 
             var result = Device.Initialize();
             switch (result)

--- a/OpenTabletDriver.Desktop/Interop/Input/Relative/EvdevRelativePointer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Relative/EvdevRelativePointer.cs
@@ -12,7 +12,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Relative
         {
             Device = new EvdevDevice("OpenTabletDriver Virtual Mouse");
 
-            Device.EnableTypeCodes(
+            Device.EnableCodes(
                 EventType.EV_REL,
                 EventCode.REL_X,
                 EventCode.REL_Y,
@@ -22,7 +22,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Relative
                 EventCode.REL_HWHEEL_HI_RES
             );
 
-            Device.EnableTypeCodes(
+            Device.EnableCodes(
                 EventType.EV_KEY,
                 EventCode.BTN_LEFT,
                 EventCode.BTN_MIDDLE,

--- a/OpenTabletDriver.Desktop/Interop/Timer/LinuxTimer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Timer/LinuxTimer.cs
@@ -6,6 +6,8 @@ using OpenTabletDriver.Native.Linux.Timers;
 using OpenTabletDriver.Native.Linux.Timers.Structs;
 using OpenTabletDriver.Plugin;
 
+#nullable enable
+
 namespace OpenTabletDriver.Desktop.Interop.Timer
 {
     using static Timers;
@@ -13,9 +15,9 @@ namespace OpenTabletDriver.Desktop.Interop.Timer
 
     internal class LinuxTimer : ITimer, IDisposable
     {
-        private Thread _timerThread;
+        private Thread? _timerThread;
         private readonly object _stateLock = new object();
-        private int _timerFD;
+        private TimerHandle? _timerFD;
         private ITimerSpec _timerSpec;
 
         private volatile bool _enabled;
@@ -23,7 +25,7 @@ namespace OpenTabletDriver.Desktop.Interop.Timer
 
         public float Interval { set; get; } = 1;
 
-        public event Action Elapsed;
+        public event Action? Elapsed;
 
         public void Start()
         {
@@ -31,9 +33,9 @@ namespace OpenTabletDriver.Desktop.Interop.Timer
             {
                 if (!_enabled)
                 {
-                    int timerFD = TimerCreate(ClockID.Monotonic, 0);
+                    var timerFD = TimerCreate();
 
-                    if (timerFD == -1)
+                    if (timerFD.IsInvalid)
                     {
                         Log.Write("LinuxTimer", $"Failed creating timer: {(ERRNO)Marshal.GetLastWin32Error()}", LogLevel.Error);
                         return;
@@ -47,23 +49,13 @@ namespace OpenTabletDriver.Desktop.Interop.Timer
                     long seconds = totalNS / ns_per_second;
                     long nseconds = totalNS % ns_per_second;
 
-                    _timerSpec = new ITimerSpec
-                    {
-                        it_interval = new TimeSpec
-                        {
-                            sec = seconds,
-                            nsec = nseconds
-                        },
-                        it_value = new TimeSpec
-                        {
-                            sec = seconds,
-                            nsec = nseconds
-                        }
-                    };
+                    var timeSpec = new TimeSpec(seconds, nseconds);
 
-                    if (TimerSetTime(_timerFD, TimerFlag.Default, ref _timerSpec, IntPtr.Zero) != ERRNO.NONE)
+                    _timerSpec = new ITimerSpec(timeSpec, timeSpec);
+
+                    if (!TimerSetTime(_timerFD, TimerFlag.Default, in _timerSpec, out _, out var startError))
                     {
-                        Log.Write("LinuxTimer", $"Failed activating the timer: ${(ERRNO)Marshal.GetLastWin32Error()}", LogLevel.Error);
+                        Log.Write("LinuxTimer", $"Failed activating the timer: {startError}", LogLevel.Error);
                         return;
                     }
 
@@ -71,9 +63,7 @@ namespace OpenTabletDriver.Desktop.Interop.Timer
                     {
                         while (_enabled)
                         {
-                            ulong timerExpirations = 0;
-
-                            if (TimerGetTime(_timerFD, ref timerExpirations, sizeof(ulong)) == sizeof(ulong) && _enabled)
+                            if (TimerGetTime(_timerFD, out _, out var readError) && _enabled)
                             {
                                 try
                                 {
@@ -87,7 +77,10 @@ namespace OpenTabletDriver.Desktop.Interop.Timer
                             }
                             else if (_enabled)
                             {
-                                Log.Write("LinuxTimer", $"Unexpected timer error: ${(ERRNO)Marshal.GetLastWin32Error()}", LogLevel.Error);
+                                if (readError == ERRNO.EAGAIN)
+                                    throw new NotImplementedException("Non-blocking timers are unimplemented");
+
+                                Log.Write("LinuxTimer", $"Unexpected timer error: ${readError}", LogLevel.Error);
                                 break;
                             }
                         }
@@ -102,6 +95,12 @@ namespace OpenTabletDriver.Desktop.Interop.Timer
             }
         }
 
+        private static readonly ITimerSpec s_StoppingTimerSpec = new()
+        {
+            it_interval = new TimeSpec(0, 0),
+            it_value = new TimeSpec(0, 1), // makes it loop once more to safely close
+        };
+
         public void Stop()
         {
             lock (_stateLock)
@@ -110,36 +109,21 @@ namespace OpenTabletDriver.Desktop.Interop.Timer
                 {
                     _enabled = false;
 
-                    var timerSpec = new ITimerSpec
+                    if (_timerFD == null)
                     {
-                        it_interval = new TimeSpec
-                        {
-                            sec = 0,
-                            nsec = 0
-                        },
-                        it_value = new TimeSpec
-                        {
-                            sec = 0,
-                            nsec = 1 // makes it loop once more to safely close
-                        }
-                    };
-
-                    if (TimerSetTime(_timerFD, TimerFlag.Default, ref timerSpec, IntPtr.Zero) != ERRNO.NONE)
+                        Log.Write(nameof(LinuxTimer), "Failed deactivating the timer: timerFD was null (did you forget to start it first?)", LogLevel.Error);
+                    }
+                    else if (!TimerSetTime(_timerFD, TimerFlag.Default, in s_StoppingTimerSpec, out _, out var deactivateError))
                     {
-                        Log.Write("LinuxTimer", $"Failed deactivating the timer: ${(ERRNO)Marshal.GetLastWin32Error()}", LogLevel.Error);
+                        Log.Write("LinuxTimer", $"Failed deactivating the timer: ${deactivateError}", LogLevel.Error);
                         return;
                     }
 
                     _timerThread?.Join();
                     _timerThread = null;
 
-                    if (CloseTimer(_timerFD) != ERRNO.NONE)
-                    {
-                        Log.Write("LinuxTimer", $"Failed deleting the timer: ${(ERRNO)Marshal.GetLastWin32Error()}", LogLevel.Error);
-                        return;
-                    }
-
-                    _timerFD = -1;
+                    _timerFD?.Dispose();
+                    _timerFD = null;
                 }
             }
         }

--- a/OpenTabletDriver.Native/Linux/Evdev/Evdev.cs
+++ b/OpenTabletDriver.Native/Linux/Evdev/Evdev.cs
@@ -1,36 +1,244 @@
 using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+using OpenTabletDriver.Native.Linux.Evdev.Structs;
+
+#nullable enable
 
 namespace OpenTabletDriver.Native.Linux.Evdev
 {
-    public static partial class Evdev
+    /// <summary>
+    /// Linux Evdev/uinput device handling
+    /// <para/>
+    /// Usage:<br/>
+    /// 1. <see cref="libevdev_new"/><br/>
+    /// 2. <see cref="libevdev_set_name"/><br/>
+    /// 3. Enable any needed from:<br/>
+    /// - <see cref="libevdev_enable_event_code(EvdevHandle, EventType, EventCode)"/><br/>
+    /// - <see cref="libevdev_enable_event_code_abs"/><br/>
+    /// - <see cref="libevdev_enable_event_code_rep"/><br/>
+    /// - <see cref="libevdev_enable_event_type"/> (optionally, enabling event codes auto-enables event types)<br/>
+    /// - <see cref="libevdev_enable_property"/>.<para/>
+    /// Then <see cref="libevdev_uinput_create_from_device"/>
+    /// into as many
+    /// <see cref="libevdev_uinput_write_event"/> as you need
+    /// <para/>
+    /// Upstream documentation:<br/>
+    /// <a href="https://www.freedesktop.org/software/libevdev/doc/latest/group__init.html">Freedesktop.org libevdev docs: evdev init</a><br/>
+    /// <a href="https://www.freedesktop.org/software/libevdev/doc/latest/group__kernel.html">Freedesktop.org libevdev docs: evdev device modification</a><br/>
+    /// <a href="https://www.freedesktop.org/software/libevdev/doc/latest/group__uinput.html">Freedesktop.org libevdev docs: uinput</a><br/>
+    /// <a href="https://www.freedesktop.org/software/libevdev/doc/latest/modules.html">See all Freedesktop.org libevdev doc modules</a><br/>
+    /// </summary>
+    internal static partial class Evdev
     {
+        internal class EvdevHandle() : SafeHandleZeroOrMinusOneIsInvalid(true)
+        {
+            protected override bool ReleaseHandle()
+            {
+                libevdev_free(handle);
+                return true;
+            }
+        }
+
+        internal class EvdevUinputHandle : SafeHandleZeroOrMinusOneIsInvalid
+        {
+            private readonly EvdevHandle _evdevHandle;
+
+            /// <remarks>
+            /// You must still manually dispose <paramref name="evdevHandle"/>
+            /// </remarks>
+            public EvdevUinputHandle(IntPtr uinputPtr, EvdevHandle evdevHandle) : base(true)
+            {
+                base.handle = uinputPtr;
+                _evdevHandle = evdevHandle;
+            }
+
+            public override bool IsInvalid => _evdevHandle.IsInvalid || base.IsInvalid;
+
+            protected override bool ReleaseHandle()
+            {
+                libevdev_uinput_destroy(handle);
+                return true;
+            }
+        }
+
         private const string libevdev = "libevdev.so.2";
 
-        [DllImport(libevdev)]
-        public extern static IntPtr libevdev_new();
+        /// <summary>
+        /// Creates a new evdev handle
+        /// </summary>
+        /// <returns>A disposable handle</returns>
+        [LibraryImport(libevdev)]
+        internal static partial EvdevHandle libevdev_new();
 
-        [DllImport(libevdev)]
-        public extern static void libevdev_set_name(IntPtr dev, string name);
+        /// <summary>
+        /// Sets a new name for the evdev device
+        /// </summary>
+        /// <param name="evdevHandle">A valid handle for the device from <see cref="libevdev_new"/></param>
+        /// <param name="name">The name of the device</param>
+        /// <remarks>The <paramref name="evdevHandle"/> is not validated</remarks>
+        [LibraryImport(libevdev)]
+        internal static partial void libevdev_set_name(EvdevHandle evdevHandle, [MarshalAs(UnmanagedType.LPStr)] string name);
 
-        [DllImport(libevdev)]
-        public extern static int libevdev_enable_property(IntPtr dev, uint prop);
+        /// <summary>
+        /// Enable property for evdev device
+        /// </summary>
+        /// <param name="evdevHandle">A valid handle for the device from <see cref="libevdev_new"/></param>
+        /// <param name="prop">A single property of <see cref="InputProperty"/></param>
+        /// <returns><c>0</c> on success, or <c>-1</c> on failure</returns>
+        /// <remarks>The <paramref name="evdevHandle"/> is not validated</remarks>
+        [LibraryImport(libevdev)]
+        internal static partial int libevdev_enable_property(EvdevHandle evdevHandle, InputProperty prop);
 
-        [DllImport(libevdev)]
-        public extern static int libevdev_enable_event_type(IntPtr dev, uint type);
+        /// <summary>
+        /// Enable type for device
+        /// </summary>
+        /// <param name="evdevHandle">A valid handle for the device from <see cref="libevdev_new"/></param>
+        /// <param name="type">The <see cref="EventType"/> to enable</param>
+        /// <returns><c>0</c> on success, or <c>-1</c> on failure</returns>
+        /// <remarks>
+        /// Upstream documentation indirectly suggests to instead enable types via
+        /// <see cref="libevdev_enable_event_code_abs"/> or <see cref="libevdev_enable_event_code(EvdevHandle,EventType,EventCode)"/>
+        /// The <paramref name="evdevHandle"/> is not validated
+        /// </remarks>
+        [LibraryImport(libevdev)]
+        internal static partial int libevdev_enable_event_type(EvdevHandle evdevHandle, EventType type);
 
-        [DllImport(libevdev)]
-        public extern static int libevdev_enable_event_code(IntPtr dev, uint type, uint code, IntPtr data);
+        /// <summary>
+        /// Private function for the external call to enable the event code for the device.
+        /// Please use the appropriate <c>internal</c> function instead (as seen in the Remarks section).
+        /// </summary>
+        /// <param name="evdevHandle">A valid handle for the device from <see cref="libevdev_new"/></param>
+        /// <param name="type">The <see cref="EventType"/> that the <paramref name="code"/> refers to</param>
+        /// <param name="code">The <see cref="EventCode"/> to enable</param>
+        /// <param name="data">A pointer to the relevant data</param>
+        /// <returns><c>0</c> on success, or <c>-1</c> on failure</returns>
+        /// <remarks>
+        /// Upstream library automatically enables the <see cref="EventType"/> if necessary<br/>
+        /// The <paramref name="evdevHandle"/> is not validated<para/>
+        /// Notes on <paramref name="type"/> and <paramref name="data"/> relations: <br/>
+        /// - <see cref="EventType.EV_ABS"/> must use <see cref="input_absinfo"/> (<see cref="libevdev_enable_event_code_abs"/>) <br/>
+        /// - <see cref="EventType.EV_REP"/> must use <see cref="int"/> (<see cref="libevdev_enable_event_code_rep"/>) <br/>
+        /// - Otherwise <paramref name="data"/> must be <c>null</c> (<see cref="libevdev_enable_event_code(EvdevHandle,EventType,EventCode)"/>)
+        /// </remarks>
+        [LibraryImport(libevdev)]
+        private static partial int libevdev_enable_event_code(EvdevHandle evdevHandle, EventType type, EventCode code, IntPtr data);
 
-        [DllImport(libevdev)]
-        public extern static int libevdev_uinput_create_from_device(IntPtr dev, int uinput_fd, out IntPtr uinput_dev);
+        /// <summary>
+        /// Enable an <see cref="EventCode"/> of type <see cref="EventType.EV_ABS"/>
+        /// </summary>
+        /// <param name="evdevHandle">A valid handle for the device from <see cref="libevdev_new"/></param>
+        /// <param name="code">The <see cref="EventCode"/> to enable</param>
+        /// <param name="absinfo">An <see cref="input_absinfo"/> struct containing the ranges for the <paramref name="code"/> you're enabling</param>
+        /// <returns><c>0</c> on success, or <c>-1</c> on failure</returns>
+        /// <exception cref="ArgumentException">On null or invalid <paramref name="evdevHandle"/></exception>
+        /// <remarks>
+        /// Automatically enables event type <see cref="EventType.EV_ABS"/> if it wasn't previously enabled
+        /// </remarks>
+        internal static unsafe int libevdev_enable_event_code_abs(EvdevHandle evdevHandle, EventCode code, input_absinfo absinfo)
+        {
+            ValidateHandle(evdevHandle);
 
-        [DllImport(libevdev)]
-        public extern static void libevdev_uinput_destroy(IntPtr uinput_dev);
+            return libevdev_enable_event_code(evdevHandle, EventType.EV_ABS, code, (IntPtr)(&absinfo));
+        }
 
-        [DllImport(libevdev)]
-        public extern static int libevdev_uinput_write_event(IntPtr uinput_dev, uint type, uint code, int value);
+        /// <summary>
+        /// Enable an <see cref="EventCode"/> of type <see cref="EventType.EV_REP"/>
+        /// </summary>
+        /// <param name="evdevHandle">A valid handle for the device from <see cref="libevdev_new"/></param>
+        /// <param name="code">The <see cref="EventCode"/> to enable</param>
+        /// <param name="data">"The data for the axis" (?)</param>
+        /// <returns><c>0</c> on success, or <c>-1</c> on failure</returns>
+        /// <exception cref="ArgumentException">On null or invalid <paramref name="evdevHandle"/></exception>
+        /// <remarks>
+        /// Untested in the OpenTabletDriver codebase.<br/>
+        /// Automatically enables event type <see cref="EventType.EV_REP"/> if it wasn't previously enabled
+        /// </remarks>
+        internal static int libevdev_enable_event_code_rep(EvdevHandle evdevHandle, EventCode code, int data)
+        {
+            ValidateHandle(evdevHandle);
 
-        public const int LIBEVDEV_UINPUT_OPEN_MANAGED = -2;
+            return libevdev_enable_event_code(evdevHandle, EventType.EV_REP, code, data);
+        }
+
+        /// <summary>
+        /// Enable an <see cref="EventCode"/> not of type <see cref="EventType.EV_ABS"/> or <see cref="EventType.EV_REP"/>
+        /// </summary>
+        /// <param name="evdevHandle">A valid handle for the device from <see cref="libevdev_new"/></param>
+        /// <param name="type">The <see cref="EventType"/> that the <paramref name="code"/> refers to</param>
+        /// <param name="code">The <see cref="EventCode"/> to enable</param>
+        /// <returns><c>0</c> on success, or <c>-1</c> on failure</returns>
+        /// <exception cref="ArgumentException">On null or invalid <paramref name="evdevHandle"/></exception>
+        /// <remarks>
+        /// Automatically enables the <paramref name="type"/> if it wasn't previously enabled.<br/>
+        /// For <see cref="EventType.EV_ABS"/> or <see cref="EventType.EV_REP"/> events, use the respective function instead:
+        /// <see cref="libevdev_enable_event_code_abs"/> or <see cref="libevdev_enable_event_code_rep"/>
+        /// </remarks>
+        internal static int libevdev_enable_event_code(EvdevHandle evdevHandle, EventType type, EventCode code)
+        {
+            Debug.Assert(type != EventType.EV_ABS,
+                $"{nameof(EventType.EV_ABS)} usage requires {nameof(input_absinfo)}. Use the {nameof(libevdev_enable_event_code_abs)} function instead");
+            Debug.Assert(type != EventType.EV_REP,
+                $"{nameof(EventType.EV_REP)} usage requires 'int'. Use the {nameof(libevdev_enable_event_code_rep)} function instead");
+
+            ValidateHandle(evdevHandle);
+
+            return libevdev_enable_event_code(evdevHandle, type, code, IntPtr.Zero);
+        }
+
+        /// <summary>
+        /// Backed by a wrapper function as <see cref="EvdevUinputHandle"/> cannot easily be marshaled
+        /// </summary>
+        [LibraryImport(libevdev, EntryPoint = "libevdev_uinput_create_from_device")]
+        private static partial int sys_libevdev_uinput_create_from_device(EvdevHandle evdevHandle, int uinput_fd, out IntPtr uinput_dev);
+
+        /// <summary>
+        /// Create an uinput device from an evdev device to send events from via <see cref="libevdev_uinput_write_event"/>
+        /// </summary>
+        /// <param name="evdevHandle">A valid handle for the device from <see cref="libevdev_new"/></param>
+        /// <param name="uinput_dev">On success, a valid <see cref="EvdevUinputHandle"/></param>
+        /// <returns><see cref="ERRNO.NONE"/> on success. On failure, the value of <paramref name="uinput_dev"/> is unmodified.</returns>
+        /// <exception cref="ArgumentException">On null or invalid <paramref name="evdevHandle"/></exception>
+        internal static ERRNO libevdev_uinput_create_from_device(EvdevHandle evdevHandle, out EvdevUinputHandle uinput_dev)
+        {
+            ValidateHandle(evdevHandle);
+
+            int rv = sys_libevdev_uinput_create_from_device(evdevHandle, _LIBEVDEV_UINPUT_OPEN_MANAGED, out var uinputDevPtr);
+            uinput_dev = new EvdevUinputHandle(uinputDevPtr, evdevHandle);
+            return (ERRNO)(-rv);
+        }
+
+        [LibraryImport(libevdev, EntryPoint = "libevdev_uinput_write_event")]
+        internal static partial int sys_libevdev_uinput_write_event(EvdevUinputHandle uinputHandle, EventType type, EventCode code, int value);
+
+        /// <summary>
+        /// Send an event via the created uinput device
+        /// </summary>
+        /// <param name="uinputHandle">A valid handle for the device from <see cref="libevdev_uinput_create_from_device"/></param>
+        /// <param name="type">The previously enabled <see cref="EventType"/></param>
+        /// <param name="code">The previously enabled <see cref="EventCode"/></param>
+        /// <param name="value">The event value</param>
+        /// <returns><see cref="ERRNO.NONE"/> on success</returns>
+        internal static ERRNO libevdev_uinput_write_event(EvdevUinputHandle uinputHandle, EventType type, EventCode code, int value)
+        {
+            ValidateHandle(uinputHandle);
+
+            return (ERRNO)(-sys_libevdev_uinput_write_event(uinputHandle, type, code, value));
+        }
+
+        private const int _LIBEVDEV_UINPUT_OPEN_MANAGED = -2;
+
+        [LibraryImport(libevdev)]
+        private static partial void libevdev_free(IntPtr dev);
+
+        [LibraryImport(libevdev)]
+        private static partial void libevdev_uinput_destroy(IntPtr uinputDev);
+
+        private static void ValidateHandle(SafeHandle handle, [CallerArgumentExpression(nameof(handle))] string argName = "")
+        {
+            if (handle == null || handle.IsInvalid) throw new ArgumentException("Invalid handle", argName);
+        }
     }
 }

--- a/OpenTabletDriver.Native/Linux/Evdev/EvdevDevice.cs
+++ b/OpenTabletDriver.Native/Linux/Evdev/EvdevDevice.cs
@@ -1,5 +1,9 @@
 using System;
-using System.IO;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using OpenTabletDriver.Native.Linux.Evdev.Structs;
+
+#nullable enable
 
 namespace OpenTabletDriver.Native.Linux.Evdev
 {
@@ -13,16 +17,13 @@ namespace OpenTabletDriver.Native.Linux.Evdev
             libevdev_set_name(this.device, deviceName);
         }
 
-        public bool CanWrite { private set; get; }
+        [MemberNotNullWhen(true, nameof(uidev))]
+        public bool CanWrite => !uidev?.IsInvalid ?? false;
 
-        private IntPtr device, uidev;
+        private readonly EvdevHandle device;
+        private EvdevUinputHandle? uidev;
 
-        public ERRNO Initialize()
-        {
-            var err = libevdev_uinput_create_from_device(this.device, LIBEVDEV_UINPUT_OPEN_MANAGED, out this.uidev);
-            CanWrite = err == 0;
-            return (ERRNO)(-err);
-        }
+        public ERRNO Initialize() => libevdev_uinput_create_from_device(this.device, out this.uidev);
 
         public void Dispose()
         {
@@ -36,42 +37,34 @@ namespace OpenTabletDriver.Native.Linux.Evdev
         {
             if (_isDisposed) return;
 
-            CanWrite = false;
+            if (uidev is { IsInvalid: false })
+                uidev.Dispose();
+            uidev = null;
 
-            if (this.uidev != IntPtr.Zero)
-            {
-                libevdev_uinput_destroy(this.uidev);
-                this.uidev = IntPtr.Zero;
-                this.device = IntPtr.Zero;
-            }
+            if (device is { IsInvalid: false })
+                device.Dispose();
 
             _isDisposed = true;
         }
 
         ~EvdevDevice() => Dispose(false);
 
-        public void EnableProperty(InputProperty prop) => libevdev_enable_property(this.device, (uint)prop);
+        public void EnableProperty(InputProperty prop) => libevdev_enable_property(this.device, prop);
 
-        public void EnableType(EventType type) => libevdev_enable_event_type(this.device, (uint)type);
+        public void EnableType(EventType type) => libevdev_enable_event_type(this.device, type);
 
-        public void EnableCode(EventType type, EventCode code) => libevdev_enable_event_code(this.device, (uint)type, (uint)code, IntPtr.Zero);
+        public void EnableCode(EventType type, EventCode code) => libevdev_enable_event_code(this.device, type, code);
         public void EnableCodes(EventType type, params EventCode[] codes)
         {
             foreach (var code in codes)
                 EnableCode(type, code);
         }
 
-        public void EnableCustomCode(EventType type, EventCode code, IntPtr ptr) => libevdev_enable_event_code(this.device, (uint)type, (uint)code, ptr);
+        public void EnableAbsCode(EventCode code, input_absinfo absinfo) => libevdev_enable_event_code_abs(this.device, code, absinfo);
 
-        public void EnableTypeCodes(EventType type, params EventCode[] codes)
+        public ERRNO Write(EventType type, EventCode code, int value)
         {
-            EnableType(type);
-            EnableCodes(type, codes);
-        }
-
-        public int Write(EventType type, EventCode code, int value)
-        {
-            return CanWrite ? libevdev_uinput_write_event(this.uidev, (uint)type, (uint)code, value) : int.MinValue;
+            return CanWrite ? libevdev_uinput_write_event(this.uidev, type, code, value) : throw new InvalidOperationException("Unable to write to an unavailable device");
         }
 
         public bool Sync()

--- a/OpenTabletDriver.Native/Linux/Evdev/EventType.cs
+++ b/OpenTabletDriver.Native/Linux/Evdev/EventType.cs
@@ -12,5 +12,6 @@ namespace OpenTabletDriver.Native.Linux.Evdev
         EV_KEY = 0x01,
         EV_REL = 0x02,
         EV_ABS = 0x03,
+        EV_REP = 0x14,
     }
 }

--- a/OpenTabletDriver.Native/Linux/Timers/Timers.cs
+++ b/OpenTabletDriver.Native/Linux/Timers/Timers.cs
@@ -1,26 +1,99 @@
 using System;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 using OpenTabletDriver.Native.Linux.Timers.Structs;
+
+#nullable enable
 
 namespace OpenTabletDriver.Native.Linux.Timers
 {
-    public static class Timers
+    public static partial class Timers
     {
-        private const string libc = "libc.so.6";
+        public class TimerHandle() : SafeHandleZeroOrMinusOneIsInvalid(true)
+        {
+            protected override bool ReleaseHandle() => CloseTimer(handle) != -1;
+        }
 
-        [DllImport(libc, EntryPoint = "timerfd_create", SetLastError = true)]
-        public static extern int TimerCreate(ClockID clockID, TimerFlag flags);
+        private const string _LIBC = "libc.so.6";
 
-        [DllImport(libc, EntryPoint = "timerfd_settime", SetLastError = true)]
-        public static extern ERRNO TimerSetTime(int fd, TimerFlag flags, ref ITimerSpec newValue, ref ITimerSpec oldValue);
+        /// <summary>
+        /// Extern of libc's <c>timerfd_create</c>. Created timer must be manually started with <see cref="TimerSetTime"/>
+        /// </summary>
+        /// <returns>A <see cref="TimerHandle"/> pointing to the timer file descriptor</returns>
+        /// <remarks>Not all clock IDs are supported - please check <see cref="TimerHandle.IsInvalid"/> carefully after calling</remarks>
+        [LibraryImport(_LIBC, EntryPoint = "timerfd_create", SetLastError = true)]
+        public static partial TimerHandle TimerCreate(ClockID clockID = ClockID.Monotonic, TimerFlag flags = TimerFlag.Default);
 
-        [DllImport(libc, EntryPoint = "timerfd_settime", SetLastError = true)]
-        public static extern ERRNO TimerSetTime(int fd, TimerFlag flags, ref ITimerSpec newValue, IntPtr oldValue);
+        /// <summary>
+        /// Arms or disarms a timer referred to by <paramref name="handle"/>
+        /// <para/>
+        /// Extern of libc's <c>timerfd_settime</c>
+        /// </summary>
+        /// <param name="handle">A valid <see cref="TimerHandle"/></param>
+        /// <param name="flags">The <see cref="TimerFlag"/>s for the timer</param>
+        /// <param name="newValue">The new <see cref="ITimerSpec"/> to use</param>
+        /// <param name="oldValue">The old <see cref="ITimerSpec"/> that was in use</param>
+        /// <param name="error">The upstream errno, if any. Will be <see cref="ERRNO.NONE"/> if function returns <c>true</c></param>
+        /// <returns>
+        /// <c>true</c> on success, or <c>false</c> on error<br/>
+        /// If <c>false</c>, <see cref="ERRNO"/> can be read from <paramref name="error"/>
+        /// </returns>
+        /// <exception cref="ArgumentException">If <paramref name="handle"/> is invalid</exception>
+        public static bool TimerSetTime(TimerHandle handle, TimerFlag flags, in ITimerSpec newValue, out ITimerSpec oldValue, out ERRNO error)
+        {
+            error = ERRNO.NONE;
 
-        [DllImport(libc, EntryPoint = "read", SetLastError = true)]
-        public static extern int TimerGetTime(int fd, ref ulong buf, int count);
+            if (handle.IsInvalid) throw new ArgumentException("Invalid handle", nameof(handle));
 
-        [DllImport(libc, EntryPoint = "close", SetLastError = true)]
-        public static extern ERRNO CloseTimer(int fd);
+            var rv = Sys_TimerSetTime(handle, flags, in newValue, out oldValue);
+
+            if (rv == -1)
+                error = (ERRNO)Marshal.GetLastWin32Error();
+
+            return rv != -1;
+        }
+
+        /// <summary>
+        /// Check if timer has lapsed/expired, blocking if the timer has not yet lapsed.
+        /// </summary>
+        /// <param name="handle">A valid <see cref="TimerHandle"/></param>
+        /// <param name="expirations">An output buffer for the amount of times that the timer has cycled</param>
+        /// <param name="error">The upstream errno, if any. Will be <see cref="ERRNO.NONE"/> if function returns <c>true</c></param>
+        /// <returns>
+        /// <c>true</c> on success, or <c>false</c> on error or unexpected return value from <c>read</c>.<br/>
+        /// If <c>false</c>, any potential API errors can be read as <see cref="ERRNO"/> from <paramref name="error"/>
+        /// </returns>
+        /// <exception cref="ArgumentException">If <paramref name="handle"/> is invalid</exception>
+        /// <remarks>
+        /// Does not block if <see cref="TimerFlag.NonBlocking"/> was set in <see cref="TimerCreate"/>,
+        /// and instead returns <c>false</c> with error <see cref="ERRNO.EAGAIN"/> if the timer has not yet lapsed.
+        /// </remarks>
+        public static bool TimerGetTime(TimerHandle handle, out ulong expirations, out ERRNO error)
+        {
+            error = ERRNO.NONE;
+
+            if (handle.IsInvalid)
+                throw new ArgumentException("Handle is invalid", nameof(handle));
+
+            var rv = Sys_TimerGetTime(handle, out expirations, sizeof(ulong));
+
+            if (rv == -1)
+                error = (ERRNO)Marshal.GetLastWin32Error();
+
+            return rv == sizeof(ulong);
+        }
+
+        /// <returns><c>0</c> on success, or <c>-1</c> on error and <c>errno</c> will be set (use <see cref="Marshal.GetLastWin32Error"/>)</returns>
+        [LibraryImport(_LIBC, EntryPoint = "timerfd_settime", SetLastError = true)]
+        private static partial int Sys_TimerSetTime(TimerHandle handle, TimerFlag flags, in ITimerSpec newValue, out ITimerSpec oldValue);
+
+        /// <returns><c>0</c> on success, or <c>-1</c> on error and <c>errno</c> will be set (use <see cref="Marshal.GetLastWin32Error"/>)</returns>
+        [LibraryImport(_LIBC, EntryPoint = "read", SetLastError = true)]
+        private static partial int Sys_TimerGetTime(TimerHandle handle, out ulong expirations, int count);
+
+        /// <returns><c>0</c> on success, or <c>-1</c> on error and <c>errno</c> will be set (use <see cref="Marshal.GetLastWin32Error"/>)</returns>
+        [LibraryImport(_LIBC, EntryPoint = "close", SetLastError = true)]
+        private static partial int CloseTimer(IntPtr fdHandle);
     }
 }

--- a/OpenTabletDriver.Native/Linux/Xorg/XLib.cs
+++ b/OpenTabletDriver.Native/Linux/Xorg/XLib.cs
@@ -1,36 +1,45 @@
 using System;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+#nullable enable
 
 namespace OpenTabletDriver.Native.Linux.Xorg
 {
-    using Display = IntPtr;
-    using IntPtr = IntPtr;
-    using KeySym = IntPtr;
-    using Window = IntPtr;
-
-    public class XLib
+    public partial class XLib
     {
+        public abstract class XLibHandle() : SafeHandleZeroOrMinusOneIsInvalid(true)
+        {
+            protected override bool ReleaseHandle() => XCloseDisplay(handle) == 0;
+        }
+
+        public class XLibDisplayHandle : XLibHandle;
+        public class XLibWindowHandle : XLibHandle
+        {
+            protected override bool ReleaseHandle() => true; // nothing to clean up
+        }
+
         private const string libX11 = "libX11.so.6";
         private static object Lock = new object();
 
-        [DllImport(libX11, EntryPoint = "XOpenDisplay")]
-        private extern unsafe static IntPtr sys_XOpenDisplay(char* display);
-        public static unsafe IntPtr XOpenDisplay(char* display)
+        [LibraryImport(libX11, EntryPoint = "XOpenDisplay")]
+        private static partial XLibDisplayHandle sys_XOpenDisplay([MarshalAs(UnmanagedType.LPStr)] string? display);
+        public static XLibDisplayHandle XOpenDisplay(string? display)
         {
             lock (Lock)
                 return sys_XOpenDisplay(display);
         }
 
-        [DllImport(libX11, EntryPoint = "XCloseDisplay")]
-        public extern static int XCloseDisplay(IntPtr display);
+        [LibraryImport(libX11)]
+        private static partial int XCloseDisplay(IntPtr display);
 
-        [DllImport(libX11, EntryPoint = "XDefaultRootWindow")]
-        public static extern Window XDefaultRootWindow(Display display);
+        [LibraryImport(libX11)]
+        public static partial XLibWindowHandle XDefaultRootWindow(XLibDisplayHandle display);
 
-        [DllImport(libX11, EntryPoint = "XDisplayWidth")]
-        public static extern int XDisplayWidth(Display display, int screen_number);
+        [LibraryImport(libX11)]
+        public static partial int XDisplayWidth(XLibDisplayHandle display, int screen_number);
 
-        [DllImport(libX11, EntryPoint = "XDisplayHeight")]
-        public static extern int XDisplayHeight(Display display, int screen_number);
+        [LibraryImport(libX11)]
+        public static partial int XDisplayHeight(XLibDisplayHandle display, int screen_number);
     }
 }

--- a/OpenTabletDriver.Native/Linux/Xorg/XRandr.cs
+++ b/OpenTabletDriver.Native/Linux/Xorg/XRandr.cs
@@ -1,16 +1,17 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+#nullable enable
 
 namespace OpenTabletDriver.Native.Linux.Xorg
 {
-    using Display = IntPtr;
-    using Window = IntPtr;
-
-    public static class XRandr
+    public static partial class XRandr
     {
         private const string libXRandr = "libXrandr.so.2";
 
-        [DllImport(libXRandr, EntryPoint = "XRRGetMonitors")]
-        public unsafe extern static XRRMonitorInfo* XRRGetMonitors(Display dpy, Window window, bool get_active, out int nmonitors);
+        [LibraryImport(libXRandr, EntryPoint = "XRRGetMonitors")]
+        [return: MarshalUsing(CountElementName = "nmonitors")]
+        public static partial XRRMonitorInfo[] XRRGetMonitors(XLib.XLibDisplayHandle dpy, XLib.XLibWindowHandle window, [MarshalAs(UnmanagedType.Bool)] bool get_active, out int nmonitors);
     }
 }


### PR DESCRIPTION
This PR aims to refactor the OpenTabletDriver.Native Linux API to harden against developer mistakes. External function signatures have been double checked, and used types in function signatures have been improved (e.g. using handles instead of raw `IntPtr`s) or signatures have been improved (e.g. `ref` -> `in` where the destination function only needed `in` behavior) to help the compiler optimize more.

A breakdown of all the changes are described below:

- Adds editorconfig TODO for not making P/Invoke functions public
  - Reasoning: Potential plugin API security issue and it also makes the plugin API unclear (e.g. timers should not be used by plugins)
  - To reduce the scope of this PR this isn't entirely enabled yet, but is implemented for some of the native Linux operations.
- Adds editorconfig TODO for using `[LibraryImport]` over `[DllImport`]
  - As it builds marshalling code compile-time instead of at runtime, reducing (likely static) runtime overhead.

- Rewrites Linux native methods to use `[LibraryImport]`

- Rewrites native udev/uinput, XLib, XRandr, and Linux timer related stuff to use built-in handle wrapper classes
  - Related classes are rewritten to use these handles

- Added wrapper functions for Linux native unsafe contexts, so that the consumer (e.g. `EvdevVirtualTablet`) does not have to be unsafe itself.

- Drops usage of enabling event types to evdev endpoint, as upstream documentation states that the appropriate event types are automatically enabled when enabling event codes
  - The function enabling event types remains as to document that the function is generally not necessary to use

- Enables nullable reference types in touched classes

- Extensively documented the `Evdev` class