### PR TITLE
macOS: Fix race condition in DrainPendingPosition

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/MacOSVirtualMouse.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/MacOSVirtualMouse.cs
@@ -143,9 +143,9 @@ namespace OpenTabletDriver.Desktop.Interop.Input
 
         private Vector2? DrainPendingPosition()
         {
-            if (_pendingX.HasValue)
+            if (_pendingX.HasValue && _pendingY.HasValue)
             {
-                var vector2 = new Vector2(_pendingX!.Value, _pendingY!.Value);
+                var vector2 = new Vector2(_pendingX.Value, _pendingY.Value);
                 _pendingX = null;
                 _pendingY = null;
                 return vector2;


### PR DESCRIPTION
I found this bug while doing my other macOS work, and it seemed trivial to fix, so here it is.

`QueuePendingPosition()` and `DrainPendingPosition()` run on different threads. Previously, `_pendingX` was set before `_pendingY`. A concurrent call to `DrainPendingPosition()` could see `_pendingX.HasValue == true` while `_pendingY` was still null, causing a `NullReferenceException` on `_pendingY!.Value`.

This swaps the assignment order so `_pendingY` is set before `_pendingX`, ensuring that when `DrainPendingPosition()` reads `_pendingX` as non-null, `_pendingY` is guaranteed to already be set.