### PR TITLE
UX: Update Eto 2.5.11 -> 2.11.0

### DIFF
--- a/OpenTabletDriver.UX.Gtk/OpenTabletDriver.UX.Gtk.csproj
+++ b/OpenTabletDriver.UX.Gtk/OpenTabletDriver.UX.Gtk.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="NuGet Packages">
-    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.11" />
+    <PackageReference Include="Eto.Platform.Gtk" Version="2.11.0" />
   </ItemGroup>
 
   <ItemGroup Label="Project References">

--- a/OpenTabletDriver.UX.MacOS/OpenTabletDriver.UX.MacOS.csproj
+++ b/OpenTabletDriver.UX.MacOS/OpenTabletDriver.UX.MacOS.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup Label="NuGet Packages">
-    <PackageReference Include="Eto.Platform.Mac64" Version="2.5.10" />
+    <PackageReference Include="Eto.Platform.Mac64" Version="2.11.0" />
   </ItemGroup>
-  
+
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\OpenTabletDriver.UX\OpenTabletDriver.UX.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/OpenTabletDriver.UX.Wpf/OpenTabletDriver.UX.Wpf.csproj
+++ b/OpenTabletDriver.UX.Wpf/OpenTabletDriver.UX.Wpf.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Project Properties">
     <OutputType>WinExe</OutputType>
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="NuGet Packages">
-    <PackageReference Include="Eto.Platform.Wpf" Version="2.5.6" />
+    <PackageReference Include="Eto.Platform.Wpf" Version="2.11.0" />
   </ItemGroup>
 
   <ItemGroup Label="Project References">

--- a/OpenTabletDriver.UX/Controls/Placeholder.cs
+++ b/OpenTabletDriver.UX/Controls/Placeholder.cs
@@ -15,7 +15,7 @@ namespace OpenTabletDriver.UX.Controls
                 Items =
                 {
                     new StackLayoutItem(null, true),
-                    new Bitmap(App.Logo.WithSize(256, 256)),
+                    new Bitmap(App.Logo, 256, 256),
                     new StackLayoutItem
                     {
                         Control = label = new Label()

--- a/OpenTabletDriver.UX/OpenTabletDriver.UX.csproj
+++ b/OpenTabletDriver.UX/OpenTabletDriver.UX.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup Label="NuGet Packages">
-    <PackageReference Include="Eto.Forms" Version="2.5.10" />
+    <PackageReference Include="Eto.Forms" Version="2.11.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
   </ItemGroup>
   

--- a/OpenTabletDriver.UX/Windows/AboutWindow.cs
+++ b/OpenTabletDriver.UX/Windows/AboutWindow.cs
@@ -70,7 +70,7 @@ namespace OpenTabletDriver.UX.Windows
                 {
                     new ImageView
                     {
-                        Image = new Bitmap(App.Logo.WithSize(256, 256)),
+                        Image = new Bitmap(App.Logo, 256, 256),
                     },
                     new Label
                     {

--- a/OpenTabletDriver.UX/Windows/DeviceStringReader.cs
+++ b/OpenTabletDriver.UX/Windows/DeviceStringReader.cs
@@ -17,7 +17,7 @@ namespace OpenTabletDriver.UX.Windows
         {
             this.Title = "Device String Reader";
             this.Icon = App.Logo.WithSize(App.Logo.Size);
-            this.ClientSize = new Size(-1, 320);
+            this.ClientSize = new Size(400, 320);
 
             var sendRequestButton = new Button
             {

--- a/OpenTabletDriver.UX/Windows/Greeter/Pages/FAQPage.cs
+++ b/OpenTabletDriver.UX/Windows/Greeter/Pages/FAQPage.cs
@@ -12,7 +12,7 @@ namespace OpenTabletDriver.UX.Windows.Greeter.Pages
             this.Content = new StackedContent
             {
                 new PaddingSpacerItem(),
-                new Bitmap(App.Logo.WithSize(150, 150)),
+                new Bitmap(App.Logo, 150, 150),
                 new StylizedText("Wiki", SystemFonts.Bold(12), new Padding(0, 0, 0, 8)),
                 "If you have any issues, check out the Wiki.",
                 "This can be found under the Help menu in the main window.",

--- a/OpenTabletDriver.UX/Windows/Greeter/Pages/PluginPage.cs
+++ b/OpenTabletDriver.UX/Windows/Greeter/Pages/PluginPage.cs
@@ -12,7 +12,7 @@ namespace OpenTabletDriver.UX.Windows.Greeter.Pages
             this.Content = new StackedContent
             {
                 new PaddingSpacerItem(),
-                new Bitmap(App.Logo.WithSize(150, 150)),
+                new Bitmap(App.Logo, 150, 150),
                 new StylizedText("Plugins", SystemFonts.Bold(12), new Padding(0, 0, 0, 8)),
                 "Plugins can be downloaded from the plugin manager at your own risk.",
                 "The plugin manager can be found in the Plugins menu in the main window.",

--- a/OpenTabletDriver.UX/Windows/Greeter/Pages/SystemTrayPage.cs
+++ b/OpenTabletDriver.UX/Windows/Greeter/Pages/SystemTrayPage.cs
@@ -12,7 +12,7 @@ namespace OpenTabletDriver.UX.Windows.Greeter.Pages
             this.Content = new StackedContent
             {
                 new PaddingSpacerItem(),
-                new Bitmap(App.Logo.WithSize(150, 150)),
+                new Bitmap(App.Logo, 150, 150),
                 new StylizedText("System Tray", SystemFonts.Bold(12), new Padding(0, 0, 0, 8)),
                 "When minimized, OpenTabletDriver will run in the background.",
                 "The window can be restored from the system tray.",

--- a/OpenTabletDriver.UX/Windows/Greeter/Pages/WelcomePage.cs
+++ b/OpenTabletDriver.UX/Windows/Greeter/Pages/WelcomePage.cs
@@ -12,7 +12,7 @@ namespace OpenTabletDriver.UX.Windows.Greeter.Pages
             this.Content = new StackedContent
             {
                 new PaddingSpacerItem(),
-                new Bitmap(App.Logo.WithSize(256, 256)),
+                new Bitmap(App.Logo, 256, 256),
                 new StylizedText("OpenTabletDriver Guide", SystemFonts.Bold(12), new Padding(0, 0, 0, 10)),
                 "Welcome to OpenTabletDriver!",
                 "OpenTabletDriver is an open source, cross platform, user mode tablet driver.",

--- a/OpenTabletDriver.UX/Windows/Updater/UpdaterWindow.cs
+++ b/OpenTabletDriver.UX/Windows/Updater/UpdaterWindow.cs
@@ -48,7 +48,7 @@ namespace OpenTabletDriver.UX.Windows.Updater
                     Items =
                     {
                         new PaddingSpacerItem(),
-                        new Bitmap(App.Logo.WithSize(256, 256)),
+                        new Bitmap(App.Logo, 256, 256),
                         "An update is available to install",
                         $"OpenTabletDriver v{updateAvailable.Version}",
                         new PaddingSpacerItem(),


### PR DESCRIPTION
Breaks some Eto auto sizing, which has been updated to no longer autosize (device string reader)

Also breaks some `Logo.WithSize()` invocations which have been fixed

Also requested in PR #4075 for macOS only.

Supersedes #3655 and this time doesn't have the same quirks on Linux as described there.

Could get into v0.6.7 if we're daring.

Needs testing on:

- [ ] Windows

Assumed working on macOS due to #4075 existing

macOS might behave unexpectedly if #4075 is merged and it's not properly tested.