### PR TITLE
Add Bluetooth support for Wacom CTL-4100WL and CTL-6100WL

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-4100WL.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-4100WL.json
@@ -47,7 +47,13 @@
       "VendorID": 1386,
       "ProductID": 887,
       "InputReportLength": 361,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser"
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2BluetoothReportParser"
+    },
+    {
+      "VendorID": 1386,
+      "ProductID": 966,
+      "InputReportLength": 361,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2BluetoothReportParser"
     },
     {
       "VendorID": 1386,

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-6100WL.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-6100WL.json
@@ -27,6 +27,12 @@
     },
     {
       "VendorID": 1386,
+      "ProductID": 889,
+      "InputReportLength": 361,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2BluetoothReportParser"
+    },
+    {
+      "VendorID": 1386,
       "ProductID": 967,
       "InputReportLength": 192,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser",

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-6100WL.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTL-6100WL.json
@@ -33,6 +33,12 @@
       "FeatureInitReport": [
         "AgI="
       ]
+    },
+    {
+      "VendorID": 1386,
+      "ProductID": 968,
+      "InputReportLength": 361,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2BluetoothReportParser"
     }
   ]
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2BluetoothAuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2BluetoothAuxReport.cs
@@ -1,0 +1,16 @@
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
+{
+    public struct IntuosV2BluetoothAuxReport : IAuxReport
+    {
+        public IntuosV2BluetoothAuxReport(byte[] report)
+        {
+            Raw = report;
+            AuxButtons = IntuosV2BluetoothReport.ParseAuxButtons(report[44]);
+        }
+
+        public byte[] Raw { set; get; }
+        public bool[] AuxButtons { set; get; }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2BluetoothReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2BluetoothReport.cs
@@ -4,7 +4,7 @@ using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
 {
-    public struct IntuosV2BluetoothReport : ITabletReport, IProximityReport, IEraserReport
+    public struct IntuosV2BluetoothReport : ITabletReport, IProximityReport, IEraserReport, IAuxReport
     {
         public IntuosV2BluetoothReport(byte[] report, int offset)
         {
@@ -27,6 +27,19 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
             ];
             NearProximity = penByte.IsBitSet(5);
             HoverDistance = report[offset + 7];
+
+            var auxByte = report[44];
+            AuxButtons =
+            [
+                auxByte.IsBitSet(0),
+                auxByte.IsBitSet(1),
+                auxByte.IsBitSet(2),
+                auxByte.IsBitSet(3),
+                auxByte.IsBitSet(4),
+                auxByte.IsBitSet(5),
+                auxByte.IsBitSet(6),
+                auxByte.IsBitSet(7),
+            ];
         }
 
         public byte[] Raw { set; get; }
@@ -36,5 +49,6 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
         public bool[] PenButtons { set; get; }
         public bool NearProximity { set; get; }
         public uint HoverDistance { set; get; }
+        public bool[] AuxButtons { set; get; }
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2BluetoothReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2BluetoothReport.cs
@@ -1,0 +1,40 @@
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
+{
+    public struct IntuosV2BluetoothReport : ITabletReport, IProximityReport, IEraserReport
+    {
+        public IntuosV2BluetoothReport(byte[] report, int offset)
+        {
+            Raw = report;
+
+            var penByte = report[offset];
+
+            Position = new Vector2
+            {
+                X = Unsafe.ReadUnaligned<ushort>(ref report[offset + 1]),
+                Y = Unsafe.ReadUnaligned<ushort>(ref report[offset + 3])
+            };
+            Pressure = Unsafe.ReadUnaligned<ushort>(ref report[offset + 5]);
+
+            Eraser = penByte.IsBitSet(4);
+            PenButtons =
+            [
+                penByte.IsBitSet(1),
+                penByte.IsBitSet(2),
+            ];
+            NearProximity = penByte.IsBitSet(5);
+            HoverDistance = report[offset + 7];
+        }
+
+        public byte[] Raw { set; get; }
+        public Vector2 Position { set; get; }
+        public uint Pressure { set; get; }
+        public bool Eraser { set; get; }
+        public bool[] PenButtons { set; get; }
+        public bool NearProximity { set; get; }
+        public uint HoverDistance { set; get; }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2BluetoothReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2BluetoothReport.cs
@@ -25,22 +25,19 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
                 penByte.IsBitSet(1),
                 penByte.IsBitSet(2),
             ];
-            NearProximity = penByte.IsBitSet(5);
+            NearProximity = penByte.IsBitSet(6);
             HoverDistance = report[offset + 7];
 
-            var auxByte = report[44];
-            AuxButtons =
-            [
-                auxByte.IsBitSet(0),
-                auxByte.IsBitSet(1),
-                auxByte.IsBitSet(2),
-                auxByte.IsBitSet(3),
-                auxByte.IsBitSet(4),
-                auxByte.IsBitSet(5),
-                auxByte.IsBitSet(6),
-                auxByte.IsBitSet(7),
-            ];
+            AuxButtons = ParseAuxButtons(report[44]);
         }
+
+        internal static bool[] ParseAuxButtons(byte auxByte) =>
+        [
+            auxByte.IsBitSet(0),
+            auxByte.IsBitSet(1),
+            auxByte.IsBitSet(2),
+            auxByte.IsBitSet(3),
+        ];
 
         public byte[] Raw { set; get; }
         public Vector2 Position { set; get; }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2BluetoothReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2BluetoothReportParser.cs
@@ -7,6 +7,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public class IntuosV2BluetoothReportParser : IReportParser<IDeviceReport>
     {
+        private const int MinimumReportLength = 46;
         private const int SubPacketSize = 8;
         private const int SubPacketStart = 1;
         private const int MaxSubPackets = 4;
@@ -15,42 +16,29 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
 
         public IDeviceReport Parse(byte[] data)
         {
-            if (data[0] != 0x81)
+            if (data.Length < MinimumReportLength || data[0] != 0x81)
                 return new DeviceReport(data);
 
-            // Find the last non-empty sub-packet
             int lastOffset = -1;
             for (int i = 0; i < MaxSubPackets; i++)
             {
                 int offset = SubPacketStart + i * SubPacketSize;
-                if (offset + SubPacketSize > data.Length)
-                    break;
-
-                if (data[offset] == 0x00)
-                    break;
-
-                lastOffset = offset;
+                if (data[offset].IsBitSet(7))
+                    lastOffset = offset;
             }
-
-            IntuosV2BluetoothReport report;
 
             if (lastOffset < 0)
-            {
-                report = new IntuosV2BluetoothReport(data, 0);
-            }
-            else
-            {
-                report = new IntuosV2BluetoothReport(data, lastOffset);
-            }
+                return new IntuosV2BluetoothAuxReport(data);
 
-            if (!report.NearProximity)
-            {
-                report.Position = _lastPosition;
-            }
-            else
-            {
+            var status = data[lastOffset];
+            if (!status.IsBitSet(6))
+                return new OutOfRangeReport(data);
+
+            var report = new IntuosV2BluetoothReport(data, lastOffset);
+            if (status.IsBitSet(5))
                 _lastPosition = report.Position;
-            }
+            else
+                report.Position = _lastPosition;
 
             return report;
         }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2BluetoothReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2BluetoothReportParser.cs
@@ -1,0 +1,48 @@
+using System.Diagnostics.CodeAnalysis;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
+{
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    public class IntuosV2BluetoothReportParser : IReportParser<IDeviceReport>
+    {
+        private const int SubPacketSize = 8;
+        private const int SubPacketStart = 1;
+        private const int MaxSubPackets = 4;
+
+        public IDeviceReport Parse(byte[] data)
+        {
+            if (data[0] != 0x81)
+                return new DeviceReport(data);
+
+            // Find the last non-empty sub-packet
+            int lastOffset = -1;
+            for (int i = 0; i < MaxSubPackets; i++)
+            {
+                int offset = SubPacketStart + i * SubPacketSize;
+                if (offset + SubPacketSize > data.Length)
+                    break;
+
+                if (data[offset] == 0x00)
+                    break;
+
+                lastOffset = offset;
+            }
+
+            if (lastOffset < 0)
+                return new DeviceReport(data);
+
+            var status = data[lastOffset];
+
+            // 0x80 = pen leaving proximity
+            if (status == 0x80)
+                return new DeviceReport(data);
+
+            // bit 5 set = pen in proximity
+            if (status.IsBitSet(5))
+                return new IntuosV2BluetoothReport(data, lastOffset);
+
+            return new DeviceReport(data);
+        }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2BluetoothReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV2/IntuosV2BluetoothReportParser.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
 using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
@@ -9,6 +10,8 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
         private const int SubPacketSize = 8;
         private const int SubPacketStart = 1;
         private const int MaxSubPackets = 4;
+
+        private Vector2 _lastPosition = Vector2.Zero;
 
         public IDeviceReport Parse(byte[] data)
         {
@@ -29,20 +32,27 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2
                 lastOffset = offset;
             }
 
+            IntuosV2BluetoothReport report;
+
             if (lastOffset < 0)
-                return new DeviceReport(data);
+            {
+                report = new IntuosV2BluetoothReport(data, 0);
+            }
+            else
+            {
+                report = new IntuosV2BluetoothReport(data, lastOffset);
+            }
 
-            var status = data[lastOffset];
+            if (!report.NearProximity)
+            {
+                report.Position = _lastPosition;
+            }
+            else
+            {
+                _lastPosition = report.Position;
+            }
 
-            // 0x80 = pen leaving proximity
-            if (status == 0x80)
-                return new DeviceReport(data);
-
-            // bit 5 set = pen in proximity
-            if (status.IsBitSet(5))
-                return new IntuosV2BluetoothReport(data, lastOffset);
-
-            return new DeviceReport(data);
+            return report;
         }
     }
 }

--- a/OpenTabletDriver.Tests/IntuosV2BluetoothReportParserTest.cs
+++ b/OpenTabletDriver.Tests/IntuosV2BluetoothReportParserTest.cs
@@ -1,0 +1,131 @@
+using Newtonsoft.Json.Linq;
+using System.Numerics;
+using OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2;
+using OpenTabletDriver.Desktop.RPC;
+using OpenTabletDriver.Plugin.Tablet;
+using Xunit;
+
+namespace OpenTabletDriver.Tests
+{
+    public class IntuosV2BluetoothReportParserTest
+    {
+        [Fact]
+        public void Parse_Uses_Last_Valid_Pen_Frame()
+        {
+            var parser = new IntuosV2BluetoothReportParser();
+            var data = CreateReport(0xE0, 100, 200, 0, 10);
+            WritePenFrame(data, 9, 0xE4, 300, 400, 1234, 20);
+
+            var report = Assert.IsType<IntuosV2BluetoothReport>(parser.Parse(data));
+
+            Assert.Equal(new Vector2(300, 400), report.Position);
+            Assert.Equal(1234u, report.Pressure);
+            Assert.Equal(new[] { false, true }, report.PenButtons);
+            Assert.True(report.NearProximity);
+            Assert.Equal(20u, report.HoverDistance);
+        }
+
+        [Fact]
+        public void Parse_Reports_Auxiliary_Buttons_Without_Pen_Data()
+        {
+            var parser = new IntuosV2BluetoothReportParser();
+            var data = CreateReport();
+            data[44] = 0b0000_0101;
+
+            var report = parser.Parse(data);
+            var auxReport = Assert.IsAssignableFrom<IAuxReport>(report);
+
+            Assert.IsNotAssignableFrom<ITabletReport>(report);
+            Assert.Equal(new[] { true, false, true, false }, auxReport.AuxButtons);
+        }
+
+        [Fact]
+        public void Parse_Auxiliary_Report_Can_Be_Read_By_Tablet_Debugger()
+        {
+            var parser = new IntuosV2BluetoothReportParser();
+            var data = CreateReport();
+            data[44] = 0b0000_0101;
+            var report = parser.Parse(data);
+            var serializedReport = new DebugReportData
+            {
+                Tablet = null!,
+                Path = report.GetType().FullName!,
+                Data = JToken.FromObject(report)
+            };
+
+            var deserializedReport = Assert.IsAssignableFrom<IAuxReport>(serializedReport.ToObject());
+
+            Assert.Equal(new[] { true, false, true, false }, deserializedReport.AuxButtons);
+        }
+
+        [Fact]
+        public void Parse_Preserves_Position_When_Pen_Is_Outside_Range()
+        {
+            var parser = new IntuosV2BluetoothReportParser();
+            parser.Parse(CreateReport(0xE0, 100, 200, 0, 10));
+
+            var report = Assert.IsType<IntuosV2BluetoothReport>(
+                parser.Parse(CreateReport(0xC0, 500, 600, 0, 63)));
+
+            Assert.Equal(new Vector2(100, 200), report.Position);
+            Assert.True(report.NearProximity);
+            Assert.Equal(63u, report.HoverDistance);
+        }
+
+        [Fact]
+        public void Parse_Emits_Out_Of_Range_Before_Auxiliary_Only_Reports()
+        {
+            var parser = new IntuosV2BluetoothReportParser();
+
+            Assert.IsType<OutOfRangeReport>(parser.Parse(CreateReport(0x80)));
+
+            var data = CreateReport();
+            data[44] = 0b0000_0010;
+            var auxReport = Assert.IsAssignableFrom<IAuxReport>(parser.Parse(data));
+            Assert.Equal(new[] { false, true, false, false }, auxReport.AuxButtons);
+        }
+
+        [Fact]
+        public void Parse_Rejects_Incomplete_Bluetooth_Reports()
+        {
+            var parser = new IntuosV2BluetoothReportParser();
+            var shortReport = new byte[45];
+            shortReport[0] = 0x81;
+
+            Assert.IsType<DeviceReport>(parser.Parse([]));
+            Assert.IsType<DeviceReport>(parser.Parse(shortReport));
+        }
+
+        private static byte[] CreateReport(
+            byte status = 0,
+            ushort x = 0,
+            ushort y = 0,
+            ushort pressure = 0,
+            byte hoverDistance = 0)
+        {
+            var data = new byte[46];
+            data[0] = 0x81;
+            WritePenFrame(data, 1, status, x, y, pressure, hoverDistance);
+            return data;
+        }
+
+        private static void WritePenFrame(
+            byte[] data,
+            int offset,
+            byte status,
+            ushort x,
+            ushort y,
+            ushort pressure,
+            byte hoverDistance)
+        {
+            data[offset] = status;
+            data[offset + 1] = (byte)x;
+            data[offset + 2] = (byte)(x >> 8);
+            data[offset + 3] = (byte)y;
+            data[offset + 4] = (byte)(y >> 8);
+            data[offset + 5] = (byte)pressure;
+            data[offset + 6] = (byte)(pressure >> 8);
+            data[offset + 7] = hoverDistance;
+        }
+    }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -126,6 +126,7 @@
 | Wacom CTL-480                      |     Supported     |
 | Wacom CTL-490                      |     Supported     |
 | Wacom CTL-6100                     |     Supported     |
+| Wacom CTL-6100WL                   |     Supported     |
 | Wacom CTL-671                      |     Supported     |
 | Wacom CTL-672                      |     Supported     |
 | Wacom CTL-680                      |     Supported     |
@@ -323,7 +324,6 @@
 | Wacom CTH-300                      |  Missing Features | Touch is not yet supported.
 | Wacom CTH-301                      |  Missing Features | Touch is not yet supported.
 | Wacom CTH-461                      |  Missing Features | Tablet buttons and touch are not yet supported.
-| Wacom CTL-6100WL                   |  Missing Features | Wireless is not yet supported.
 | Wacom DTH-1320                     |  Missing Features | Touch is not yet supported.
 | Wacom Movink 13 (DTH-135)          |  Missing Features | Touch is not yet supported.
 | Wacom Cintiq 22HD Touch (DTH-2200) |  Missing Features | Touch is not yet supported.

--- a/generate-rules.sh
+++ b/generate-rules.sh
@@ -64,6 +64,7 @@ while read s; do
 
   echo \# $(echo $names | sed 's/,/\n# /g')
   echo KERNEL==\"hidraw*\", ATTRS{idVendor}==\"$vid\", ATTRS{idProduct}==\"$pid\", TAG+=\"uaccess\", TAG+=\"udev-acl\"
+  echo KERNEL==\"hidraw*\", KERNELS==\"0005:${vid^^}:${pid^^}.*\", TAG+=\"uaccess\", TAG+=\"udev-acl\"
   echo SUBSYSTEM==\"usb\", ATTRS{idVendor}==\"$vid\", ATTRS{idProduct}==\"$pid\", TAG+=\"uaccess\", TAG+=\"udev-acl\"
 
   if [[ $libinput > 0 ]]; then


### PR DESCRIPTION
The current configurations either route these Bluetooth PIDs to the USB-only `IntuosV2ReportParser` or omit them. This routes CTL-4100WL PIDs `0x0377` and `0x03C6`, and CTL-6100WL PIDs `0x0379` and `0x03C8`, through a dedicated parser for `0x81` reports.

All four PIDs are already registered by the Linux kernel as `INTUOSHT3_BT`. The parser follows that implementation's four 8-byte pen frames, `valid` / `prox` / `range` status bits, and four-button pad report ([`87046b6c`](https://github.com/torvalds/linux/commit/87046b6c995c), [`0c8fbaa5`](https://github.com/torvalds/linux/commit/0c8fbaa55307)).

On Linux, Bluetooth HID devices lack the USB attributes used by the generated rules, so `generate-rules.sh` now adds a `KERNELS=="0005:VID:PID.*"` match with the existing `uaccess` policy. Enumeration still requires the corresponding HidSharpCore HID-parent fallback: <https://github.com/OpenTabletDriver/HIDSharpCore/pull/31>.

Addresses #1548 and #2118.

**Testing**

**CTL-4100WL (`0x03C6`)**

- Environment: NixOS 26.05, Linux `7.1.7`, GNOME on Wayland, Intel AX210 Bluetooth
- Verified: full X/Y range (`0..15200` × `0..9500`), pressure (`0..4095`), hover distance (`0..63`), both pen buttons, all four ExpressKeys, auxiliary-only reports, and proximity exit/re-entry
- Evidence: [diagnostics](https://github.com/user-attachments/files/32081669/CTL-4100WL-03C6-NixOS-26.05-otd-diagnostics.txt), [Tablet Debugger recording](https://github.com/user-attachments/files/32027684/CTL-4100WL-03C6-NixOS-26.05-tablet-data.txt)


**CTL-6100WL (`0x03C8`)**

- Verified by @hey2022: generated `03C8` udev rule, per-user `uaccess` ACL, and successful operation ([result](https://github.com/OpenTabletDriver/OpenTabletDriver/pull/4672#issuecomment-5625723278))
- Evidence: [diagnostics](https://github.com/user-attachments/files/32077898/otd_diagnostics.txt), [journal](https://github.com/user-attachments/files/32077938/journalctl-log.txt), [OTD log](https://github.com/user-attachments/files/32077949/otd_current_log.txt)

**Automated:** Tests cover pen-frame selection, auxiliary-only reports, debugger serialization, range-state transitions, and truncated reports.

Thanks @Dutchs and @hey2022 for the CTL-6100WL Bluetooth investigation and testing documented in #2118.

