### PR TITLE
Huion Q620M: Add wheel rotation support

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/Q620M.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Q620M.json
@@ -13,7 +13,13 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    }
+    },
+    "Wheels": [
+      {
+        "RelativeWheelSteps": 24,
+        "ButtonCount": 1
+      }
+    ]
   },
   "DigitizerIdentifiers": [
     {

--- a/OpenTabletDriver.Configurations/Configurations/Huion/Q620M.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Q620M.json
@@ -17,7 +17,7 @@
     "Wheels": [
       {
         "RelativeWheelSteps": 24,
-        "ButtonCount": 1
+        "ButtonCount": 0
       }
     ]
   },

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -271,7 +271,7 @@
 | Huion Kamvas Pro 22 (2019)         |  Missing Features | Touch bar is not yet supported.
 | Huion Kamvas Pro 24                |  Missing Features | Touch bar is not yet supported.
 | Huion Kamvas Pro 24 (Gen 3)        |  Missing Features | Touch is not yet supported.
-| Huion Q620M                        |  Missing Features | Wheel is not yet supported.
+| Huion Q620M                        |  Missing Features | Wheel button is not yet supported.
 | Huion Q630M                        |  Missing Features | Dials/Wheels are not yet supported.
 | Huion RTM-500                      |  Missing Features | Touch bar is not yet supported.
 | Huion RTP-700                      |  Missing Features | Touch bar is not yet supported.


### PR DESCRIPTION
Wheel button remains unimplemented as this seems to emit alongside aux reports and needs a tablet data recording.

Should work fine based on data provided in #2726

Step count is unconfirmed. Remote sibling tablets like #4631 only has `12` steps as opposed to the current number of `24` stated here, though they use a roller than this tablets actual wheel.

Fixes wheel rotation as requested in #2726, but does not fix the issue entirely.

Note that the button count is already set to 1 despite not being implemented, as the tablet does have a button, but it is not parsed correctly yet.