### PR TITLE
Wacom PTH-450: Was misconfigured as Intous4, is Intuos5

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-450.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-450.json
@@ -13,6 +13,19 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
+    },
+    "Wheels": [
+      {
+        "AbsoluteWheelMax": 71,
+        "AngleOfZeroReading": 180.0,
+        "ButtonCount": 1
+      }
+    ],
+    "Touch": {
+      "Width": 157.48,
+      "Height": 98.425,
+      "MaxX": 4095,
+      "MaxY": 4095
     }
   },
   "DigitizerIdentifiers": [
@@ -20,7 +33,7 @@
       "VendorID": 1386,
       "ProductID": 38,
       "InputReportLength": 10,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosPro.IntuosProReportParser",
       "FeatureInitReport": [
         "AgI="
       ]
@@ -29,7 +42,7 @@
       "VendorID": 1386,
       "ProductID": 38,
       "InputReportLength": 11,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosPro.WacomDriverIntuosProReportParser",
       "FeatureInitReport": [
         "AgI="
       ]

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-650.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-650.json
@@ -13,6 +13,19 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
+    },
+    "Wheels": [
+      {
+        "AbsoluteWheelMax": 71,
+        "AngleOfZeroReading": 180.0,
+        "ButtonCount": 1
+      }
+    ],
+    "Touch": {
+      "Width": 223.52,
+      "Height": 139.7,
+      "MaxX": 4095,
+      "MaxY": 4095
     }
   },
   "DigitizerIdentifiers": [
@@ -20,7 +33,7 @@
       "VendorID": 1386,
       "ProductID": 39,
       "InputReportLength": 10,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosPro.IntuosProReportParser",
       "FeatureInitReport": [
         "AgI="
       ]
@@ -29,7 +42,7 @@
       "VendorID": 1386,
       "ProductID": 39,
       "InputReportLength": 11,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosPro.WacomDriverIntuosProReportParser",
       "FeatureInitReport": [
         "AgI="
       ]

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-850.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-850.json
@@ -13,6 +13,19 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
+    },
+    "Wheels": [
+      {
+        "AbsoluteWheelMax": 71,
+        "AngleOfZeroReading": 180.0,
+        "ButtonCount": 1
+      }
+    ],
+    "Touch": {
+      "Width": 325.12,
+      "Height": 203.2,
+      "MaxX": 4095,
+      "MaxY": 4095
     }
   },
   "DigitizerIdentifiers": [
@@ -20,7 +33,7 @@
       "VendorID": 1386,
       "ProductID": 40,
       "InputReportLength": 10,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosPro.IntuosProReportParser",
       "FeatureInitReport": [
         "AgI="
       ]
@@ -29,7 +42,7 @@
       "VendorID": 1386,
       "ProductID": 40,
       "InputReportLength": 11,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosPro.WacomDriverIntuosProReportParser",
       "FeatureInitReport": [
         "AgI="
       ]

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-450.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-450.json
@@ -13,14 +13,21 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    }
+    },
+    "Wheels": [
+      {
+        "AbsoluteWheelMax": 71,
+        "AngleOfZeroReading": 180.0,
+        "ButtonCount": 1
+      }
+    ]
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 41,
       "InputReportLength": 10,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosPro.IntuosProReportParser",
       "FeatureInitReport": [
         "AgI="
       ]
@@ -29,7 +36,7 @@
       "VendorID": 1386,
       "ProductID": 41,
       "InputReportLength": 11,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Wacom64bAuxReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosPro.WacomDriverIntuosProReportParser",
       "FeatureInitReport": [
         "AgI="
       ]

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-650.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-650.json
@@ -13,14 +13,21 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    }
+    },
+    "Wheels": [
+      {
+        "AbsoluteWheelMax": 71,
+        "AngleOfZeroReading": 180.0,
+        "ButtonCount": 1
+      }
+    ]
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 42,
       "InputReportLength": 10,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.IntuosV1ReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosPro.IntuosProReportParser",
       "FeatureInitReport": [
         "AgI="
       ]
@@ -29,7 +36,7 @@
       "VendorID": 1386,
       "ProductID": 42,
       "InputReportLength": 11,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1.WacomDriverIntuosV1ReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosPro.WacomDriverIntuosProReportParser",
       "FeatureInitReport": [
         "AgI="
       ]

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -135,6 +135,7 @@
 | Wacom GD-1212-U                    |     Supported     |
 | Wacom GD-1218-U                    |     Supported     |
 | Wacom Cintiq 18SX (PL-800-U)       |     Supported     |
+| Wacom PTH-450                      |     Supported     |
 | Wacom PTH-451                      |     Supported     |
 | Wacom PTH-651                      |     Supported     |
 | Wacom PTH-851                      |     Supported     |
@@ -309,7 +310,6 @@
 | Wacom Cintiq 22HD (DTK-2200)       |  Missing Features | Touch Strips are not yet supported.
 | Wacom Cintiq 12WX (DTZ-1200W)      |  Missing Features | Touch bars and top side buttons are not yet supported.
 | Wacom MTE-450                      |  Missing Features | Wheel is not yet supported.
-| Wacom PTH-450                      |  Missing Features | Wheel is not yet supported.
 | Wacom PTH-650                      |  Missing Features | Wheel is not yet supported.
 | Wacom PTH-850                      |  Missing Features | Wheel is not yet supported.
 | Wacom PTK-450                      |  Missing Features | Wheel is not yet supported.

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -137,12 +137,16 @@
 | Wacom Cintiq 18SX (PL-800-U)       |     Supported     |
 | Wacom PTH-450                      |     Supported     |
 | Wacom PTH-451                      |     Supported     |
+| Wacom PTH-650                      |     Supported     |
 | Wacom PTH-651                      |     Supported     |
+| Wacom PTH-850                      |     Supported     |
 | Wacom PTH-851                      |     Supported     |
 | Wacom PTK-440                      |     Supported     |
+| Wacom PTK-450                      |     Supported     |
 | Wacom PTK-470                      |     Supported     |
 | Wacom PTK-540WL                    |     Supported     |
 | Wacom PTK-640                      |     Supported     |
+| Wacom PTK-650                      |     Supported     |
 | Wacom PTK-670                      |     Supported     |
 | Wacom PTK-840                      |     Supported     |
 | Wacom PTK-870                      |     Supported     |
@@ -310,10 +314,6 @@
 | Wacom Cintiq 22HD (DTK-2200)       |  Missing Features | Touch Strips are not yet supported.
 | Wacom Cintiq 12WX (DTZ-1200W)      |  Missing Features | Touch bars and top side buttons are not yet supported.
 | Wacom MTE-450                      |  Missing Features | Wheel is not yet supported.
-| Wacom PTH-650                      |  Missing Features | Wheel is not yet supported.
-| Wacom PTH-850                      |  Missing Features | Wheel is not yet supported.
-| Wacom PTK-450                      |  Missing Features | Wheel is not yet supported.
-| Wacom PTK-650                      |  Missing Features | Wheel is not yet supported.
 | Wacom PTZ-1230                     |  Missing Features | Touch bars are not yet supported.
 | Wacom PTZ-1231W                    |  Missing Features | Touch bars are not yet supported.
 | Wacom PTZ-431W                     |  Missing Features | Touch bars are not yet supported.


### PR DESCRIPTION
Add wheel, touch, and correct report parser support to the `PTH-450` configuration, matching its sibling `PTH-451` (already in the repo).

The PTH-450 is an Intuos5 Touch tablet and was previously misconfigured as an Intuos4 without wheel or touch specs.

Tested and did not cause issues with having a previously misconfigured `settings.json`.