### PR TITLE
Fix macOS crash when switching profiles with wheel tablets

### DIFF
--- a/OpenTabletDriver.UX/Controls/ControlPanel.cs
+++ b/OpenTabletDriver.UX/Controls/ControlPanel.cs
@@ -182,7 +182,11 @@ namespace OpenTabletDriver.UX.Controls
                     wheelBindingEditor.ProfileBinding.Bind(ProfileBinding);
                     var pageIndex = tabControl.Pages.IndexOf(mouseBindingEditor.Parent as TabPage);
                     wheelBindingEditors.Add(wheelBindingEditor);
-                    tabControl.Pages.Insert(pageIndex, new TabPage(wheelBindingEditor) { Text = $"Wheel {i + 1} Bindings" });
+                    var wheelPage = new TabPage(wheelBindingEditor) { Text = $"Wheel {i + 1} Bindings" };
+                    if (pageIndex >= 0)
+                        tabControl.Pages.Insert(pageIndex, wheelPage);
+                    else
+                        tabControl.Pages.Add(wheelPage);
                 }
             }
         }


### PR DESCRIPTION
Fixes an ArgumentOutOfRangeException crash on macOS when connect to a tablet with a wheel (e.g., PTH-451 / Intuos5)
- This only affected the UX, not the daemon.
- On macOS, `Pages.Clear()` in `OnProfileChanged` _clears_ tab pages, so IndexOf returns -1 on the next call to `OnTabletChanged`, causing Insert(-1, ...) to throw
- This guards against the -1 index by falling back to Pages.Add()
- Final page order is unaffected since macOS rebuilds it via SetPageVisibility