### PR TITLE
Huion H641P: Add roller support

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/H641P.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/H641P.json
@@ -13,14 +13,20 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    }
+    },
+    "Wheels": [
+      {
+        "RelativeWheelSteps": 12,
+        "ButtonCount": 0
+      }
+    ]
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 102,
       "InputReportLength": 12,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.InspiroyReportParser",
       "DeviceStrings": {
         "201": "HUION_T(21j|253)_\\d{6}$"
       },


### PR DESCRIPTION
Rollers can be abstracted as relative wheels.

`RelativeWheelSteps` are unconfirmed but based on confirmed values from #4631

No TABLETS.md change as the tablet is already reported supported.

Extends/depends on #4636

Fixes #4356