### PR TITLE
UGEE UE16: Add wheel definition

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/UGEE/UE16.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/UE16.json
@@ -13,7 +13,13 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 9
-    }
+    },
+    "Wheels": [
+      {
+        "RelativeWheelSteps": 24,
+        "ButtonCount": 0
+      }
+    ]
   },
   "DigitizerIdentifiers": [
     {


### PR DESCRIPTION
Assumed relative wheel steps based on other tablets using the same parser

Fixes #4511