### PR TITLE
Support InitReadTimeout attribute for device detection

### DIFF
--- a/OpenTabletDriver/Devices/DeviceReader.cs
+++ b/OpenTabletDriver/Devices/DeviceReader.cs
@@ -22,6 +22,7 @@ namespace OpenTabletDriver.Devices
         }
 
         private readonly Thread workerThread;
+        private readonly ManualResetEventSlim _firstReport = new ManualResetEventSlim(false);
         private bool initialized, connected;
 
         /// <summary>
@@ -137,7 +138,22 @@ namespace OpenTabletDriver.Devices
             }
         }
 
-        protected virtual void OnReport(T report) => Report?.Invoke(this, report);
+        /// <summary>
+        /// Waits for the first report to be received from the device.
+        /// </summary>
+        /// <param name="timeoutMs">Maximum time to wait in milliseconds.</param>
+        /// <returns>True if a report was received within the timeout, false otherwise.</returns>
+        public bool WaitForFirstReport(int timeoutMs)
+        {
+            return _firstReport.Wait(timeoutMs);
+        }
+
+        protected virtual void OnReport(T report)
+        {
+            _firstReport.Set();
+            Report?.Invoke(this, report);
+        }
+
         protected virtual void OnRawReport(T report) => RawReport?.Invoke(this, report);
 
         public void Dispose()
@@ -156,6 +172,7 @@ namespace OpenTabletDriver.Devices
             {
                 Connected = false;
                 ReportStream?.Dispose();
+                _firstReport.Dispose();
             }
 
             _isDisposed = true;

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -111,9 +111,24 @@ namespace OpenTabletDriver
                     if ((config.AuxiliaryDeviceIdentifiers?.Count ?? 0) > 0)
                     {
                         if (MatchDevice(config, config.AuxiliaryDeviceIdentifiers!) is InputDevice aux)
+                        {
                             devices.Add(aux);
+                        }
+                        else if (AnyIdentifierHasInitReadTimeout(config.AuxiliaryDeviceIdentifiers!))
+                        {
+                            // An auxiliary identifier with InitReadTimeout timed out, meaning
+                            // the device matched USB descriptors but no data arrived (e.g., a
+                            // wireless dongle without the tablet powered on). Reject the entire
+                            // tablet detection to avoid a false positive.
+                            Log.Write("Detect", $"Rejecting '{config.Name}': auxiliary device did not respond within timeout (dongle without tablet?).");
+                            foreach (var dev in devices)
+                                dev.Dispose();
+                            return null;
+                        }
                         else
+                        {
                             Log.Write("Detect", "Failed to find auxiliary device, express keys may be unavailable.", LogLevel.Warning);
+                        }
                     }
 
                     return new InputDeviceTree(config, devices);
@@ -159,7 +174,21 @@ namespace OpenTabletDriver
                 {
                     try
                     {
-                        return new InputDevice(this, dev, config, identifier);
+                        var device = new InputDevice(this, dev, config, identifier);
+
+                        if (identifier.Attributes?.TryGetValue("InitReadTimeout", out var timeoutStr) == true
+                            && int.TryParse(timeoutStr, out var timeoutMs)
+                            && timeoutMs > 0)
+                        {
+                            if (!device.WaitForFirstReport(timeoutMs))
+                            {
+                                device.Dispose();
+                                Log.Debug("Detect", $"Device matched descriptors for '{config.Name}' but no reports received within {timeoutMs}ms.");
+                                continue;
+                            }
+                        }
+
+                        return device;
                     }
                     catch (Exception ex)
                     {
@@ -168,6 +197,12 @@ namespace OpenTabletDriver
                 }
             }
             return null;
+        }
+
+        private static bool AnyIdentifierHasInitReadTimeout(IList<DeviceIdentifier> identifiers)
+        {
+            return identifiers.Any(id =>
+                id.Attributes?.ContainsKey("InitReadTimeout") == true);
         }
 
         private IEnumerable<IDeviceEndpoint> GetMatchingDevices(TabletConfiguration configuration, DeviceIdentifier identifier)


### PR DESCRIPTION
Some tablets connect through wireless dongles, those dongles stay physically plugged in via USB even when the tablet itself is powered off. Because the dongle's USB descriptors match the tablet configuration, OTD detects the tablet as present, but no data ever arrives, leaving the user with a false positive detection.

This adds support for an `InitReadTimeout` attribute on `DeviceIdentifier.Attributes`. When set, `MatchDevice()` waits up to the specified milliseconds for the first report after opening the endpoint. If no data arrives, the device is rejected. If the timed-out identifier is an auxiliary device, the entire tablet detection is rejected to avoid a partial match.

The signaling is implemented via a `ManualResetEventSlim` in `DeviceReader`, set on the first parsed report.

An upcoming update to the [WirelessKitAddon](https://github.com/juan-martinez-pf/WirelessKitAddon) plugin will build on this change to add automatic re-detection when a wireless tablet powers on after being initially rejected.