### PR TITLE
Add support for rotation parsing and output

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-450.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-450.json
@@ -9,6 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 2047,
+      "MinRotation": -900,
+      "MaxRotation": 899,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-451.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-451.json
@@ -9,6 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 2047,
+      "MinRotation": -900,
+      "MaxRotation": 899,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-460.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-460.json
@@ -9,7 +9,7 @@
     },
     "Pen": {
       "MaxPressure": 8191,
-      "MaxRotation": 2047,
+      "MaxRotation": 1799,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-460.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-460.json
@@ -9,7 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 8191,
-      "MaxRotation": 1799,
+      "MinRotation": -899,
+      "MaxRotation": 900,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-460.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-460.json
@@ -9,6 +9,7 @@
     },
     "Pen": {
       "MaxPressure": 8191,
+      "MaxRotation": 2047,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-650.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-650.json
@@ -9,6 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 2047,
+      "MinRotation": -900,
+      "MaxRotation": 899,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-651.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-651.json
@@ -9,6 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 2047,
+      "MinRotation": -900,
+      "MaxRotation": 899,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-660.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-660.json
@@ -9,7 +9,7 @@
     },
     "Pen": {
       "MaxPressure": 8191,
-      "MaxRotation": 2047,
+      "MaxRotation": 1799,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-660.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-660.json
@@ -9,7 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 8191,
-      "MaxRotation": 1799,
+      "MinRotation": -899,
+      "MaxRotation": 900,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-660.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-660.json
@@ -9,6 +9,7 @@
     },
     "Pen": {
       "MaxPressure": 8191,
+      "MaxRotation": 2047,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-850.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-850.json
@@ -9,6 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 2047,
+      "MinRotation": -900,
+      "MaxRotation": 899,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-851.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-851.json
@@ -9,6 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 2047,
+      "MinRotation": -900,
+      "MaxRotation": 899,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-860.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-860.json
@@ -9,7 +9,7 @@
     },
     "Pen": {
       "MaxPressure": 8191,
-      "MaxRotation": 2047,
+      "MaxRotation": 1799,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-860.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-860.json
@@ -9,7 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 8191,
-      "MaxRotation": 1799,
+      "MinRotation": -899,
+      "MaxRotation": 900,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-860.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTH-860.json
@@ -9,6 +9,7 @@
     },
     "Pen": {
       "MaxPressure": 8191,
+      "MaxRotation": 2047,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-1240.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-1240.json
@@ -9,6 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 2047,
+      "MinRotation": -900,
+      "MaxRotation": 899,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-440.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-440.json
@@ -9,6 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 2047,
+      "MinRotation": -900,
+      "MaxRotation": 899,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-450.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-450.json
@@ -9,6 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 2047,
+      "MinRotation": -900,
+      "MaxRotation": 899,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-470.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-470.json
@@ -9,6 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 8191,
+      "MinRotation": -900,
+      "MaxRotation": 898,
       "ButtonCount": 3
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-540WL.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-540WL.json
@@ -9,6 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 2047,
+      "MinRotation": -900,
+      "MaxRotation": 899,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-640.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-640.json
@@ -9,6 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 2047,
+      "MinRotation": -900,
+      "MaxRotation": 899,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-650.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-650.json
@@ -9,6 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 2047,
+      "MinRotation": -900,
+      "MaxRotation": 899,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-670.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-670.json
@@ -9,6 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 8191,
+      "MinRotation": -900,
+      "MaxRotation": 898,
       "ButtonCount": 3
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-840.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-840.json
@@ -9,6 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 2047,
+      "MinRotation": -900,
+      "MaxRotation": 899,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-870.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTK-870.json
@@ -9,6 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 8191,
+      "MinRotation": -900,
+      "MaxRotation": 898,
       "ButtonCount": 3
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-1230.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-1230.json
@@ -9,6 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 2046,
+      "MinRotation": -900,
+      "MaxRotation": 899,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-1231W.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-1231W.json
@@ -9,6 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 2046,
+      "MinRotation": -900,
+      "MaxRotation": 899,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-430.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-430.json
@@ -9,6 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 2046,
+      "MinRotation": -900,
+      "MaxRotation": 899,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-431W.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-431W.json
@@ -9,6 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 2046,
+      "MinRotation": -900,
+      "MaxRotation": 899,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-630.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-630.json
@@ -9,6 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 2046,
+      "MinRotation": -900,
+      "MaxRotation": 899,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-631W.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-631W.json
@@ -9,6 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 2046,
+      "MinRotation": -900,
+      "MaxRotation": 899,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-930.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/PTZ-930.json
@@ -9,6 +9,8 @@
     },
     "Pen": {
       "MaxPressure": 2046,
+      "MinRotation": -900,
+      "MaxRotation": 899,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/CintiqV1/CintiqV1ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/CintiqV1/CintiqV1ReportParser.cs
@@ -27,9 +27,9 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.CintiqV1
             if (report[1] == 0x80)
                 return new OutOfRangeReport(report);
             if (report[1].IsBitSet(1) && report[1].IsBitSet(3))
-                return new IntuosV1RotationReport(report, ref _prevPressure, ref _prevTilt, ref _prevPenButtons);
+                return new IntuosV1RotationReport(report, ref _prevPressure, ref _prevTilt, ref _prevRotation, ref _prevPenButtons);
             if (report[1].IsBitSet(5))
-                return new IntuosV1TabletReport(report, ref _prevPressure, ref _prevTilt, ref _prevPenButtons);
+                return new IntuosV1TabletReport(report, ref _prevPressure, ref _prevTilt, ref _prevRotation, ref _prevPenButtons);
             else if (report[1] == 0xC2)
                 return new IntuosV1ToolReport(report);
 
@@ -38,6 +38,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.CintiqV1
 
         private uint _prevPressure;
         private Vector2 _prevTilt;
+        private int _prevRotation;
         private bool[] _prevPenButtons = Array.Empty<bool>();
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3ExtraAuxReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3ExtraAuxReportParser.cs
@@ -14,7 +14,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3
             return data[0] switch
             {
                 0x02 => GetToolReport(data),
-                0x10 => new IntuosV1TabletReport(data, ref _prevPressure, ref _prevTilt, ref _prevPenButtons),
+                0x10 => new IntuosV1TabletReport(data, ref _prevPressure, ref _prevTilt, ref _prevRotation, ref _prevPenButtons),
                 0x03 => new IntuosV1AuxReport(data),
                 0x0C => new Intuos3ExtraAuxReport(data),
                 _ => new DeviceReport(data)
@@ -24,9 +24,9 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3
         private IDeviceReport GetToolReport(byte[] data)
         {
             if (data[1] == 0xEA || data[1] == 0xAA)
-                return new IntuosV1RotationReport(data, ref _prevPressure, ref _prevTilt, ref _prevPenButtons);
+                return new IntuosV1RotationReport(data, ref _prevPressure, ref _prevTilt, ref _prevRotation, ref _prevPenButtons);
             if ((data[1] & 0xF0) == 0xE0 || (data[1] & 0xF0) == 0xA0)
-                return new IntuosV1TabletReport(data, ref _prevPressure, ref _prevTilt, ref _prevPenButtons);
+                return new IntuosV1TabletReport(data, ref _prevPressure, ref _prevTilt, ref _prevRotation, ref _prevPenButtons);
             if ((data[1] & 0xF0) == 0xF0 || (data[1] & 0xF0) == 0xB0)
                 return new Intuos3MouseReport(data);
             if (data[1] == 0xC2)
@@ -37,6 +37,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3
 
         private uint _prevPressure;
         private Vector2 _prevTilt;
+        private int _prevRotation;
         private bool[] _prevPenButtons = Array.Empty<bool>();
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3ReportParser.cs
@@ -14,7 +14,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3
             return data[0] switch
             {
                 0x02 => GetToolReport(data),
-                0x10 => new IntuosV1TabletReport(data, ref _prevPressure, ref _prevTilt, ref _prevPenButtons),
+                0x10 => new IntuosV1TabletReport(data, ref _prevPressure, ref _prevTilt, ref _prevRotation, ref _prevPenButtons),
                 0x03 => new IntuosV1AuxReport(data),
                 0x0C => new Intuos3AuxReport(data),
                 _ => new DeviceReport(data)
@@ -24,9 +24,9 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3
         private IDeviceReport GetToolReport(byte[] data)
         {
             if (data[1] == 0xEA || data[1] == 0xAA)
-                return new IntuosV1RotationReport(data, ref _prevPressure, ref _prevTilt, ref _prevPenButtons);
+                return new IntuosV1RotationReport(data, ref _prevPressure, ref _prevTilt, ref _prevRotation, ref _prevPenButtons);
             if ((data[1] & 0xF0) == 0xE0 || (data[1] & 0xF0) == 0xA0)
-                return new IntuosV1TabletReport(data, ref _prevPressure, ref _prevTilt, ref _prevPenButtons);
+                return new IntuosV1TabletReport(data, ref _prevPressure, ref _prevTilt, ref _prevRotation, ref _prevPenButtons);
             if ((data[1] & 0xF0) == 0xF0 || (data[1] & 0xF0) == 0xB0)
                 return new Intuos3MouseReport(data);
             if (data[1] == 0xC2)
@@ -37,6 +37,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3
 
         private uint _prevPressure;
         private Vector2 _prevTilt;
+        private int _prevRotation;
         private bool[] _prevPenButtons = Array.Empty<bool>();
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1ReportParser.cs
@@ -26,9 +26,9 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1
             if (report[1] == 0x80)
                 return new OutOfRangeReport(report);
             if (report[1].IsBitSet(1) && report[1].IsBitSet(3))
-                return new IntuosV1RotationReport(report, ref _prevPressure, ref _prevTilt, ref _prevPenButtons);
+                return new IntuosV1RotationReport(report, ref _prevPressure, ref _prevTilt, ref _prevRotation, ref _prevPenButtons);
             if (report[1].IsBitSet(5))
-                return new IntuosV1TabletReport(report, ref _prevPressure, ref _prevTilt, ref _prevPenButtons);
+                return new IntuosV1TabletReport(report, ref _prevPressure, ref _prevTilt, ref _prevRotation, ref _prevPenButtons);
             else if (report[1] == 0xC2)
                 return new IntuosV1ToolReport(report);
 
@@ -37,6 +37,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1
 
         private uint _prevPressure;
         private Vector2 _prevTilt;
+        private int _prevRotation;
         private bool[] _prevPenButtons = Array.Empty<bool>();
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1RotationReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1RotationReport.cs
@@ -3,9 +3,9 @@ using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1
 {
-    public struct IntuosV1RotationReport : ITabletReport, IProximityReport, ITiltReport
+    public struct IntuosV1RotationReport : ITabletReport, IProximityReport, ITiltReport, IRotationReport
     {
-        public IntuosV1RotationReport(byte[] report, ref uint _prevPressure, ref Vector2 _prevTilt, ref bool[] _prevPenButtons)
+        public IntuosV1RotationReport(byte[] report, ref uint _prevPressure, ref Vector2 _prevTilt, ref int _prevRotation, ref bool[] _prevPenButtons)
         {
             Raw = report;
 
@@ -20,6 +20,11 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1
             PenButtons = _prevPenButtons;
             NearProximity = report[1].IsBitSet(6);
             HoverDistance = (uint)report[9];
+
+            Rotation = (report[6] << 2) | ((report[7] & 0xC0) >> 6);
+            if (!report[7].IsBitSet(5)) Rotation *= -1;
+
+            _prevRotation = Rotation;
         }
 
         public byte[] Raw { set; get; }
@@ -29,5 +34,6 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1
         public bool[] PenButtons { set; get; }
         public bool NearProximity { set; get; }
         public uint HoverDistance { set; get; }
+        public int Rotation { set; get; }
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1TabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1TabletReport.cs
@@ -3,9 +3,9 @@ using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1
 {
-    public struct IntuosV1TabletReport : ITabletReport, IProximityReport, ITiltReport
+    public struct IntuosV1TabletReport : ITabletReport, IProximityReport, ITiltReport, IRotationReport
     {
-        public IntuosV1TabletReport(byte[] report, ref uint _prevPressure, ref Vector2 _prevTilt, ref bool[] _prevPenButtons)
+        public IntuosV1TabletReport(byte[] report, ref uint _prevPressure, ref Vector2 _prevTilt, ref int _prevRotation, ref bool[] _prevPenButtons)
         {
             Raw = report;
 
@@ -35,6 +35,8 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1
             _prevPressure = Pressure;
             _prevTilt = Tilt;
             _prevPenButtons = PenButtons;
+
+            Rotation = _prevRotation;
         }
 
         public byte[] Raw { set; get; }
@@ -44,5 +46,6 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1
         public bool[] PenButtons { set; get; }
         public bool NearProximity { set; get; }
         public uint HoverDistance { set; get; }
+        public int Rotation { set; get; }
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2Report.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2Report.cs
@@ -32,8 +32,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
             NearProximity = report[1].IsBitSet(5);
             HoverDistance = report[16];
 
-            const uint MAX_ROTATION = 2047;
-            Rotation = (double)(report[12] | ((report[13] & 0x07) << 8)) / MAX_ROTATION * 360;
+            Rotation = report[12] | ((report[13] & 0x07) << 8);
         }
 
         public byte[] Raw { set; get; }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2Report.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2Report.cs
@@ -32,11 +32,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
             NearProximity = report[1].IsBitSet(5);
             HoverDistance = report[16];
 
-            var rawRotation = (short)(report[12] | (report[13] << 8));
-            // range is from -899 to 900, offset by 899 to get positive only
-            // supported by input-wacom (though they define it as -900 to 899 because they subtract 1 in the parsing for some reason)
-            // https://github.com/linuxwacom/input-wacom/blob/09bc480a02d2f26390eefeb7ef7472b562239460/4.18/wacom_wac.c#L3917
-            Rotation = (uint)(rawRotation + 899);
+            Rotation = Unsafe.ReadUnaligned<short>(ref report[12]);
         }
 
         public byte[] Raw { set; get; }
@@ -47,6 +43,6 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
         public bool[] PenButtons { set; get; }
         public bool NearProximity { set; get; }
         public uint HoverDistance { set; get; }
-        public uint Rotation { set; get; }
+        public int Rotation { set; get; }
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2Report.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2Report.cs
@@ -32,7 +32,11 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
             NearProximity = report[1].IsBitSet(5);
             HoverDistance = report[16];
 
-            Rotation = (uint)(report[12] | ((report[13] & 0x07) << 8));
+            var rawRotation = (short)(report[12] | (report[13] << 8));
+            // range is from -899 to 900, offset by 899 to get positive only
+            // supported by input-wacom (though they define it as -900 to 899 because they subtract 1 in the parsing for some reason)
+            // https://github.com/linuxwacom/input-wacom/blob/09bc480a02d2f26390eefeb7ef7472b562239460/4.18/wacom_wac.c#L3917
+            Rotation = (uint)(rawRotation + 899);
         }
 
         public byte[] Raw { set; get; }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2Report.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2Report.cs
@@ -32,7 +32,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
             NearProximity = report[1].IsBitSet(5);
             HoverDistance = report[16];
 
-            Rotation = report[12] | ((report[13] & 0x07) << 8);
+            Rotation = (uint)(report[12] | ((report[13] & 0x07) << 8));
         }
 
         public byte[] Raw { set; get; }
@@ -43,6 +43,6 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
         public bool[] PenButtons { set; get; }
         public bool NearProximity { set; get; }
         public uint HoverDistance { set; get; }
-        public double Rotation { set; get; }
+        public uint Rotation { set; get; }
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2Report.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2Report.cs
@@ -4,7 +4,7 @@ using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
 {
-    public struct IntuosV2Report : ITabletReport, IProximityReport, ITiltReport, IEraserReport
+    public struct IntuosV2Report : ITabletReport, IProximityReport, ITiltReport, IEraserReport, IRotationReport
     {
         public IntuosV2Report(byte[] report)
         {
@@ -31,6 +31,9 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
             ];
             NearProximity = report[1].IsBitSet(5);
             HoverDistance = report[16];
+
+            const uint MAX_ROTATION = 2047;
+            Rotation = (double)(report[12] | ((report[13] & 0x07) << 8)) / MAX_ROTATION * 360;
         }
 
         public byte[] Raw { set; get; }
@@ -41,5 +44,6 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
         public bool[] PenButtons { set; get; }
         public bool NearProximity { set; get; }
         public uint HoverDistance { set; get; }
+        public double Rotation { set; get; }
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV3/IntuosV3ExtendedReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV3/IntuosV3ExtendedReport.cs
@@ -4,7 +4,7 @@ using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV3
 {
-    public struct IntuosV3ExtendedReport : ITabletReport, IProximityReport, ITiltReport, IEraserReport
+    public struct IntuosV3ExtendedReport : ITabletReport, IProximityReport, ITiltReport, IEraserReport, IRotationReport
     {
         public IntuosV3ExtendedReport(byte[] report)
         {
@@ -34,6 +34,8 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV3
             Eraser = report[2].IsBitSet(5);
             NearProximity = report[2].IsBitSet(6);
             HoverDistance = report[19];
+
+            Rotation = Unsafe.ReadUnaligned<short>(ref report[15]);
         }
 
         public byte[] Raw { set; get; }
@@ -44,5 +46,6 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV3
         public bool NearProximity { set; get; }
         public uint HoverDistance { set; get; }
         public bool Eraser { get; set; }
+        public int Rotation { set; get; }
     }
 }

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -266,6 +266,7 @@ namespace OpenTabletDriver.Daemon
 
                         outputMode.DisablePressure = profile.BindingSettings.DisablePressure;
                         outputMode.DisableTilt = profile.BindingSettings.DisableTilt;
+                        outputMode.DisableRotation = profile.BindingSettings.DisableRotation;
                     }
                 }
 
@@ -293,6 +294,12 @@ namespace OpenTabletDriver.Daemon
                 Resynchronize?.Invoke(this, EventArgs.Empty);
                 return Task.CompletedTask;
             }
+        }
+
+        private static void LogRotationState(string group, Profile profile)
+        {
+            Log.Write(group,
+                $"Rotation: {(profile.BindingSettings.DisableRotation ? "Disabled" : "Enabled")}");
         }
 
         private static void LogTiltState(string group, Profile profile)

--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -8,7 +8,7 @@ using OpenTabletDriver.Plugin.Platform.Pointer;
 
 namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
 {
-    public class EvdevVirtualTablet : IPenActionHandler, IAbsolutePointer, IPressureHandler, ITiltHandler, IEraserHandler, IHoverDistanceHandler, ISynchronousPointer, IDisposable
+    public class EvdevVirtualTablet : IPenActionHandler, IAbsolutePointer, IPressureHandler, ITiltHandler, IRotationHandler, IEraserHandler, IHoverDistanceHandler, ISynchronousPointer, IDisposable
     {
         private const int RESOLUTION = 1000; // subpixels per screen pixel
 
@@ -104,6 +104,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
         }
 
         private const int MaxPressure = ushort.MaxValue;
+        private const int MaxRotation = ushort.MaxValue;
 
         private EventCode currentTool => isEraser ? EventCode.BTN_TOOL_RUBBER : EventCode.BTN_TOOL_PEN;
 
@@ -124,6 +125,11 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
         {
             Device.Write(EventType.EV_ABS, EventCode.ABS_TILT_X, (int)tilt.X);
             Device.Write(EventType.EV_ABS, EventCode.ABS_TILT_Y, (int)tilt.Y);
+        }
+
+        public void SetRotation(float percentage)
+        {
+            Device.Write(EventType.EV_ABS, EventCode.ABS_Z, (int)(MaxRotation * percentage));
         }
 
         public void SetEraser(bool isEraser)

--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -79,6 +79,13 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
             input_absinfo* yTiltPtr = &yTilt;
             Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_TILT_Y, (IntPtr)yTiltPtr);
 
+            var rotation = new input_absinfo
+            {
+                maximum = MaxRotation
+            };
+            input_absinfo* rotationPtr = &rotation;
+            Device.EnableCustomCode(EventType.EV_ABS, EventCode.ABS_Z, (IntPtr)rotationPtr);
+
             Device.EnableTypeCodes(
                 EventType.EV_KEY,
                 supportedEventCodes

--- a/OpenTabletDriver.Desktop/Profiles/BindingSettings.cs
+++ b/OpenTabletDriver.Desktop/Profiles/BindingSettings.cs
@@ -25,7 +25,7 @@ namespace OpenTabletDriver.Desktop.Profiles
 
         private List<WheelBindingSettings> wheelBindings = [];
 
-        private bool disablePressure, disableTilt, enableDragBindings;
+        private bool disablePressure, disableTilt, disableRotation, enableDragBindings;
 
         [JsonProperty(nameof(TipActivationThreshold))]
         public float TipActivationThreshold
@@ -109,6 +109,13 @@ namespace OpenTabletDriver.Desktop.Profiles
         {
             set => this.RaiseAndSetIfChanged(ref this.disableTilt, value);
             get => this.disableTilt;
+        }
+
+        [JsonProperty(nameof(DisableRotation))]
+        public bool DisableRotation
+        {
+            set => this.RaiseAndSetIfChanged(ref this.disableRotation, value);
+            get => this.disableRotation;
         }
 
         [JsonProperty(nameof(EnableDragBindings))]

--- a/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
@@ -145,6 +145,8 @@ namespace OpenTabletDriver.Plugin.Output
                 eraserHandler.SetEraser(eraserReport.Eraser);
             if (report is ITiltReport tiltReport && Pointer is ITiltHandler tiltHandler && !DisableTilt)
                 tiltHandler.SetTilt(tiltReport.Tilt);
+            if (report is IRotationReport rotationReport && Pointer is IRotationHandler rotationHandler)
+                rotationHandler.SetRotation(rotationReport.Rotation / (float)Tablet.Properties.Specifications.Pen.MaxRotation);
             if (report is ITabletReport tabletReport && Pointer is IPressureHandler pressureHandler &&
                 !DisablePressure && Tablet?.Properties.Specifications.Pen != null)
                 pressureHandler.SetPressure(tabletReport.Pressure / (float)Tablet.Properties.Specifications.Pen.MaxPressure);

--- a/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
@@ -146,8 +146,11 @@ namespace OpenTabletDriver.Plugin.Output
             if (report is ITiltReport tiltReport && Pointer is ITiltHandler tiltHandler && !DisableTilt)
                 tiltHandler.SetTilt(tiltReport.Tilt);
             if (report is IRotationReport rotationReport && Pointer is IRotationHandler rotationHandler &&
-                !DisableRotation && Tablet?.Properties.Specifications.Pen.MaxRotation != null)
-                rotationHandler.SetRotation(rotationReport.Rotation / (float)Tablet.Properties.Specifications.Pen.MaxRotation);
+                !DisableRotation && Tablet?.Properties.Specifications.Pen.MaxRotation != null && Tablet?.Properties.Specifications.Pen.MinRotation != null)
+            {
+                var rotationRange = (float)Tablet.Properties.Specifications.Pen.MaxRotation! - (float)Tablet.Properties.Specifications.Pen.MinRotation!;
+                rotationHandler.SetRotation((rotationReport.Rotation - (float)Tablet.Properties.Specifications.Pen.MinRotation!) / rotationRange);
+            }
             if (report is ITabletReport tabletReport && Pointer is IPressureHandler pressureHandler &&
                 !DisablePressure && Tablet?.Properties.Specifications.Pen != null)
                 pressureHandler.SetPressure(tabletReport.Pressure / (float)Tablet.Properties.Specifications.Pen.MaxPressure);

--- a/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
@@ -145,7 +145,8 @@ namespace OpenTabletDriver.Plugin.Output
                 eraserHandler.SetEraser(eraserReport.Eraser);
             if (report is ITiltReport tiltReport && Pointer is ITiltHandler tiltHandler && !DisableTilt)
                 tiltHandler.SetTilt(tiltReport.Tilt);
-            if (report is IRotationReport rotationReport && Pointer is IRotationHandler rotationHandler)
+            if (report is IRotationReport rotationReport && Pointer is IRotationHandler rotationHandler &&
+                !DisableRotation && Tablet?.Properties.Specifications.Pen.MaxRotation != null)
                 rotationHandler.SetRotation(rotationReport.Rotation / (float)Tablet.Properties.Specifications.Pen.MaxRotation);
             if (report is ITabletReport tabletReport && Pointer is IPressureHandler pressureHandler &&
                 !DisablePressure && Tablet?.Properties.Specifications.Pen != null)

--- a/OpenTabletDriver.Plugin/Output/IOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/IOutputMode.cs
@@ -38,5 +38,10 @@ namespace OpenTabletDriver.Plugin.Output
         /// Whether to disable tilt
         /// </summary>
         public bool DisableTilt { set; get; }
+
+        /// <summary>
+        /// Whether to disable rotation
+        /// </summary>
+        public bool DisableRotation { set; get; }
     }
 }

--- a/OpenTabletDriver.Plugin/Output/OutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/OutputMode.cs
@@ -51,6 +51,8 @@ namespace OpenTabletDriver.Plugin.Output
 
         public bool DisableTilt { set; get; }
 
+        public bool DisableRotation { set; get; }
+
         public Matrix3x2 TransformationMatrix { protected set; get; }
 
         public IList<IPositionedPipelineElement<IDeviceReport>> Elements

--- a/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
@@ -146,7 +146,8 @@ namespace OpenTabletDriver.Plugin.Output
                 eraserHandler.SetEraser(eraserReport.Eraser);
             if (report is ITiltReport tiltReport && Pointer is ITiltHandler tiltHandler && !DisableTilt)
                 tiltHandler.SetTilt(tiltReport.Tilt);
-            if (report is IRotationReport rotationReport && Pointer is IRotationHandler rotationHandler)
+            if (report is IRotationReport rotationReport && Pointer is IRotationHandler rotationHandler &&
+                !DisableRotation && Tablet?.Properties.Specifications.Pen.MaxRotation != null)
                 rotationHandler.SetRotation(rotationReport.Rotation / (float)Tablet.Properties.Specifications.Pen.MaxRotation);
             if (report is ITabletReport tabletReport && Pointer is IPressureHandler pressureHandler &&
                 !DisablePressure && Tablet?.Properties.Specifications.Pen != null)

--- a/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
@@ -147,8 +147,11 @@ namespace OpenTabletDriver.Plugin.Output
             if (report is ITiltReport tiltReport && Pointer is ITiltHandler tiltHandler && !DisableTilt)
                 tiltHandler.SetTilt(tiltReport.Tilt);
             if (report is IRotationReport rotationReport && Pointer is IRotationHandler rotationHandler &&
-                !DisableRotation && Tablet?.Properties.Specifications.Pen.MaxRotation != null)
-                rotationHandler.SetRotation(rotationReport.Rotation / (float)Tablet.Properties.Specifications.Pen.MaxRotation);
+                !DisableRotation && Tablet?.Properties.Specifications.Pen.MaxRotation != null && Tablet?.Properties.Specifications.Pen.MinRotation != null)
+            {
+                var rotationRange = (float)Tablet.Properties.Specifications.Pen.MaxRotation! - (float)Tablet.Properties.Specifications.Pen.MinRotation!;
+                rotationHandler.SetRotation((rotationReport.Rotation - (float)Tablet.Properties.Specifications.Pen.MinRotation!) / rotationRange);
+            }
             if (report is ITabletReport tabletReport && Pointer is IPressureHandler pressureHandler &&
                 !DisablePressure && Tablet?.Properties.Specifications.Pen != null)
                 pressureHandler.SetPressure(tabletReport.Pressure / (float)Tablet.Properties.Specifications.Pen.MaxPressure);

--- a/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
@@ -146,6 +146,8 @@ namespace OpenTabletDriver.Plugin.Output
                 eraserHandler.SetEraser(eraserReport.Eraser);
             if (report is ITiltReport tiltReport && Pointer is ITiltHandler tiltHandler && !DisableTilt)
                 tiltHandler.SetTilt(tiltReport.Tilt);
+            if (report is IRotationReport rotationReport && Pointer is IRotationHandler rotationHandler)
+                rotationHandler.SetRotation(rotationReport.Rotation / (float)Tablet.Properties.Specifications.Pen.MaxRotation);
             if (report is ITabletReport tabletReport && Pointer is IPressureHandler pressureHandler &&
                 !DisablePressure && Tablet?.Properties.Specifications.Pen != null)
                 pressureHandler.SetPressure(tabletReport.Pressure / (float)Tablet.Properties.Specifications.Pen.MaxPressure);

--- a/OpenTabletDriver.Plugin/Platform/Pointer/IRotationHandler.cs
+++ b/OpenTabletDriver.Plugin/Platform/Pointer/IRotationHandler.cs
@@ -1,0 +1,7 @@
+namespace OpenTabletDriver.Plugin.Platform.Pointer
+{
+    public interface IRotationHandler
+    {
+        void SetRotation(float percentage);
+    }
+}

--- a/OpenTabletDriver.Plugin/Platform/Pointer/IRotationHandler.cs
+++ b/OpenTabletDriver.Plugin/Platform/Pointer/IRotationHandler.cs
@@ -2,6 +2,10 @@ namespace OpenTabletDriver.Plugin.Platform.Pointer
 {
     public interface IRotationHandler
     {
+        /// <summary>
+        /// Set the rotation of the pen using absolute barrel rotation data.
+        /// </summary>
+        /// <param name="percentage">Rotation value normalized to between 0 and 1</param>
         void SetRotation(float percentage);
     }
 }

--- a/OpenTabletDriver.Plugin/ReportFormatter.cs
+++ b/OpenTabletDriver.Plugin/ReportFormatter.cs
@@ -38,6 +38,8 @@ namespace OpenTabletDriver.Plugin
                 sb.AppendLines(GetStringFormat(proximityReport));
             if (report is ITiltReport tiltReport)
                 sb.AppendLines(GetStringFormat(tiltReport));
+            if (report is IRotationReport rotationReport)
+                sb.AppendLines(GetStringFormat(rotationReport));
             if (report is ITouchReport touchReport)
                 sb.AppendLines(GetStringFormat(touchReport));
             if (report is IAbsoluteWheelReport absoluteWheelReport)
@@ -75,6 +77,8 @@ namespace OpenTabletDriver.Plugin
                 sb.AppendOneLine(GetStringFormat(proximityReport));
             if (report is ITiltReport tiltReport)
                 sb.AppendOneLine(GetStringFormat(tiltReport));
+            if (report is IRotationReport rotationReport)
+                sb.AppendOneLine(GetStringFormat(rotationReport));
             if (report is ITouchReport touchReport)
                 sb.AppendOneLine(GetStringFormat(touchReport));
             if (report is IAbsoluteWheelReport absoluteWheelReport)
@@ -130,6 +134,10 @@ namespace OpenTabletDriver.Plugin
             yield return $"Tilt:[{tiltReport.Tilt.X},{tiltReport.Tilt.Y}]";
         }
 
+        private static IEnumerable<string> GetStringFormat(IRotationReport rotationReport)
+        {
+            yield return $"Rotation:{rotationReport.Rotation}";
+        }
         private static IEnumerable<string> GetStringFormat(ITouchReport touchReport)
         {
             yield return $"Touch data:";

--- a/OpenTabletDriver.Plugin/ReportFormatter.cs
+++ b/OpenTabletDriver.Plugin/ReportFormatter.cs
@@ -138,6 +138,7 @@ namespace OpenTabletDriver.Plugin
         {
             yield return $"Rotation:{rotationReport.Rotation}";
         }
+
         private static IEnumerable<string> GetStringFormat(ITouchReport touchReport)
         {
             yield return $"Touch data:";

--- a/OpenTabletDriver.Plugin/Tablet/IRotationReport.cs
+++ b/OpenTabletDriver.Plugin/Tablet/IRotationReport.cs
@@ -2,6 +2,6 @@ namespace OpenTabletDriver.Plugin.Tablet
 {
     public interface IRotationReport : IDeviceReport
     {
-        uint Rotation { set; get; }
+        int Rotation { set; get; }
     }
 }

--- a/OpenTabletDriver.Plugin/Tablet/IRotationReport.cs
+++ b/OpenTabletDriver.Plugin/Tablet/IRotationReport.cs
@@ -1,0 +1,7 @@
+namespace OpenTabletDriver.Plugin.Tablet
+{
+    public interface IRotationReport : IDeviceReport
+    {
+        double Rotation { set; get; }
+    }
+}

--- a/OpenTabletDriver.Plugin/Tablet/IRotationReport.cs
+++ b/OpenTabletDriver.Plugin/Tablet/IRotationReport.cs
@@ -2,6 +2,12 @@ namespace OpenTabletDriver.Plugin.Tablet
 {
     public interface IRotationReport : IDeviceReport
     {
+        /// <summary>
+        /// Raw rotation data from the tablet.
+        /// </summary>
+        /// <remarks>
+        /// The rotation range is stored in the tablet's config as <see cref="PenSpecifications.MinRotation"/> and <see cref="PenSpecifications.MaxRotation"/>.
+        /// </remarks>
         int Rotation { set; get; }
     }
 }

--- a/OpenTabletDriver.Plugin/Tablet/IRotationReport.cs
+++ b/OpenTabletDriver.Plugin/Tablet/IRotationReport.cs
@@ -2,6 +2,6 @@ namespace OpenTabletDriver.Plugin.Tablet
 {
     public interface IRotationReport : IDeviceReport
     {
-        double Rotation { set; get; }
+        uint Rotation { set; get; }
     }
 }

--- a/OpenTabletDriver.Plugin/Tablet/PenSpecifications.cs
+++ b/OpenTabletDriver.Plugin/Tablet/PenSpecifications.cs
@@ -13,6 +13,11 @@ namespace OpenTabletDriver.Plugin.Tablet
         public uint MaxPressure { set; get; }
 
         /// <summary>
+        /// The minimum rotation that the pen supports.
+        /// </summary>
+        public int? MinRotation { set; get; }
+
+        /// <summary>
         /// The maximum rotation that the pen supports.
         /// </summary>
         public uint? MaxRotation { set; get; }

--- a/OpenTabletDriver.Plugin/Tablet/PenSpecifications.cs
+++ b/OpenTabletDriver.Plugin/Tablet/PenSpecifications.cs
@@ -15,7 +15,7 @@ namespace OpenTabletDriver.Plugin.Tablet
         /// <summary>
         /// The maximum rotation that the pen supports.
         /// </summary>
-        public uint MaxRotation { set; get; }
+        public uint? MaxRotation { set; get; }
 
         /// <summary>
         /// Specifications for the pen buttons.

--- a/OpenTabletDriver.Plugin/Tablet/PenSpecifications.cs
+++ b/OpenTabletDriver.Plugin/Tablet/PenSpecifications.cs
@@ -13,6 +13,11 @@ namespace OpenTabletDriver.Plugin.Tablet
         public uint MaxPressure { set; get; }
 
         /// <summary>
+        /// The maximum rotation that the pen supports.
+        /// </summary>
+        public uint MaxRotation { set; get; }
+
+        /// <summary>
         /// Specifications for the pen buttons.
         /// </summary>
         [Required(ErrorMessage = $"{nameof(ButtonCount)} must be defined")]

--- a/OpenTabletDriver.UX/Controls/Bindings/PenBindingEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/PenBindingEditor.cs
@@ -112,6 +112,13 @@ namespace OpenTabletDriver.UX.Controls.Bindings
                                     },
                                     new Group {
                                         Orientation = Orientation.Horizontal,
+                                        ToolTip = "Disable rotation if it is available",
+                                        Content = disableRotation = new CheckBox {
+                                            Text = "Disable Rotation",
+                                        }
+                                    },
+                                    new Group {
+                                        Orientation = Orientation.Horizontal,
                                         ToolTip = "Pen Bindings require pressure to activate",
                                         Content = enableDragBindings = new CheckBox {
                                             Text = "Drag Bindings",
@@ -131,12 +138,13 @@ namespace OpenTabletDriver.UX.Controls.Bindings
             penButtons.ItemSourceBinding.Bind(SettingsBinding.Child(c => (IList<PluginSettingStore>)c.PenButtons)!);
             disablePressure.CheckedBinding.Cast<bool>().Bind(SettingsBinding.Child(c => c.DisablePressure));
             disableTilt.CheckedBinding.Cast<bool>().Bind(SettingsBinding.Child(c => c.DisableTilt));
+            disableRotation.CheckedBinding.Cast<bool>().Bind(SettingsBinding.Child(c => c.DisableRotation));
             enableDragBindings.CheckedBinding.Cast<bool>().Bind(SettingsBinding.Child(c => c.EnableDragBindings));
         }
 
         private BindingDisplay tipButton, eraserButton;
         private FloatSlider tipThreshold, eraserThreshold;
-        private CheckBox disablePressure, disableTilt, enableDragBindings;
+        private CheckBox disablePressure, disableTilt, disableRotation, enableDragBindings;
         private BindingDisplayList penButtons;
     }
 }


### PR DESCRIPTION
Implemented for PTK-x70 and PTH-x60. Setting both min and max rotation values in the config for this.

Tested myself with my PTZ-431W, PTK-440, PTK-640, PTK-1240, PTH-451, PTH-460, PTH-660, PTK-470. Other tablets in the same series' as these should match the same specs and this is supported by input-wacom.