### PR TITLE
Fix locked cursor handling in relative mode on macOS

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/Relative/MacOSRelativePointer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Relative/MacOSRelativePointer.cs
@@ -11,6 +11,8 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Relative
 
     public class MacOSRelativePointer : MacOSVirtualMouse, IRelativePointer
     {
+        private Vector2 error;
+
         public void SetPosition(Vector2 delta)
         {
             QueuePendingPosition(delta.X, delta.Y);
@@ -18,9 +20,17 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Relative
 
         protected override void SetPendingPosition(IntPtr mouseEvent, float x, float y)
         {
-            CGEventSetLocation(mouseEvent, GetCursorPosition() + new CGPoint(x, y));
-            CGEventSetDoubleValueField(mouseEvent, CGEventField.mouseEventDeltaX, x);
-            CGEventSetDoubleValueField(mouseEvent, CGEventField.mouseEventDeltaY, y);
+            var pos = GetCursorPosition();
+            if (CGCursorIsVisible())
+                CGEventSetLocation(mouseEvent, pos + new CGPoint(x, y));
+            else
+                CGEventSetLocation(mouseEvent, pos);
+
+            Vector2 delta = new Vector2(x, y) + error;
+            error = new Vector2(delta.X % 1, delta.Y % 1);
+
+            CGEventSetDoubleValueField(mouseEvent, CGEventField.mouseEventDeltaX, Math.Truncate(delta.X));
+            CGEventSetDoubleValueField(mouseEvent, CGEventField.mouseEventDeltaY, Math.Truncate(delta.Y));
         }
 
         protected override void ResetPendingPosition(IntPtr mouseEvent)

--- a/OpenTabletDriver.Native/OSX/OSX.cs
+++ b/OpenTabletDriver.Native/OSX/OSX.cs
@@ -55,6 +55,9 @@ namespace OpenTabletDriver.Native.OSX
         public extern static void CGEventSetLocation(CGEventRef eventRef, CGPoint location);
 
         [DllImport(Quartz)]
+        public extern static bool CGCursorIsVisible();
+
+        [DllImport(Quartz)]
         public extern static CGEventRef CGEventCreateScrollWheelEvent2(CGEventRef eventRef, CGScrollEventUnit units, uint wheelCount, int wheel1, int wheel2, int wheel3);
 
         [DllImport(Quartz)]

--- a/OpenTabletDriver.Native/OSX/OSX.cs
+++ b/OpenTabletDriver.Native/OSX/OSX.cs
@@ -54,6 +54,10 @@ namespace OpenTabletDriver.Native.OSX
         [DllImport(Quartz)]
         public extern static void CGEventSetLocation(CGEventRef eventRef, CGPoint location);
 
+        /// <remarks>
+        /// Upstream has marked this function as deprecated with no replacement:
+        /// <a href="https://developer.apple.com/documentation/coregraphics/cgcursorisvisible()">developer.apple.com</a>
+        /// </remarks>
         [DllImport(Quartz)]
         public extern static bool CGCursorIsVisible();
 


### PR DESCRIPTION
This fixes cursor bumping into the edges of the screen when playing games because it's not recentered by the game explicitly, and also fixes the delta being very quantized

I don't know if this also happens on other platforms, but with these changes it works perfectly on macOS