### PR TITLE
Add PenScrollingBinding

### DIFF
--- a/OpenTabletDriver.Desktop/Binding/BindingState.cs
+++ b/OpenTabletDriver.Desktop/Binding/BindingState.cs
@@ -30,6 +30,11 @@ namespace OpenTabletDriver.Desktop.Binding
                     stateBinding.Release(tablet, report);
             }
 
+            if (pressureThresholdIsMetOrUnneeded && Binding is IStatePositionBinding statePositionBinding && report is IAbsolutePositionReport absolutePositionReport)
+            {
+                statePositionBinding.SetPosition(absolutePositionReport.Position);
+            }
+
             if (!newState || pressureThresholdIsMetOrUnneeded) // don't update state to true without threshold
                 PreviousState = newState;
         }

--- a/OpenTabletDriver.Desktop/Binding/PenScrollingBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/PenScrollingBinding.cs
@@ -1,0 +1,138 @@
+using OpenTabletDriver.Plugin;
+using OpenTabletDriver.Plugin.Attributes;
+using OpenTabletDriver.Plugin.DependencyInjection;
+using OpenTabletDriver.Plugin.Platform.Pointer;
+using OpenTabletDriver.Plugin.Tablet;
+using OpenTabletDriver.Plugin.Timers;
+using System;
+using System.Numerics;
+
+#nullable enable
+
+namespace OpenTabletDriver.Desktop.Binding
+{
+    [PluginName(PLUGIN_NAME)]
+    public class PenScrollingBinding : IStatePositionBinding
+    {
+        private const string PLUGIN_NAME = "Pen Scrolling Binding";
+
+        private Vector2 _initialPosition = default;
+        private int _scrollAmountHorizontal = 0;
+        private int _scrollAmountVertical = 0;
+
+        [Resolved]
+        public IMouseScrollHandler? Pointer { set; get; }
+
+        private ITimer? _scrollingTimer;
+
+        [Resolved]
+        public ITimer? ScrollingTimer
+        {
+            get => _scrollingTimer;
+            set
+            {
+                if (value is null)
+                    return;
+
+                if (_scrollingTimer != null && !ReferenceEquals(_scrollingTimer, value))
+                {
+                    if (_scrollingTimer.Enabled)
+                        _scrollingTimer.Stop();
+                    _scrollingTimer.Elapsed -= Scroll;
+                    _scrollingTimer.Dispose();
+                }
+
+                _scrollingTimer = value;
+                _scrollingTimer.Elapsed += Scroll;
+            }
+        }
+
+        [BooleanPropertyAttribute("Scroll horizontally", "pen movement scrolls horizontally"), DefaultPropertyValue(true)]
+        public bool HorziontalScrollingEnabled { get; set; }
+
+        [BooleanPropertyAttribute("Scroll vertically", "pen movement scrolls vertically"), DefaultPropertyValue(true)]
+        public bool VerticalScrollingEnabled { get; set; }
+
+        [Property("Sensitivity"), ToolTip("The sensitivity of scrolling with pen movement."), DefaultPropertyValue(50f)]
+        public float Sensitivity { get; set; }
+
+        [SliderProperty("Refresh rate", 1f, 320f, 60f), ToolTip("How often scrolling event gets sent (lower for better performance, higher for smoother scrolling)."), DefaultPropertyValue(60f)]
+        public float RefreshRate { get; set; }
+
+        [BooleanPropertyAttribute("Invert horizontal axis", "invert horizontal scrolling"), DefaultPropertyValue(false)]
+        public bool InvertHorizontalAxis { get; set; }
+
+        [BooleanPropertyAttribute("Invert vertical axis", "invert vertical scrolling (MacOS like)"), DefaultPropertyValue(false)]
+        public bool InvertVerticalAxis { get; set; }
+
+        public void Press(TabletReference tablet, IDeviceReport report)
+        {
+            if (report is not IAbsolutePositionReport)
+            {
+                throw new InvalidOperationException("PenScrollingBinding not supported on this device");
+            }
+
+            ResetScrollingTimer();
+
+            _initialPosition = ((IAbsolutePositionReport)report).Position;
+            _scrollAmountHorizontal = 0;
+            _scrollAmountVertical = 0;
+
+            _scrollingTimer?.Start();
+        }
+
+        protected void ResetScrollingTimer()
+        {
+            if (_scrollingTimer == null)
+            {
+                Log.Write(nameof(PenScrollingBinding), "Timer was not injected, can not scroll", LogLevel.Error);
+                return;
+            }
+
+            if (_scrollingTimer.Enabled)
+                _scrollingTimer.Stop();
+
+            _scrollingTimer.Interval = 1000f / RefreshRate;
+        }
+
+        public void Release(TabletReference tablet, IDeviceReport report)
+        {
+            if (_scrollingTimer != null)
+                _scrollingTimer.Stop();
+        }
+
+        public void SetPosition(Vector2 pos)
+        {
+            if (_scrollingTimer is null || !_scrollingTimer.Enabled)
+                return;
+
+            if (InvertHorizontalAxis)
+                _scrollAmountHorizontal = (int)Math.Ceiling((_initialPosition.X - pos.X) * (Sensitivity / 100));
+            else
+                _scrollAmountHorizontal = (int)Math.Ceiling((pos.X - _initialPosition.X) * (Sensitivity / 100));
+
+            if (InvertVerticalAxis)
+                _scrollAmountVertical = (int)Math.Ceiling((pos.Y - _initialPosition.Y) * (Sensitivity / 100));
+            else
+                _scrollAmountVertical = (int)Math.Ceiling((_initialPosition.Y - pos.Y) * (Sensitivity / 100));
+        }
+
+        public void Scroll()
+        {
+            if (Pointer == null)
+            {
+                Log.Write(nameof(PenScrollingBinding), "Pointer was not injected, can not scroll", LogLevel.Error);
+                return;
+            }
+
+            if (HorziontalScrollingEnabled)
+                Pointer.ScrollHorizontally(_scrollAmountHorizontal);
+
+            if (VerticalScrollingEnabled)
+                Pointer.ScrollVertically(_scrollAmountVertical);
+
+            if (Pointer is ISynchronousPointer synchronousPointer)
+                synchronousPointer.Flush();
+        }
+    }
+}

--- a/OpenTabletDriver.Desktop/Binding/PenScrollingBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/PenScrollingBinding.cs
@@ -16,9 +16,8 @@ namespace OpenTabletDriver.Desktop.Binding
     {
         private const string PLUGIN_NAME = "Pen Scrolling Binding";
 
-        private Vector2 _initialPosition = default;
-        private int _scrollAmountHorizontal = 0;
-        private int _scrollAmountVertical = 0;
+        private Vector2 _initialPosition;
+        private int _scrollAmountHorizontal, _scrollAmountVertical;
 
         [Resolved]
         public IMouseScrollHandler? Pointer { set; get; }
@@ -48,7 +47,7 @@ namespace OpenTabletDriver.Desktop.Binding
         }
 
         [BooleanPropertyAttribute("Scroll horizontally", "pen movement scrolls horizontally"), DefaultPropertyValue(true)]
-        public bool HorziontalScrollingEnabled { get; set; }
+        public bool HorizontalScrollingEnabled { get; set; }
 
         [BooleanPropertyAttribute("Scroll vertically", "pen movement scrolls vertically"), DefaultPropertyValue(true)]
         public bool VerticalScrollingEnabled { get; set; }
@@ -67,14 +66,14 @@ namespace OpenTabletDriver.Desktop.Binding
 
         public void Press(TabletReference tablet, IDeviceReport report)
         {
-            if (report is not IAbsolutePositionReport)
+            if (report is not IAbsolutePositionReport absolutePositionReport)
             {
                 throw new InvalidOperationException("PenScrollingBinding not supported on this device");
             }
 
             ResetScrollingTimer();
 
-            _initialPosition = ((IAbsolutePositionReport)report).Position;
+            _initialPosition = absolutePositionReport.Position;
             _scrollAmountHorizontal = 0;
             _scrollAmountVertical = 0;
 
@@ -84,10 +83,7 @@ namespace OpenTabletDriver.Desktop.Binding
         protected void ResetScrollingTimer()
         {
             if (_scrollingTimer == null)
-            {
-                Log.Write(nameof(PenScrollingBinding), "Timer was not injected, can not scroll", LogLevel.Error);
-                return;
-            }
+                throw new InvalidOperationException("Timer was not injected, can not scroll");
 
             if (_scrollingTimer.Enabled)
                 _scrollingTimer.Stop();
@@ -120,12 +116,9 @@ namespace OpenTabletDriver.Desktop.Binding
         public void Scroll()
         {
             if (Pointer == null)
-            {
-                Log.Write(nameof(PenScrollingBinding), "Pointer was not injected, can not scroll", LogLevel.Error);
-                return;
-            }
+                throw new InvalidOperationException("Pointer was not injected, can not scroll");
 
-            if (HorziontalScrollingEnabled)
+            if (HorizontalScrollingEnabled)
                 Pointer.ScrollHorizontally(_scrollAmountHorizontal);
 
             if (VerticalScrollingEnabled)

--- a/OpenTabletDriver.Desktop/Binding/PenScrollingBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/PenScrollingBinding.cs
@@ -1,11 +1,11 @@
+using System;
+using System.Numerics;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Attributes;
 using OpenTabletDriver.Plugin.DependencyInjection;
 using OpenTabletDriver.Plugin.Platform.Pointer;
 using OpenTabletDriver.Plugin.Tablet;
 using OpenTabletDriver.Plugin.Timers;
-using System;
-using System.Numerics;
 
 #nullable enable
 

--- a/OpenTabletDriver.Plugin/IStatePositionBinding.cs
+++ b/OpenTabletDriver.Plugin/IStatePositionBinding.cs
@@ -6,6 +6,6 @@ namespace OpenTabletDriver.Plugin
 {
     public interface IStatePositionBinding : IStateBinding
     {
-        public void SetPosition(Vector2 pos);
+        void SetPosition(Vector2 pos);
     }
 }

--- a/OpenTabletDriver.Plugin/IStatePositionBinding.cs
+++ b/OpenTabletDriver.Plugin/IStatePositionBinding.cs
@@ -1,5 +1,4 @@
 
-using OpenTabletDriver.Plugin.Tablet;
 using System.Numerics;
 
 namespace OpenTabletDriver.Plugin

--- a/OpenTabletDriver.Plugin/IStatePositionBinding.cs
+++ b/OpenTabletDriver.Plugin/IStatePositionBinding.cs
@@ -1,0 +1,11 @@
+
+using OpenTabletDriver.Plugin.Tablet;
+using System.Numerics;
+
+namespace OpenTabletDriver.Plugin
+{
+    public interface IStatePositionBinding : IStateBinding
+    {
+        public void SetPosition(Vector2 pos);
+    }
+}


### PR DESCRIPTION
Added a new Binding PenScrollingBinding

The further from the initial position the pen is moved the faster the scrolling. This is the default behaviour for scrolling in wacom windows drivers.

## Configuration options
* Directions - horizontal, vertical and their inversions
* Sensitivity - how fast
* Refresh rate - how often

There's a bit of a push and pull between the sensitivity and refresh rate parameters, but the default configuration seems to work well on my device.

## Showcase

[Screencast_20260315_215656.webm](https://github.com/user-attachments/assets/5e3f9b37-d211-43a1-9d86-bc970fb85319)