### PR TITLE
Editorconfig small

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -65,6 +65,7 @@ dotnet_style_prefer_inferred_tuple_names = true:warning
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
 dotnet_style_prefer_auto_properties = true:warning
 dotnet_style_prefer_compound_assignment = true:warning
+dotnet_style_prefer_simplified_interpolation = true:warning
 
 [*.{sh,md,csproj,json,yml}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -61,6 +61,8 @@ dotnet_style_object_initializer = true:warning
 dotnet_style_collection_initializer = true:warning
 dotnet_style_prefer_collection_expression = when_types_loosely_match:warning
 dotnet_style_explicit_tuple_names = true:warning
+dotnet_style_prefer_inferred_tuple_names = true:warning
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
 
 [*.{sh,md,csproj,json,yml}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -63,6 +63,7 @@ dotnet_style_prefer_collection_expression = when_types_loosely_match:warning
 dotnet_style_explicit_tuple_names = true:warning
 dotnet_style_prefer_inferred_tuple_names = true:warning
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
+dotnet_style_prefer_auto_properties = true:warning
 
 [*.{sh,md,csproj,json,yml}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -70,6 +70,15 @@ dotnet_style_prefer_simplified_boolean_expressions = true:warning
 dotnet_style_null_propagation = true:warning
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
 
+# C# Style Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#c-style-rules
+
+## prefer 'var' usage
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = true:suggestion
+### except for built-in types where not using var can be more clear
+csharp_style_var_for_built_in_types = false:suggestion
+
 [*.{sh,md,csproj,json,yml}]
 indent_size = 2
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -57,6 +57,8 @@ dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:war
 dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:warning
 dotnet_style_parentheses_in_other_operators = never_if_unnecessary:warning
 
+dotnet_style_object_initializer = true:warning
+
 [*.{sh,md,csproj,json,yml}]
 indent_size = 2
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -44,6 +44,11 @@ dotnet_diagnostic.IDE0005.severity = warning
 # IDE-only inspections (Rider, etc.)
 resharper_can_simplify_dictionary_lookup_with_try_get_value_highlighting=warning
 
+# .NET Style Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#net-style-rules
+
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+
 [*.{sh,md,csproj,json,yml}]
 indent_size = 2
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -67,6 +67,7 @@ dotnet_style_prefer_auto_properties = true:warning
 dotnet_style_prefer_compound_assignment = true:warning
 dotnet_style_prefer_simplified_interpolation = true:warning
 dotnet_style_prefer_simplified_boolean_expressions = true:warning
+dotnet_style_null_propagation = true:warning
 
 [*.{sh,md,csproj,json,yml}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -51,6 +51,12 @@ dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
 dotnet_style_readonly_field = true:warning
 csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async:warning
 
+## Parentheses (IDE0047 / IDE0048)
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:warning
+
 [*.{sh,md,csproj,json,yml}]
 indent_size = 2
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -60,6 +60,7 @@ dotnet_style_parentheses_in_other_operators = never_if_unnecessary:warning
 dotnet_style_object_initializer = true:warning
 dotnet_style_collection_initializer = true:warning
 dotnet_style_prefer_collection_expression = when_types_loosely_match:warning
+dotnet_style_explicit_tuple_names = true:warning
 
 [*.{sh,md,csproj,json,yml}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -68,6 +68,7 @@ dotnet_style_prefer_compound_assignment = true:warning
 dotnet_style_prefer_simplified_interpolation = true:warning
 dotnet_style_prefer_simplified_boolean_expressions = true:warning
 dotnet_style_null_propagation = true:warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
 
 [*.{sh,md,csproj,json,yml}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -48,6 +48,7 @@ resharper_can_simplify_dictionary_lookup_with_try_get_value_highlighting=warning
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#net-style-rules
 
 dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+dotnet_style_readonly_field = true:warning
 
 [*.{sh,md,csproj,json,yml}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -66,6 +66,7 @@ dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
 dotnet_style_prefer_auto_properties = true:warning
 dotnet_style_prefer_compound_assignment = true:warning
 dotnet_style_prefer_simplified_interpolation = true:warning
+dotnet_style_prefer_simplified_boolean_expressions = true:warning
 
 [*.{sh,md,csproj,json,yml}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -49,6 +49,7 @@ resharper_can_simplify_dictionary_lookup_with_try_get_value_highlighting=warning
 
 dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
 dotnet_style_readonly_field = true:warning
+csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async:warning
 
 [*.{sh,md,csproj,json,yml}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -58,6 +58,7 @@ dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:warning
 dotnet_style_parentheses_in_other_operators = never_if_unnecessary:warning
 
 dotnet_style_object_initializer = true:warning
+dotnet_style_collection_initializer = true:warning
 
 [*.{sh,md,csproj,json,yml}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -64,6 +64,7 @@ dotnet_style_explicit_tuple_names = true:warning
 dotnet_style_prefer_inferred_tuple_names = true:warning
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
 dotnet_style_prefer_auto_properties = true:warning
+dotnet_style_prefer_compound_assignment = true:warning
 
 [*.{sh,md,csproj,json,yml}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -59,6 +59,7 @@ dotnet_style_parentheses_in_other_operators = never_if_unnecessary:warning
 
 dotnet_style_object_initializer = true:warning
 dotnet_style_collection_initializer = true:warning
+dotnet_style_prefer_collection_expression = when_types_loosely_match:warning
 
 [*.{sh,md,csproj,json,yml}]
 indent_size = 2

--- a/OpenTabletDriver.Benchmarks/Misc/DriverInfoBenchmark.cs
+++ b/OpenTabletDriver.Benchmarks/Misc/DriverInfoBenchmark.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using BenchmarkDotNet.Attributes;
 using OpenTabletDriver.SystemDrivers;
 
@@ -11,7 +10,7 @@ namespace OpenTabletDriver.Benchmarks.Misc
         [SuppressMessage("Performance", "CA1822:Mark members as static")] // invalid for benchmarks
         public DriverInfo[] GetDriverInfos()
         {
-            return DriverInfo.GetDriverInfos().ToArray();
+            return [.. DriverInfo.GetDriverInfos()];
         }
     }
 }

--- a/OpenTabletDriver.Benchmarks/Output/LinuxInteropBenchmark.cs
+++ b/OpenTabletDriver.Benchmarks/Output/LinuxInteropBenchmark.cs
@@ -7,8 +7,8 @@ namespace OpenTabletDriver.Benchmarks.Output
 {
     public class LinuxInteropBenchmark
     {
-        EvdevAbsolutePointer absolutePointer = new EvdevAbsolutePointer();
-        EvdevRelativePointer relativePointer = new EvdevRelativePointer();
+        private EvdevAbsolutePointer absolutePointer = new EvdevAbsolutePointer();
+        private EvdevRelativePointer relativePointer = new EvdevRelativePointer();
 
         [Benchmark]
         public void EvdevAbsolute()

--- a/OpenTabletDriver.Benchmarks/Output/LinuxInteropBenchmark.cs
+++ b/OpenTabletDriver.Benchmarks/Output/LinuxInteropBenchmark.cs
@@ -7,8 +7,8 @@ namespace OpenTabletDriver.Benchmarks.Output
 {
     public class LinuxInteropBenchmark
     {
-        private EvdevAbsolutePointer absolutePointer = new EvdevAbsolutePointer();
-        private EvdevRelativePointer relativePointer = new EvdevRelativePointer();
+        private readonly EvdevAbsolutePointer absolutePointer = new EvdevAbsolutePointer();
+        private readonly EvdevRelativePointer relativePointer = new EvdevRelativePointer();
 
         [Benchmark]
         public void EvdevAbsolute()

--- a/OpenTabletDriver.Benchmarks/Output/MacOSInteropBenchmark.cs
+++ b/OpenTabletDriver.Benchmarks/Output/MacOSInteropBenchmark.cs
@@ -7,8 +7,8 @@ namespace OpenTabletDriver.Benchmarks.Output
 {
     public class MacOSInteropBenchmark
     {
-        private MacOSAbsolutePointer absolutePointer = new MacOSAbsolutePointer();
-        private MacOSRelativePointer relativePointer = new MacOSRelativePointer();
+        private readonly MacOSAbsolutePointer absolutePointer = new MacOSAbsolutePointer();
+        private readonly MacOSRelativePointer relativePointer = new MacOSRelativePointer();
 
         [Benchmark]
         public void CoreGraphicsAbsolute()

--- a/OpenTabletDriver.Benchmarks/Output/WindowsInteropBenchmark.cs
+++ b/OpenTabletDriver.Benchmarks/Output/WindowsInteropBenchmark.cs
@@ -7,8 +7,8 @@ namespace OpenTabletDriver.Benchmarks.Output
 {
     public class WindowsInteropBenchmark
     {
-        private WindowsAbsolutePointer absolutePointer = new WindowsAbsolutePointer();
-        private WindowsRelativePointer relativePointer = new WindowsRelativePointer();
+        private readonly WindowsAbsolutePointer absolutePointer = new WindowsAbsolutePointer();
+        private readonly WindowsRelativePointer relativePointer = new WindowsRelativePointer();
 
         [Benchmark]
         public void SendInputAbsolute()

--- a/OpenTabletDriver.Benchmarks/Parser/ReportParserBenchmark.cs
+++ b/OpenTabletDriver.Benchmarks/Parser/ReportParserBenchmark.cs
@@ -7,8 +7,8 @@ namespace OpenTabletDriver.Benchmarks.Parser
 {
     public class ReportParserBenchmark
     {
-        private TabletReportParser parser = new TabletReportParser();
-        private SkipByteTabletReportParser skipParser = new SkipByteTabletReportParser();
+        private readonly TabletReportParser parser = new TabletReportParser();
+        private readonly SkipByteTabletReportParser skipParser = new SkipByteTabletReportParser();
         private byte[] data;
 
         [GlobalSetup]

--- a/OpenTabletDriver.Configurations/DeviceConfigurationProvider.cs
+++ b/OpenTabletDriver.Configurations/DeviceConfigurationProvider.cs
@@ -14,10 +14,9 @@ namespace OpenTabletDriver.Configurations
             var asm = typeof(DeviceConfigurationProvider).Assembly;
             var jsonSerializer = new JsonSerializer();
 
-            TabletConfigurations = asm.GetManifestResourceNames()
+            TabletConfigurations = [.. asm.GetManifestResourceNames()
                 .Where(path => path.Contains(".json"))
-                .Select(path => Deserialize(jsonSerializer, asm.GetManifestResourceStream(path)))
-                .ToArray();
+                .Select(path => Deserialize(jsonSerializer, asm.GetManifestResourceStream(path)))];
         }
 
         public IEnumerable<TabletConfiguration> TabletConfigurations { get; }

--- a/OpenTabletDriver.Configurations/Parsers/10moon/10moonTabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/10moon/10moonTabletReport.cs
@@ -12,12 +12,12 @@ namespace OpenTabletDriver.Configurations.Parsers.TenMoon
 
             Position = new Vector2
             {
-                X = report[1] << 8 | report[2],
-                Y = Math.Max((short)(report[3] << 8 | report[4]), (short)0)
+                X = (report[1] << 8) | report[2],
+                Y = Math.Max((short)((report[3] << 8) | report[4]), (short)0)
             };
 
             var buttonPressed = (report[9] & 6) != 0;
-            var prePressure = report[5] << 8 | report[6];
+            var prePressure = (report[5] << 8) | report[6];
             Pressure = (uint)(0x0672 - (prePressure - (buttonPressed ? 50 : 0)));
 
             PenButtons =

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/CintiqV1/CintiqV1ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/CintiqV1/CintiqV1ReportParser.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1;
@@ -38,6 +37,6 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.CintiqV1
 
         private uint _prevPressure;
         private Vector2 _prevTilt;
-        private bool[] _prevPenButtons = Array.Empty<bool>();
+        private bool[] _prevPenButtons = [];
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3ExtraAuxReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3ExtraAuxReportParser.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1;
@@ -37,6 +36,6 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3
 
         private uint _prevPressure;
         private Vector2 _prevTilt;
-        private bool[] _prevPenButtons = Array.Empty<bool>();
+        private bool[] _prevPenButtons = [];
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3MouseReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3MouseReport.cs
@@ -11,8 +11,8 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3
 
             Position = new Vector2
             {
-                X = (report[3] | report[2] << 8) << 1 | report[9] >> 1 & 1,
-                Y = (report[5] | report[4] << 8) << 1 | report[9] & 1
+                X = ((report[3] | (report[2] << 8)) << 1) | ((report[9] >> 1) & 1),
+                Y = ((report[5] | (report[4] << 8)) << 1) | (report[9] & 1)
             };
             MouseButtons =
             [

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos3/Intuos3ReportParser.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1;
@@ -37,6 +36,6 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos3
 
         private uint _prevPressure;
         private Vector2 _prevTilt;
-        private bool[] _prevPenButtons = Array.Empty<bool>();
+        private bool[] _prevPenButtons = [];
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos4/Intuos4MouseReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos4/Intuos4MouseReport.cs
@@ -11,8 +11,8 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos4
 
             Position = new Vector2
             {
-                X = (report[3] | report[2] << 8) << 1 | report[9] >> 1 & 1,
-                Y = (report[5] | report[4] << 8) << 1 | report[9] & 1
+                X = ((report[3] | (report[2] << 8)) << 1) | ((report[9] >> 1) & 1),
+                Y = ((report[5] | (report[4] << 8)) << 1) | (report[9] & 1)
             };
             MouseButtons =
             [

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos4/Intuos4ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos4/Intuos4ReportParser.cs
@@ -28,6 +28,6 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos4
             };
         }
 
-        private IntuosV1ReportParser _IntuosV1ReportParser = new IntuosV1ReportParser();
+        private readonly IntuosV1ReportParser _IntuosV1ReportParser = new IntuosV1ReportParser();
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1ReportParser.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using OpenTabletDriver.Plugin.Tablet;
@@ -37,6 +36,6 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1
 
         private uint _prevPressure;
         private Vector2 _prevTilt;
-        private bool[] _prevPenButtons = Array.Empty<bool>();
+        private bool[] _prevPenButtons = [];
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1RotationReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1RotationReport.cs
@@ -11,8 +11,8 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1
 
             Position = new Vector2
             {
-                X = (report[3] | report[2] << 8) << 1 | ((report[9] >> 1) & 1),
-                Y = (report[5] | report[4] << 8) << 1 | (report[9] & 1)
+                X = ((report[3] | (report[2] << 8)) << 1) | ((report[9] >> 1) & 1),
+                Y = ((report[5] | (report[4] << 8)) << 1) | (report[9] & 1)
             };
             Tilt = _prevTilt;
             Pressure = _prevPressure;

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1TabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV1/IntuosV1TabletReport.cs
@@ -11,8 +11,8 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV1
 
             Position = new Vector2
             {
-                X = (report[3] | report[2] << 8) << 1 | ((report[9] >> 1) & 1),
-                Y = (report[5] | report[4] << 8) << 1 | (report[9] & 1)
+                X = ((report[3] | (report[2] << 8)) << 1) | ((report[9] >> 1) & 1),
+                Y = ((report[5] | (report[4] << 8)) << 1) | (report[9] & 1)
             };
             Tilt = new Vector2
             {

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV3/IntuosV3ExtendedReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosV3/IntuosV3ExtendedReport.cs
@@ -12,8 +12,8 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV3
 
             Position = new Vector2
             {
-                X = Unsafe.ReadUnaligned<ushort>(ref report[3]) | report[5] << 16,
-                Y = Unsafe.ReadUnaligned<ushort>(ref report[6]) | report[8] << 16
+                X = Unsafe.ReadUnaligned<ushort>(ref report[3]) | (report[5] << 16),
+                Y = Unsafe.ReadUnaligned<ushort>(ref report[6]) | (report[8] << 16)
             };
 
             Tilt = new Vector2

--- a/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenTabletGen2Report.cs
+++ b/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenTabletGen2Report.cs
@@ -12,10 +12,10 @@ namespace OpenTabletDriver.Configurations.Parsers.XP_Pen
 
             Position = new Vector2
             {
-                X = Unsafe.ReadUnaligned<ushort>(ref report[2]) | report[10] << 16,
-                Y = Unsafe.ReadUnaligned<ushort>(ref report[4]) | report[11] << 16
+                X = Unsafe.ReadUnaligned<ushort>(ref report[2]) | (report[10] << 16),
+                Y = Unsafe.ReadUnaligned<ushort>(ref report[4]) | (report[11] << 16)
             };
-            Pressure = (uint)((Unsafe.ReadUnaligned<ushort>(ref report[6]) & 0xBFFF) | (report[13] & 0x01) << 13);
+            Pressure = (uint)((Unsafe.ReadUnaligned<ushort>(ref report[6]) & 0xBFFF) | ((report[13] & 0x01) << 13));
             Eraser = report[1].IsBitSet(3);
 
             PenButtons =

--- a/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenTabletOverflowReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenTabletOverflowReport.cs
@@ -12,8 +12,8 @@ namespace OpenTabletDriver.Configurations.Parsers.XP_Pen
 
             Position = new Vector2
             {
-                X = Unsafe.ReadUnaligned<ushort>(ref report[2]) | report[10] << 16,
-                Y = Unsafe.ReadUnaligned<ushort>(ref report[4]) | report[11] << 16
+                X = Unsafe.ReadUnaligned<ushort>(ref report[2]) | (report[10] << 16),
+                Y = Unsafe.ReadUnaligned<ushort>(ref report[4]) | (report[11] << 16)
             };
             Pressure = Unsafe.ReadUnaligned<ushort>(ref report[6]);
             Eraser = report[1].IsBitSet(3);

--- a/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenTabletPressureOffsetOverflowReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenTabletPressureOffsetOverflowReport.cs
@@ -12,8 +12,8 @@ namespace OpenTabletDriver.Configurations.Parsers.XP_Pen
 
             Position = new Vector2
             {
-                X = Unsafe.ReadUnaligned<ushort>(ref report[2]) | report[10] << 16,
-                Y = Unsafe.ReadUnaligned<ushort>(ref report[4]) | report[11] << 16
+                X = Unsafe.ReadUnaligned<ushort>(ref report[2]) | (report[10] << 16),
+                Y = Unsafe.ReadUnaligned<ushort>(ref report[4]) | (report[11] << 16)
             };
             Pressure = (uint)(Unsafe.ReadUnaligned<ushort>(ref report[6]) & 0x1FFF);
             Eraser = report[1].IsBitSet(3);

--- a/OpenTabletDriver.Console/CommandTools.cs
+++ b/OpenTabletDriver.Console/CommandTools.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace OpenTabletDriver.Console
 {
-    static class CommandTools
+    internal static class CommandTools
     {
         private static Command SetupCommand<T>(T action, string description, params string[] aliases)
             where T : Delegate

--- a/OpenTabletDriver.Console/Program.Commands.cs
+++ b/OpenTabletDriver.Console/Program.Commands.cs
@@ -16,7 +16,7 @@ using static System.Console;
 
 namespace OpenTabletDriver.Console
 {
-    partial class Program
+    internal partial class Program
     {
         #region Update
 

--- a/OpenTabletDriver.Console/Program.IPC.cs
+++ b/OpenTabletDriver.Console/Program.IPC.cs
@@ -3,7 +3,7 @@ using OpenTabletDriver.Desktop.RPC;
 
 namespace OpenTabletDriver.Console
 {
-    partial class Program
+    internal partial class Program
     {
         public static readonly RpcClient<IDriverDaemon> Driver = new RpcClient<IDriverDaemon>("OpenTabletDriver.Daemon");
     }

--- a/OpenTabletDriver.Console/Program.Misc.cs
+++ b/OpenTabletDriver.Console/Program.Misc.cs
@@ -10,31 +10,31 @@ using static System.Console;
 
 namespace OpenTabletDriver.Console
 {
-    partial class Program
+    internal partial class Program
     {
-        static SHA256 sha256 = SHA256.Create();
+        private static SHA256 sha256 = SHA256.Create();
 
-        static async Task<Settings> GetSettings()
+        private static async Task<Settings> GetSettings()
         {
             if (!await EnsureDaemonReady())
                 throw new InvalidOperationException("Cannot get settings without a daemon");
             return await Driver.Instance.GetSettings();
         }
 
-        static async Task ApplySettings(Settings settings)
+        private static async Task ApplySettings(Settings settings)
         {
             if (!await EnsureDaemonReady()) return;
             await Driver.Instance.SetSettings(settings);
         }
 
-        static async Task ModifySettings(Action<Settings> func)
+        private static async Task ModifySettings(Action<Settings> func)
         {
             var settings = await GetSettings();
             func.Invoke(settings);
             await ApplySettings(settings);
         }
 
-        static async Task ModifyProfile(string profileName, Action<Profile> func)
+        private static async Task ModifyProfile(string profileName, Action<Profile> func)
         {
             await ModifySettings(async s =>
             {
@@ -50,7 +50,7 @@ namespace OpenTabletDriver.Console
             });
         }
 
-        static async Task<Profile> GetProfile(string profileName, Settings settings = null)
+        private static async Task<Profile> GetProfile(string profileName, Settings settings = null)
         {
             if (!await EnsureDaemonReady())
                 throw new InvalidOperationException("Cannot get a profile without a daemon");
@@ -70,7 +70,7 @@ namespace OpenTabletDriver.Console
             return profile ?? throw new ArgumentException($"Cannot find profile for tablet '{profileName}'");
         }
 
-        static async Task ListTypes<T>(Func<Type, bool> predicate = null)
+        private static async Task ListTypes<T>(Func<Type, bool> predicate = null)
         {
             if (!await EnsureDaemonReady()) return;
             var types = AppInfo.PluginManager.GetChildTypes<T>();
@@ -91,14 +91,14 @@ namespace OpenTabletDriver.Console
             }
         }
 
-        static string GetSHA256(string path)
+        private static string GetSHA256(string path)
         {
             var data = File.ReadAllBytes(path);
             var hash = sha256.ComputeHash(data);
             return string.Join(null, hash.Select(b => b.ToString("X")));
         }
 
-        static void AppendPluginStoreSettingsCollectionByPaths<T>(PluginSettingStoreCollection pssc, params string[] paths) where T : class
+        private static void AppendPluginStoreSettingsCollectionByPaths<T>(PluginSettingStoreCollection pssc, params string[] paths) where T : class
         {
             foreach (var path in paths)
             {
@@ -115,7 +115,7 @@ namespace OpenTabletDriver.Console
             }
         }
 
-        static void DisableAllInPluginStoreSettingsCollectionByPaths(PluginSettingStoreCollection pssc, params string[] paths)
+        private static void DisableAllInPluginStoreSettingsCollectionByPaths(PluginSettingStoreCollection pssc, params string[] paths)
         {
             foreach (string path in paths)
             {

--- a/OpenTabletDriver.Console/Program.Misc.cs
+++ b/OpenTabletDriver.Console/Program.Misc.cs
@@ -12,7 +12,7 @@ namespace OpenTabletDriver.Console
 {
     internal partial class Program
     {
-        private static SHA256 sha256 = SHA256.Create();
+        private static readonly SHA256 sha256 = SHA256.Create();
 
         private static async Task<Settings> GetSettings()
         {

--- a/OpenTabletDriver.Console/Program.cs
+++ b/OpenTabletDriver.Console/Program.cs
@@ -9,7 +9,7 @@ namespace OpenTabletDriver.Console
 {
     using static CommandTools;
 
-    partial class Program
+    internal partial class Program
     {
         public static async Task Main(string[] args)
         {

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -139,7 +139,7 @@ namespace OpenTabletDriver.Daemon
 
         public Driver Driver { get; }
         private Settings? Settings { set; get; }
-        private Collection<ITool> Tools { set; get; } = new Collection<ITool>();
+        private Collection<ITool> Tools { set; get; } = [];
         private readonly IUpdater Updater = DesktopInterop.Updater;
         private readonly ISleepDetector? SleepDetector = new SleepDetector();
         private Settings? lastValidSettings;
@@ -412,7 +412,7 @@ namespace OpenTabletDriver.Daemon
                             where filter != null
                             select filter!).ToArray();
 
-            outputMode.Elements = elements.Append(bindingHandler).ToList();
+            outputMode.Elements = [.. elements, bindingHandler];
 
             foreach (var filter in elements)
             {

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -140,12 +140,12 @@ namespace OpenTabletDriver.Daemon
         public Driver Driver { get; }
         private Settings? Settings { set; get; }
         private Collection<ITool> Tools { set; get; } = new Collection<ITool>();
-        private IUpdater Updater = DesktopInterop.Updater;
+        private readonly IUpdater Updater = DesktopInterop.Updater;
         private readonly ISleepDetector? SleepDetector = new SleepDetector();
         private Settings? lastValidSettings;
 
         private UpdateInfo? _updateInfo;
-        private LogFile _logFile;
+        private readonly LogFile _logFile;
 
         private bool debugging;
 

--- a/OpenTabletDriver.Daemon/Program.cs
+++ b/OpenTabletDriver.Daemon/Program.cs
@@ -15,15 +15,15 @@ using OpenTabletDriver.Plugin.Components;
 
 namespace OpenTabletDriver.Daemon
 {
-    class CommandLineOptions
+    internal class CommandLineOptions
     {
         public DirectoryInfo AppDataDirectory { get; set; }
         public DirectoryInfo ConfigurationDirectory { get; set; }
     }
 
-    partial class Program
+    internal partial class Program
     {
-        static async Task Main(string[] args)
+        private static async Task Main(string[] args)
         {
             Log.Output += (sender, message) =>
             {
@@ -40,7 +40,7 @@ namespace OpenTabletDriver.Daemon
             await StartDaemon();
         }
 
-        static async Task StartDaemon()
+        private static async Task StartDaemon()
         {
             using var instance = new Instance("OpenTabletDriver.Daemon");
             if (instance.AlreadyExists)
@@ -134,7 +134,7 @@ namespace OpenTabletDriver.Daemon
             return host;
         }
 
-        static CommandLineOptions ParseCmdLineOptions(string[] args)
+        private static CommandLineOptions ParseCmdLineOptions(string[] args)
         {
             var cmdLineOptions = new CommandLineOptions();
 
@@ -175,7 +175,7 @@ namespace OpenTabletDriver.Daemon
             return cmdLineOptions;
         }
 
-        static DriverDaemon BuildDaemon()
+        private static DriverDaemon BuildDaemon()
         {
             return new DriverDaemon(new DriverBuilder()
                 .ConfigureServices(serviceCollection =>

--- a/OpenTabletDriver.Desktop/AppInfo.cs
+++ b/OpenTabletDriver.Desktop/AppInfo.cs
@@ -11,16 +11,6 @@ namespace OpenTabletDriver.Desktop
 
     public class AppInfo
     {
-        private string configurationDirectory,
-            settingsFile,
-            pluginDirectory,
-            presetDirectory,
-            logDirectory,
-            temporaryDirectory,
-            cacheDirectory,
-            backupDirectory,
-            trashDirectory;
-
         public AppInfo()
         {
             // on Linux, verify presence of necessary environment variables (as '~' expands to $HOME environment variable)
@@ -32,11 +22,10 @@ namespace OpenTabletDriver.Desktop
             }
         }
 
-        private static AppInfo current;
         public static AppInfo Current
         {
-            set => current = value;
-            get => current ??= SystemInterop.CurrentPlatform switch
+            set;
+            get => field ??= SystemInterop.CurrentPlatform switch
             {
                 PluginPlatform.Windows => new AppInfo
                 {
@@ -67,56 +56,56 @@ namespace OpenTabletDriver.Desktop
 
         public string ConfigurationDirectory
         {
-            set => this.configurationDirectory = value;
-            get => this.configurationDirectory ?? GetDefaultConfigurationDirectory();
+            set;
+            get => field ?? GetDefaultConfigurationDirectory();
         }
 
         public string SettingsFile
         {
-            set => this.settingsFile = value;
-            get => this.settingsFile ?? GetDefaultSettingsFile();
+            set;
+            get => field ?? GetDefaultSettingsFile();
         }
 
         public string PluginDirectory
         {
-            set => this.pluginDirectory = value;
-            get => this.pluginDirectory ?? GetDefaultPluginDirectory();
+            set;
+            get => field ?? GetDefaultPluginDirectory();
         }
 
         public string PresetDirectory
         {
-            set => this.presetDirectory = value;
-            get => this.presetDirectory ?? GetDefaultPresetDirectory();
+            set;
+            get => field ?? GetDefaultPresetDirectory();
         }
 
         public string LogDirectory
         {
-            set => this.logDirectory = value;
-            get => this.logDirectory ?? GetDefaultLogDirectory();
+            set;
+            get => field ?? GetDefaultLogDirectory();
         }
 
         public string TemporaryDirectory
         {
-            set => this.temporaryDirectory = value;
-            get => this.temporaryDirectory ?? GetDefaultTemporaryDirectory();
+            set;
+            get => field ?? GetDefaultTemporaryDirectory();
         }
 
         public string CacheDirectory
         {
-            set => this.cacheDirectory = value;
-            get => this.cacheDirectory ?? GetDefaultCacheDirectory();
+            set;
+            get => field ?? GetDefaultCacheDirectory();
         }
 
         public string BackupDirectory
         {
-            set => this.backupDirectory = value;
-            get => this.backupDirectory ?? GetDefaultBackupDirectory();
+            set;
+            get => field ?? GetDefaultBackupDirectory();
         }
 
         public string TrashDirectory
         {
-            set => this.trashDirectory = value;
-            get => this.trashDirectory ?? GetDefaultTrashDirectory();
+            set;
+            get => field ?? GetDefaultTrashDirectory();
         }
 
         public static string ProgramDirectory => AppContext.BaseDirectory;

--- a/OpenTabletDriver.Desktop/Binding/AdaptiveBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/AdaptiveBinding.cs
@@ -41,21 +41,19 @@ namespace OpenTabletDriver.Desktop.Binding
 
         public static string[] ButtonNames => [.. ValidButtons.Keys];
 
-        private string _binding = string.Empty;
-
         [Property(nameof(Binding)), PropertyValidated(nameof(ButtonNames))]
         public string Binding
         {
-            get => _binding;
+            get;
             set
             {
                 if (!ValidButtons.TryGetValue(value, out var button))
                     throw new ArgumentException("Invalid button name", value);
 
                 _action = button;
-                _binding = value;
+                field = value;
             }
-        }
+        } = string.Empty;
 
         public void Press(TabletReference tablet, IDeviceReport report)
         {

--- a/OpenTabletDriver.Desktop/Binding/AdaptiveBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/AdaptiveBinding.cs
@@ -39,7 +39,7 @@ namespace OpenTabletDriver.Desktop.Binding
             Binding = ActionToString(action);
         }
 
-        public static string[] ButtonNames => ValidButtons.Keys.ToArray();
+        public static string[] ButtonNames => [.. ValidButtons.Keys];
 
         private string _binding = string.Empty;
 

--- a/OpenTabletDriver.Desktop/Binding/BindingHandler.cs
+++ b/OpenTabletDriver.Desktop/Binding/BindingHandler.cs
@@ -26,14 +26,14 @@ namespace OpenTabletDriver.Desktop.Binding
         public ThresholdBindingState? Eraser { set; get; }
         private bool _isEraser;
 
-        public Dictionary<int, BindingState?> PenButtons { set; get; } = new Dictionary<int, BindingState?>();
-        public Dictionary<int, BindingState?> AuxButtons { set; get; } = new Dictionary<int, BindingState?>();
-        public Dictionary<int, BindingState?> MouseButtons { set; get; } = new Dictionary<int, BindingState?>();
+        public Dictionary<int, BindingState?> PenButtons { set; get; } = [];
+        public Dictionary<int, BindingState?> AuxButtons { set; get; } = [];
+        public Dictionary<int, BindingState?> MouseButtons { set; get; } = [];
 
         public BindingState? MouseScrollDown { set; get; }
         public BindingState? MouseScrollUp { set; get; }
 
-        public Dictionary<int, WheelBindings> Wheels { get; } = new Dictionary<int, WheelBindings>();
+        public Dictionary<int, WheelBindings> Wheels { get; } = [];
 
         public PipelinePosition Position => PipelinePosition.PostTransform;
 

--- a/OpenTabletDriver.Desktop/Binding/KeyBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/KeyBinding.cs
@@ -42,10 +42,9 @@ namespace OpenTabletDriver.Desktop.Binding
                 Keyboard?.Release(Key);
         }
 
-        private static IEnumerable<string>? validKeys;
         public static IEnumerable<string>? ValidKeys
         {
-            get => validKeys ??= SystemInterop.CurrentPlatform switch
+            get => field ??= SystemInterop.CurrentPlatform switch
             {
                 PluginPlatform.Windows => WindowsVirtualKeyboard.EtoKeysymToVK.Keys,
                 PluginPlatform.Linux => EvdevVirtualKeyboard.EtoKeysymToEventCode.Keys,

--- a/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModeButtonBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModeButtonBinding.cs
@@ -19,8 +19,7 @@ namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
 
         [Resolved] public IPressureHandler? PressureHandler;
 
-        private EvdevVirtualTablet? _virtualTablet;
-        private EvdevVirtualTablet? VirtualTablet => _virtualTablet ??= PressureHandler as EvdevVirtualTablet;
+        private EvdevVirtualTablet? VirtualTablet => field ??= PressureHandler as EvdevVirtualTablet;
 
         [OnDependencyLoad]
         public void VerifyInitialization()

--- a/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModeButtonBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModeButtonBinding.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using OpenTabletDriver.Desktop.Interop.Input.Absolute;
 using OpenTabletDriver.Native.Linux.Evdev;
 using OpenTabletDriver.Plugin;
@@ -37,7 +36,7 @@ namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
             { "Pen Button 3", EventCode.BTN_STYLUS3 },
         };
 
-        public static string[] ValidButtons => SupportedButtons.Keys.ToArray();
+        public static string[] ValidButtons => [.. SupportedButtons.Keys];
 
         [Property("Button"), PropertyValidated(nameof(ValidButtons))]
         public string? Button { get; set; }

--- a/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModePadBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModePadBinding.cs
@@ -42,7 +42,7 @@ namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
         };
 
 
-        public static string[] ValidKeys => s_ValidButtons.Keys.ToArray();
+        public static string[] ValidKeys => [.. s_ValidButtons.Keys];
 
         [Property("Button"), PropertyValidated(nameof(ValidKeys))]
         public string? Button

--- a/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModePadBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModePadBinding.cs
@@ -47,10 +47,10 @@ namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
         [Property("Button"), PropertyValidated(nameof(ValidKeys))]
         public string? Button
         {
-            get => _button;
+            get;
             set
             {
-                _button = value;
+                field = value;
                 if (value != null)
                     _buttonPadEvent = s_ValidButtons.First(x => x.Key == value).Value;
                 else
@@ -58,7 +58,6 @@ namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
             }
         }
 
-        private string? _button;
         private TabletPadEvent? _buttonPadEvent;
 
         public void Press(TabletReference tablet, IDeviceReport report)

--- a/OpenTabletDriver.Desktop/Binding/MouseBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/MouseBinding.cs
@@ -43,9 +43,8 @@ namespace OpenTabletDriver.Desktop.Binding
                 Pointer?.MouseUp(mouseButton);
         }
 
-        private static IEnumerable<string>? validButtons;
         public static IEnumerable<string> ValidButtons =>
-            validButtons ??= Enum.GetValues<MouseButton>().Select(Enum.GetName)!;
+            field ??= Enum.GetValues<MouseButton>().Select(Enum.GetName)!;
 
         public override string ToString() => $"{PLUGIN_NAME}: {Button}";
     }

--- a/OpenTabletDriver.Desktop/Binding/MouseScrollBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/MouseScrollBinding.cs
@@ -16,10 +16,7 @@ namespace OpenTabletDriver.Desktop.Binding
     public class MouseScrollBinding : IStateBinding
     {
         private const string PLUGIN_NAME = "Mouse Scroll Binding";
-
-        private ITimer? _timer;
         private ScrollDirection _direction;
-        private int _interval = 1;
 
         [Resolved]
         public IMouseScrollHandler? Pointer { set; get; }
@@ -27,18 +24,18 @@ namespace OpenTabletDriver.Desktop.Binding
         [Resolved]
         public ITimer? Timer
         {
-            get => _timer;
+            get;
             set
             {
-                if (_timer != null)
-                    _timer.Elapsed -= Scroll;
+                if (field != null)
+                    field.Elapsed -= Scroll;
 
-                _timer = value;
+                field = value;
 
-                if (_timer != null)
+                if (field != null)
                 {
-                    _timer.Interval = _interval;
-                    _timer.Elapsed += Scroll;
+                    field.Interval = Interval;
+                    field.Elapsed += Scroll;
                 }
             }
         }
@@ -65,8 +62,6 @@ namespace OpenTabletDriver.Desktop.Binding
             }
         }
 
-        private int _amount = 120;
-
         [Property("Amount"),
          DefaultPropertyValue(120),
          ToolTip("The amount to scroll. A negative value will scroll up or left " +
@@ -74,9 +69,9 @@ namespace OpenTabletDriver.Desktop.Binding
                  "Note: A tick equals to 120 on Windows & Linux.")]
         public int Amount
         {
-            get => _amount;
-            set => _amount = value != 0 ? value : 1;
-        }
+            get;
+            set => field = value != 0 ? value : 1;
+        } = 120;
 
         [Property("Interval"),
          DefaultPropertyValue(300),
@@ -84,14 +79,14 @@ namespace OpenTabletDriver.Desktop.Binding
          ToolTip("The interval at which to scroll.")]
         public int Interval
         {
-            get => _interval;
+            get;
             set
             {
-                _interval = Math.Max(1, value);
-                if (_timer != null)
-                    _timer.Interval = _interval;
+                field = Math.Max(1, value);
+                if (Timer != null)
+                    Timer.Interval = field;
             }
-        }
+        } = 1;
 
         public void Press(TabletReference tablet, IDeviceReport report)
         {
@@ -112,9 +107,8 @@ namespace OpenTabletDriver.Desktop.Binding
                 synchronousPointer.Flush();
         }
 
-        private static IEnumerable<string>? validDirections;
         public static IEnumerable<string> ValidDirections =>
-            validDirections ??= Enum.GetValues<ScrollDirection>().Select(Enum.GetName)!;
+            field ??= Enum.GetValues<ScrollDirection>().Select(Enum.GetName)!;
 
         public override string ToString() => $"{PLUGIN_NAME}: Direction: {Direction}, Amount: {Amount}, Interval: {Interval}";
     }

--- a/OpenTabletDriver.Desktop/Binding/MouseScrollBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/MouseScrollBinding.cs
@@ -83,8 +83,7 @@ namespace OpenTabletDriver.Desktop.Binding
             set
             {
                 field = Math.Max(1, value);
-                if (Timer != null)
-                    Timer.Interval = field;
+                Timer?.Interval = field;
             }
         } = 1;
 

--- a/OpenTabletDriver.Desktop/Binding/MultiKeyBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/MultiKeyBinding.cs
@@ -17,7 +17,6 @@ namespace OpenTabletDriver.Desktop.Binding
         private const char KEYS_SPLITTER = '+';
 
         private string[] keys = [];
-        private string? keysString;
 
         [Resolved]
         public IVirtualKeyboard? Keyboard { set; get; }
@@ -35,10 +34,10 @@ namespace OpenTabletDriver.Desktop.Binding
         {
             set
             {
-                this.keysString = value;
+                field = value;
                 this.keys = ParseKeys(Keys);
             }
-            get => this.keysString;
+            get;
         }
 
         public void Press(TabletReference tablet, IDeviceReport report)

--- a/OpenTabletDriver.Desktop/Binding/PresetBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/PresetBinding.cs
@@ -16,7 +16,7 @@ namespace OpenTabletDriver.Desktop.Binding
         private static readonly HPETDeltaStopwatch _stopwatch = new();
 
         public static readonly IReadOnlyCollection<Preset> Presets = AppInfo.PresetManager.GetPresets();
-        public static string[] ValidPresets => Presets.Select(x => x.Name).ToArray();
+        public static string[] ValidPresets => [.. Presets.Select(x => x.Name)];
 
         [Property("Preset"), PropertyValidated(nameof(ValidPresets))]
         public string Preset { set; get; }

--- a/OpenTabletDriver.Desktop/Binding/PresetBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/PresetBinding.cs
@@ -13,9 +13,9 @@ namespace OpenTabletDriver.Desktop.Binding
     public class PresetBinding : IStateBinding
     {
         private const int TIMEOUT = 50;
-        private readonly static HPETDeltaStopwatch _stopwatch = new();
+        private static readonly HPETDeltaStopwatch _stopwatch = new();
 
-        public readonly static IReadOnlyCollection<Preset> Presets = AppInfo.PresetManager.GetPresets();
+        public static readonly IReadOnlyCollection<Preset> Presets = AppInfo.PresetManager.GetPresets();
         public static string[] ValidPresets => Presets.Select(x => x.Name).ToArray();
 
         [Property("Preset"), PropertyValidated(nameof(ValidPresets))]

--- a/OpenTabletDriver.Desktop/Binding/WheelBindings.cs
+++ b/OpenTabletDriver.Desktop/Binding/WheelBindings.cs
@@ -28,7 +28,7 @@ namespace OpenTabletDriver.Desktop.Binding
             _stepsPerTick = 360d / stepCount;
         }
 
-        public Dictionary<int, BindingState?> WheelButtons { get; } = new();
+        public Dictionary<int, BindingState?> WheelButtons { get; } = [];
 
         public DeltaThresholdBindingState? ClockwiseRotation { set; get; }
         public DeltaThresholdBindingState? CounterClockwiseRotation { set; get; }

--- a/OpenTabletDriver.Desktop/Conversion/GaomonV2AreaConverter.cs
+++ b/OpenTabletDriver.Desktop/Conversion/GaomonV2AreaConverter.cs
@@ -21,10 +21,10 @@ namespace OpenTabletDriver.Desktop.Conversion
         {
             var digitizer = tablet.Properties.Specifications.Digitizer;
 
-            var oWidth = (iWidth / digitizer.MaxX) * digitizer.Width;
-            var oHeight = (iHeight / digitizer.MaxY) * digitizer.Height;
-            var offsetX = (x / digitizer.MaxX) * digitizer.Width + (oWidth / 2);
-            var offsetY = (x / digitizer.MaxY) * digitizer.Height + (oHeight / 2);
+            var oWidth = iWidth / digitizer.MaxX * digitizer.Width;
+            var oHeight = iHeight / digitizer.MaxY * digitizer.Height;
+            var offsetX = (x / digitizer.MaxX * digitizer.Width) + (oWidth / 2);
+            var offsetY = (x / digitizer.MaxY * digitizer.Height) + (oHeight / 2);
 
             return new Area((float)oWidth, (float)oHeight, new Vector2((float)offsetX, (float)offsetY), 0f);
         }

--- a/OpenTabletDriver.Desktop/DesktopDeviceConfigurationProvider.cs
+++ b/OpenTabletDriver.Desktop/DesktopDeviceConfigurationProvider.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/OpenTabletDriver.Desktop/DesktopDeviceConfigurationProvider.cs
+++ b/OpenTabletDriver.Desktop/DesktopDeviceConfigurationProvider.cs
@@ -19,7 +19,7 @@ namespace OpenTabletDriver.Desktop
 
         private IEnumerable<TabletConfiguration> GetTabletConfigurations()
         {
-            IEnumerable<(ConfigurationSource, TabletConfiguration)> jsonConfigurations = Array.Empty<(ConfigurationSource, TabletConfiguration)>();
+            IEnumerable<(ConfigurationSource, TabletConfiguration)> jsonConfigurations = [];
 
             if (Directory.Exists(AppInfo.Current.ConfigurationDirectory))
             {

--- a/OpenTabletDriver.Desktop/FileUtilities.cs
+++ b/OpenTabletDriver.Desktop/FileUtilities.cs
@@ -36,7 +36,7 @@ namespace OpenTabletDriver.Desktop
 
         public static string InjectEnvironmentVariables(string str)
         {
-            StringBuilder sb = new StringBuilder(str);
+            var sb = new StringBuilder(str);
             sb.Replace("~", Environment.GetEnvironmentVariable("HOME"));
 
             foreach (DictionaryEntry envVar in Environment.GetEnvironmentVariables())

--- a/OpenTabletDriver.Desktop/Helpers.cs
+++ b/OpenTabletDriver.Desktop/Helpers.cs
@@ -20,7 +20,7 @@ namespace OpenTabletDriver.Desktop
             int bucketCount = (int)Math.Ceiling((double)count / maxValuePerBucket);
 
             // initialize number of elements
-            int[] rv = Enumerable.Repeat(0, bucketCount).ToArray();
+            int[] rv = [.. Enumerable.Repeat(0, bucketCount)];
 
             int remaining = count;
             int index = 0;

--- a/OpenTabletDriver.Desktop/Interop/DesktopInterop.cs
+++ b/OpenTabletDriver.Desktop/Interop/DesktopInterop.cs
@@ -23,14 +23,6 @@ namespace OpenTabletDriver.Desktop.Interop
         {
         }
 
-        private static IUpdater updater;
-        private static IVirtualScreen virtualScreen;
-        private static IAbsolutePointer absolutePointer;
-        private static IRelativePointer relativePointer;
-        private static IPressureHandler virtualTablet;
-        private static IVirtualKeyboard virtualKeyboard;
-        private static IVirtualPad virtualPad;
-
         public static void Open(string path)
         {
             switch (CurrentPlatform)
@@ -69,8 +61,8 @@ namespace OpenTabletDriver.Desktop.Interop
 
         public static IUpdater Updater => CurrentPlatform switch
         {
-            PluginPlatform.Windows => updater ??= new WindowsUpdater(AppInfo.Current, GitHubClient),
-            PluginPlatform.MacOS => updater ??= new MacOSUpdater(AppInfo.Current, GitHubClient),
+            PluginPlatform.Windows => field ??= new WindowsUpdater(AppInfo.Current, GitHubClient),
+            PluginPlatform.MacOS => field ??= new MacOSUpdater(AppInfo.Current, GitHubClient),
             _ => null
         };
 
@@ -85,7 +77,7 @@ namespace OpenTabletDriver.Desktop.Interop
         public static IAbsolutePointer AbsolutePointer => CurrentPlatform switch
         {
             PluginPlatform.Windows => new WindowsAbsolutePointer(),
-            PluginPlatform.Linux => absolutePointer ??= new EvdevAbsolutePointer(),
+            PluginPlatform.Linux => field ??= new EvdevAbsolutePointer(),
             PluginPlatform.MacOS => new MacOSAbsolutePointer(),
             _ => null
         };
@@ -93,32 +85,32 @@ namespace OpenTabletDriver.Desktop.Interop
         public static IRelativePointer RelativePointer => CurrentPlatform switch
         {
             PluginPlatform.Windows => new WindowsRelativePointer(),
-            PluginPlatform.Linux => relativePointer ??= new EvdevRelativePointer(),
+            PluginPlatform.Linux => field ??= new EvdevRelativePointer(),
             PluginPlatform.MacOS => new MacOSRelativePointer(),
             _ => null
         };
 
         public static IPressureHandler VirtualTablet => CurrentPlatform switch
         {
-            PluginPlatform.Linux => virtualTablet ??= new EvdevVirtualTablet(),
+            PluginPlatform.Linux => field ??= new EvdevVirtualTablet(),
             _ => null
         };
 
         public static IVirtualKeyboard VirtualKeyboard => CurrentPlatform switch
         {
             PluginPlatform.Windows => new WindowsVirtualKeyboard(),
-            PluginPlatform.Linux => virtualKeyboard ??= new EvdevVirtualKeyboard(),
-            PluginPlatform.MacOS => virtualKeyboard ??= new MacOSVirtualKeyboard(),
+            PluginPlatform.Linux => field ??= new EvdevVirtualKeyboard(),
+            PluginPlatform.MacOS => field ??= new MacOSVirtualKeyboard(),
             _ => null
         };
 
         public static IVirtualPad VirtualPad => CurrentPlatform switch
         {
-            PluginPlatform.Linux => virtualPad ??= new EvdevVirtualPad(),
+            PluginPlatform.Linux => field ??= new EvdevVirtualPad(),
             _ => null
         };
 
-        public static IVirtualScreen VirtualScreen => virtualScreen ??= CurrentPlatform switch
+        public static IVirtualScreen VirtualScreen => field ??= CurrentPlatform switch
         {
             PluginPlatform.Windows => new WindowsDisplay(),
             PluginPlatform.Linux => ConstructLinuxDisplay(),

--- a/OpenTabletDriver.Desktop/Interop/Display/MacOSDisplay.cs
+++ b/OpenTabletDriver.Desktop/Interop/Display/MacOSDisplay.cs
@@ -43,7 +43,7 @@ namespace OpenTabletDriver.Desktop.Interop.Display
             return $"VirtualDisplay {Index} ({Width}x{Height}@{Position})";
         }
 
-        private Lazy<IEnumerable<IDisplay>> _displays = new Lazy<IEnumerable<IDisplay>>(() =>
+        private readonly Lazy<IEnumerable<IDisplay>> _displays = new Lazy<IEnumerable<IDisplay>>(() =>
         {
             var displayBounds = GetDisplayBounds().ToList();
             var offsetX = displayBounds.Min(d => d.origin.x);

--- a/OpenTabletDriver.Desktop/Interop/Display/WaylandDisplay.cs
+++ b/OpenTabletDriver.Desktop/Interop/Display/WaylandDisplay.cs
@@ -24,9 +24,11 @@ namespace OpenTabletDriver.Desktop.Interop.Display
                     switch (@interface)
                     {
                         case "wl_output":
-                            var output = new WaylandOutput();
-                            output.Index = _outputs.Count + 1;
-                            output.WlOutput = wlRegistry.Bind<WlOutput>(name, @interface, 1);
+                            var output = new WaylandOutput
+                            {
+                                Index = _outputs.Count + 1,
+                                WlOutput = wlRegistry.Bind<WlOutput>(name, @interface, 1)
+                            };
                             output.WlOutput.Geometry += (wlOutput, x, y, physicalWidth, physicalHeight, subpixel, make, model, transform) =>
                             {
                                 if (output.XdgOutput == null || output.XdgOutput.Version < 2)

--- a/OpenTabletDriver.Desktop/Interop/Display/WaylandDisplay.cs
+++ b/OpenTabletDriver.Desktop/Interop/Display/WaylandDisplay.cs
@@ -10,7 +10,7 @@ namespace OpenTabletDriver.Desktop.Interop.Display
 {
     public class WaylandDisplay : IVirtualScreen
     {
-        private List<WaylandOutput> _outputs;
+        private readonly List<WaylandOutput> _outputs;
 
         public WaylandDisplay()
         {

--- a/OpenTabletDriver.Desktop/Interop/Display/WaylandDisplay.cs
+++ b/OpenTabletDriver.Desktop/Interop/Display/WaylandDisplay.cs
@@ -14,7 +14,7 @@ namespace OpenTabletDriver.Desktop.Interop.Display
 
         public WaylandDisplay()
         {
-            _outputs = new List<WaylandOutput>();
+            _outputs = [];
             using (var connection = new WaylandClientConnection())
             {
                 ZxdgOutputManagerV1 outputManager = null;

--- a/OpenTabletDriver.Desktop/Interop/Display/WindowsDisplay.cs
+++ b/OpenTabletDriver.Desktop/Interop/Display/WindowsDisplay.cs
@@ -48,7 +48,7 @@ namespace OpenTabletDriver.Desktop.Interop.Display
             List<DisplayInfo> displayCollection = [];
             MonitorEnumDelegate monitorDelegate = delegate (IntPtr hMonitor, IntPtr hdcMonitor, ref Rect lprcMonitor, IntPtr dwData)
             {
-                MonitorInfoEx monitorInfo = new MonitorInfoEx();
+                var monitorInfo = new MonitorInfoEx();
                 monitorInfo.size = (uint)Marshal.SizeOf(monitorInfo);
                 if (GetMonitorInfo(hMonitor, ref monitorInfo))
                 {
@@ -63,7 +63,7 @@ namespace OpenTabletDriver.Desktop.Interop.Display
                         bottom = info.dmPositionY + info.dmPelsHeight
                     };
 
-                    DisplayInfo displayInfo = new DisplayInfo(monitor, monitorInfo.flags);
+                    var displayInfo = new DisplayInfo(monitor, monitorInfo.flags);
                     displayCollection.Add(displayInfo);
                 }
                 return true;

--- a/OpenTabletDriver.Desktop/Interop/Display/WindowsDisplay.cs
+++ b/OpenTabletDriver.Desktop/Interop/Display/WindowsDisplay.cs
@@ -25,8 +25,7 @@ namespace OpenTabletDriver.Desktop.Interop.Display
             var monitors = GetDisplays();
             var primary = monitors.FirstOrDefault(m => m.IsPrimary);
 
-            var displays = new List<IDisplay>();
-            displays.Add(this);
+            var displays = new List<IDisplay> { this };
             foreach (var monitor in monitors)
             {
                 var display = new Display(

--- a/OpenTabletDriver.Desktop/Interop/Display/WindowsDisplay.cs
+++ b/OpenTabletDriver.Desktop/Interop/Display/WindowsDisplay.cs
@@ -45,7 +45,7 @@ namespace OpenTabletDriver.Desktop.Interop.Display
 
         private static List<DisplayInfo> GetDisplays()
         {
-            List<DisplayInfo> displayCollection = new List<DisplayInfo>();
+            List<DisplayInfo> displayCollection = [];
             MonitorEnumDelegate monitorDelegate = delegate (IntPtr hMonitor, IntPtr hdcMonitor, ref Rect lprcMonitor, IntPtr dwData)
             {
                 MonitorInfoEx monitorInfo = new MonitorInfoEx();

--- a/OpenTabletDriver.Desktop/Interop/Display/XScreen.cs
+++ b/OpenTabletDriver.Desktop/Interop/Display/XScreen.cs
@@ -20,8 +20,7 @@ namespace OpenTabletDriver.Desktop.Interop.Display
             var monitors = GetXRandrDisplays().ToList();
             var primary = monitors.FirstOrDefault(d => d.Primary != 0);
 
-            var displays = new List<IDisplay>();
-            displays.Add(this);
+            var displays = new List<IDisplay> { this };
             foreach (var monitor in monitors)
             {
                 var display = new Interop.Display.Display(

--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -16,7 +16,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
 
         private EvdevDevice Device { set; get; }
 
-        private EventCode[] supportedEventCodes =
+        private readonly EventCode[] supportedEventCodes =
         [
             EventCode.BTN_TOUCH,
             EventCode.BTN_STYLUS,

--- a/OpenTabletDriver.Desktop/Interop/Input/Exotic/EvdevVirtualPad.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Exotic/EvdevVirtualPad.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using OpenTabletDriver.Native.Linux;
 using OpenTabletDriver.Native.Linux.Evdev;
 using OpenTabletDriver.Native.Linux.Evdev.Structs;
@@ -26,7 +25,7 @@ public sealed class EvdevVirtualPad : IVirtualPad, IDisposable
         { TabletPadEvent.BUTTON_10, EventCode.BTN_9 },
     };
 
-    private static readonly EventCode[] s_SupportedEventCodes = s_ValidButtons.Values.ToArray();
+    private static readonly EventCode[] s_SupportedEventCodes = [.. s_ValidButtons.Values];
 
     public unsafe EvdevVirtualPad()
     {

--- a/OpenTabletDriver.Desktop/Interop/Input/Keyboard/EvdevVirtualKeyboard.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Keyboard/EvdevVirtualKeyboard.cs
@@ -14,7 +14,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Keyboard
         {
             Device = new EvdevDevice("OpenTabletDriver Virtual Keyboard");
 
-            Device.EnableTypeCodes(EventType.EV_KEY, EtoKeysymToEventCode.Values.Distinct().ToArray());
+            Device.EnableTypeCodes(EventType.EV_KEY, [.. EtoKeysymToEventCode.Values.Distinct()]);
 
             var result = Device.Initialize();
             switch (result)

--- a/OpenTabletDriver.Desktop/Interop/Timer/FallbackTimer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Timer/FallbackTimer.cs
@@ -45,7 +45,7 @@ namespace OpenTabletDriver.Desktop.Interop.Timer
             float nextNotification = 0;
             float elapsedMilliseconds;
 
-            Stopwatch stopWatch = new Stopwatch();
+            var stopWatch = new Stopwatch();
             stopWatch.Start();
 
             while (this.runTimer)

--- a/OpenTabletDriver.Desktop/Interop/Timer/MacOSTimer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Timer/MacOSTimer.cs
@@ -71,8 +71,10 @@ namespace OpenTabletDriver.Desktop.Interop.Timer
                         return;
                     }
 
-                    thread = new Thread(ThreadMain);
-                    thread.IsBackground = true;
+                    thread = new Thread(ThreadMain)
+                    {
+                        IsBackground = true
+                    };
                     thread!.Start();
                     Enabled = true;
                 }

--- a/OpenTabletDriver.Desktop/Interop/Timer/MacOSTimer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Timer/MacOSTimer.cs
@@ -15,7 +15,7 @@ namespace OpenTabletDriver.Desktop.Interop.Timer
 {
     internal class MacOSTimer : ITimer, IDisposable
     {
-        const int TIMER_CANCELLED = 1;
+        private const int TIMER_CANCELLED = 1;
 
         private Thread? thread;
         private int kqueue;

--- a/OpenTabletDriver.Desktop/PresetManager.cs
+++ b/OpenTabletDriver.Desktop/PresetManager.cs
@@ -19,7 +19,7 @@ namespace OpenTabletDriver.Desktop
 
         public DirectoryInfo PresetDirectory { get; }
 
-        private List<Preset> Presets { get; } = new List<Preset>();
+        private List<Preset> Presets { get; } = [];
 
         public IReadOnlyCollection<Preset> GetPresets() => Presets;
 

--- a/OpenTabletDriver.Desktop/Profiles/AbsoluteModeSettings.cs
+++ b/OpenTabletDriver.Desktop/Profiles/AbsoluteModeSettings.cs
@@ -6,42 +6,39 @@ namespace OpenTabletDriver.Desktop.Profiles
 {
     public class AbsoluteModeSettings : ViewModel
     {
-        private AreaSettings display, tablet;
-        private bool _lockar, _clipping, _areaLimiting;
-
         [JsonProperty(nameof(Display))]
         public AreaSettings Display
         {
-            set => this.RaiseAndSetIfChanged(ref this.display, value);
-            get => this.display;
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonProperty(nameof(Tablet))]
         public AreaSettings Tablet
         {
-            set => this.RaiseAndSetIfChanged(ref this.tablet, value);
-            get => this.tablet;
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonProperty(nameof(EnableClipping))]
         public bool EnableClipping
         {
-            set => RaiseAndSetIfChanged(ref _clipping, value);
-            get => _clipping;
+            set => RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonProperty(nameof(EnableAreaLimiting))]
         public bool EnableAreaLimiting
         {
-            set => RaiseAndSetIfChanged(ref _areaLimiting, value);
-            get => _areaLimiting;
+            set => RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonProperty(nameof(LockAspectRatio))]
         public bool LockAspectRatio
         {
-            set => RaiseAndSetIfChanged(ref _lockar, value);
-            get => _lockar;
+            set => RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         public static AbsoluteModeSettings GetDefaults(DigitizerSpecifications digitizer)

--- a/OpenTabletDriver.Desktop/Profiles/AreaSettings.cs
+++ b/OpenTabletDriver.Desktop/Profiles/AreaSettings.cs
@@ -8,41 +8,39 @@ namespace OpenTabletDriver.Desktop.Profiles
 {
     public class AreaSettings : ViewModel
     {
-        private float width, height, x, y, rotation;
-
         [JsonProperty(nameof(Width))]
         public float Width
         {
-            set => this.RaiseAndSetIfChanged(ref this.width, value);
-            get => this.width;
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonProperty(nameof(Height))]
         public float Height
         {
-            set => this.RaiseAndSetIfChanged(ref this.height, value);
-            get => this.height;
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonProperty(nameof(X))]
         public float X
         {
-            set => this.RaiseAndSetIfChanged(ref this.x, value);
-            get => this.x;
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonProperty(nameof(Y))]
         public float Y
         {
-            set => this.RaiseAndSetIfChanged(ref this.y, value);
-            get => this.y;
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonProperty(nameof(Rotation))]
         public float Rotation
         {
-            set => this.RaiseAndSetIfChanged(ref this.rotation, value);
-            get => this.rotation;
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonIgnore]

--- a/OpenTabletDriver.Desktop/Profiles/BindingSettings.cs
+++ b/OpenTabletDriver.Desktop/Profiles/BindingSettings.cs
@@ -19,9 +19,9 @@ namespace OpenTabletDriver.Desktop.Profiles
             mouseScrollUp,
             mouseScrollDown;
 
-        private PluginSettingStoreCollection penButtons = new PluginSettingStoreCollection(),
-            auxButtons = new PluginSettingStoreCollection(),
-            mouseButtons = new PluginSettingStoreCollection();
+        private PluginSettingStoreCollection penButtons = [],
+            auxButtons = [],
+            mouseButtons = [];
 
         private List<WheelBindingSettings> wheelBindings = [];
 
@@ -128,9 +128,9 @@ namespace OpenTabletDriver.Desktop.Profiles
                 EraserButton = new PluginSettingStore(
                     new AdaptiveBinding(PenAction.Eraser)
                 ),
-                PenButtons = new PluginSettingStoreCollection(),
-                AuxButtons = new PluginSettingStoreCollection(),
-                MouseButtons = new PluginSettingStoreCollection(),
+                PenButtons = [],
+                AuxButtons = [],
+                MouseButtons = [],
             };
 
             bindingSettings.AddPenButtons(tabletSpecifications);

--- a/OpenTabletDriver.Desktop/Profiles/BindingSettings.cs
+++ b/OpenTabletDriver.Desktop/Profiles/BindingSettings.cs
@@ -12,110 +12,95 @@ namespace OpenTabletDriver.Desktop.Profiles
 {
     public class BindingSettings : ViewModel
     {
-        private float tP = 1, eP = 1;
-
-        private PluginSettingStore tipButton,
-            eraserButton,
-            mouseScrollUp,
-            mouseScrollDown;
-
-        private PluginSettingStoreCollection penButtons = [],
-            auxButtons = [],
-            mouseButtons = [];
-
-        private List<WheelBindingSettings> wheelBindings = [];
-
-        private bool disablePressure, disableTilt, enableDragBindings;
-
         [JsonProperty(nameof(TipActivationThreshold))]
         public float TipActivationThreshold
         {
-            set => this.RaiseAndSetIfChanged(ref this.tP, value);
-            get => this.tP;
-        }
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
+        } = 1;
 
         [JsonProperty(nameof(TipButton))]
         public PluginSettingStore TipButton
         {
-            set => this.RaiseAndSetIfChanged(ref this.tipButton, value);
-            get => this.tipButton;
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonProperty(nameof(EraserActivationThreshold))]
         public float EraserActivationThreshold
         {
-            set => this.RaiseAndSetIfChanged(ref this.eP, value);
-            get => this.eP;
-        }
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
+        } = 1;
 
         [JsonProperty(nameof(EraserButton))]
         public PluginSettingStore EraserButton
         {
-            set => this.RaiseAndSetIfChanged(ref this.eraserButton, value);
-            get => this.eraserButton;
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonProperty(nameof(PenButtons))]
         public PluginSettingStoreCollection PenButtons
         {
-            set => this.RaiseAndSetIfChanged(ref this.penButtons, value);
-            get => this.penButtons;
-        }
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
+        } = [];
 
         [JsonProperty(nameof(AuxButtons))]
         public PluginSettingStoreCollection AuxButtons
         {
-            set => this.RaiseAndSetIfChanged(ref this.auxButtons, value);
-            get => this.auxButtons;
-        }
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
+        } = [];
 
         [JsonProperty(nameof(MouseButtons))]
         public PluginSettingStoreCollection MouseButtons
         {
-            set => this.RaiseAndSetIfChanged(ref this.mouseButtons, value);
-            get => this.mouseButtons;
-        }
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
+        } = [];
 
         [JsonProperty(nameof(MouseScrollUp))]
         public PluginSettingStore MouseScrollUp
         {
-            set => this.RaiseAndSetIfChanged(ref this.mouseScrollUp, value);
-            get => this.mouseScrollUp;
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonProperty(nameof(MouseScrollDown))]
         public PluginSettingStore MouseScrollDown
         {
-            set => this.RaiseAndSetIfChanged(ref this.mouseScrollDown, value);
-            get => this.mouseScrollDown;
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonProperty(nameof(WheelBindings))]
         public List<WheelBindingSettings> WheelBindings
         {
-            set => this.RaiseAndSetIfChanged(ref this.wheelBindings, value);
-            get => this.wheelBindings;
-        }
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
+        } = [];
 
         [JsonProperty(nameof(DisablePressure))]
         public bool DisablePressure
         {
-            set => this.RaiseAndSetIfChanged(ref this.disablePressure, value);
-            get => this.disablePressure;
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonProperty(nameof(DisableTilt))]
         public bool DisableTilt
         {
-            set => this.RaiseAndSetIfChanged(ref this.disableTilt, value);
-            get => this.disableTilt;
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonProperty(nameof(EnableDragBindings))]
         public bool EnableDragBindings
         {
-            set => this.RaiseAndSetIfChanged(ref this.enableDragBindings, value);
-            get => this.enableDragBindings;
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         public static BindingSettings GetDefaults(TabletSpecifications tabletSpecifications)

--- a/OpenTabletDriver.Desktop/Profiles/Profile.cs
+++ b/OpenTabletDriver.Desktop/Profiles/Profile.cs
@@ -15,7 +15,7 @@ namespace OpenTabletDriver.Desktop.Profiles
         private AbsoluteModeSettings absoluteMode = new AbsoluteModeSettings();
         private RelativeModeSettings relativeMode = new RelativeModeSettings();
         private BindingSettings bindings = new BindingSettings();
-        private PluginSettingStoreCollection filters = new PluginSettingStoreCollection();
+        private PluginSettingStoreCollection filters = [];
 
         [JsonProperty(nameof(Tablet))]
         public string Tablet

--- a/OpenTabletDriver.Desktop/Profiles/Profile.cs
+++ b/OpenTabletDriver.Desktop/Profiles/Profile.cs
@@ -10,54 +10,47 @@ namespace OpenTabletDriver.Desktop.Profiles
 {
     public class Profile : ViewModel
     {
-        private string tablet;
-        private PluginSettingStore outputMode;
-        private AbsoluteModeSettings absoluteMode = new AbsoluteModeSettings();
-        private RelativeModeSettings relativeMode = new RelativeModeSettings();
-        private BindingSettings bindings = new BindingSettings();
-        private PluginSettingStoreCollection filters = [];
-
         [JsonProperty(nameof(Tablet))]
         public string Tablet
         {
-            set => this.RaiseAndSetIfChanged(ref tablet, value);
-            get => tablet;
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonProperty(nameof(OutputMode))]
         public PluginSettingStore OutputMode
         {
-            set => RaiseAndSetIfChanged(ref outputMode, value);
-            get => outputMode;
+            set => RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonProperty(nameof(Filters))]
         public PluginSettingStoreCollection Filters
         {
-            set => RaiseAndSetIfChanged(ref filters, value);
-            get => filters;
-        }
+            set => RaiseAndSetIfChanged(ref field, value);
+            get;
+        } = [];
 
         [JsonProperty(nameof(AbsoluteModeSettings))]
         public AbsoluteModeSettings AbsoluteModeSettings
         {
-            set => this.RaiseAndSetIfChanged(ref absoluteMode, value);
-            get => absoluteMode;
-        }
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
+        } = new AbsoluteModeSettings();
 
         [JsonProperty(nameof(RelativeModeSettings))]
         public RelativeModeSettings RelativeModeSettings
         {
-            set => this.RaiseAndSetIfChanged(ref relativeMode, value);
-            get => relativeMode;
-        }
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
+        } = new RelativeModeSettings();
 
         [JsonProperty("Bindings")]
         public BindingSettings BindingSettings
         {
-            set => this.RaiseAndSetIfChanged(ref bindings, value);
-            get => bindings;
-        }
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
+        } = new BindingSettings();
 
         private static Type DefaultOutputModeType =>
             SystemInterop.CurrentPlatform switch

--- a/OpenTabletDriver.Desktop/Profiles/RelativeModeSettings.cs
+++ b/OpenTabletDriver.Desktop/Profiles/RelativeModeSettings.cs
@@ -6,35 +6,32 @@ namespace OpenTabletDriver.Desktop.Profiles
 {
     public class RelativeModeSettings : ViewModel
     {
-        private float xS, yS, relRot;
-        private TimeSpan rT;
-
         [JsonProperty(nameof(XSensitivity))]
         public float XSensitivity
         {
-            set => RaiseAndSetIfChanged(ref this.xS, value);
-            get => this.xS;
+            set => RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonProperty(nameof(YSensitivity))]
         public float YSensitivity
         {
-            set => RaiseAndSetIfChanged(ref this.yS, value);
-            get => this.yS;
+            set => RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonProperty(nameof(RelativeRotation))]
         public float RelativeRotation
         {
-            set => RaiseAndSetIfChanged(ref this.relRot, value);
-            get => this.relRot;
+            set => RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonProperty("RelativeResetDelay")]
         public TimeSpan ResetTime
         {
-            set => RaiseAndSetIfChanged(ref this.rT, value);
-            get => this.rT;
+            set => RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonIgnore]

--- a/OpenTabletDriver.Desktop/Profiles/WheelBindingSettings.cs
+++ b/OpenTabletDriver.Desktop/Profiles/WheelBindingSettings.cs
@@ -10,59 +10,51 @@ namespace OpenTabletDriver.Desktop.Profiles
     /// </summary>
     public class WheelBindingSettings : ViewModel
     {
-        private PluginSettingStoreCollection _wheelButtons = [];
-
         // TODO: default values for these are current relied upon by UI StepSize behavior
         //       It should be instead be initialized by TabletReference or similar
-        private float _ct, _cct;
 
-        private PluginSettingStore?
-            _clockwiseRotation,
-            _counterClockwiseRotation;
-
-        private double? _stepSize;
 
         [JsonProperty(nameof(WheelButtons))]
         public PluginSettingStoreCollection WheelButtons
         {
-            set => RaiseAndSetIfChanged(ref _wheelButtons, value);
-            get => _wheelButtons;
-        }
+            set => RaiseAndSetIfChanged(ref field, value);
+            get;
+        } = [];
 
         [JsonProperty(nameof(ClockwiseRotation))]
         public PluginSettingStore? ClockwiseRotation
         {
-            set => RaiseAndSetIfChanged(ref _clockwiseRotation, value);
-            get => _clockwiseRotation;
+            set => RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonProperty(nameof(ClockwiseActivationThreshold))]
         public float ClockwiseActivationThreshold
         {
-            set => RaiseAndSetIfChanged(ref _ct, value);
-            get => _ct;
+            set => RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonProperty(nameof(CounterClockwiseRotation))]
         public PluginSettingStore? CounterClockwiseRotation
         {
-            set => RaiseAndSetIfChanged(ref _counterClockwiseRotation, value);
-            get => _counterClockwiseRotation;
+            set => RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonProperty(nameof(CounterClockwiseActivationThreshold))]
         public float CounterClockwiseActivationThreshold
         {
-            set => RaiseAndSetIfChanged(ref _cct, value);
-            get => _cct;
+            set => RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         // should be instantiated by daemon on load
         [JsonProperty(nameof(StepSize))]
         public double? StepSize
         {
-            set => RaiseAndSetIfChanged(ref _stepSize, value);
-            get => _stepSize;
+            set => RaiseAndSetIfChanged(ref field, value);
+            get;
         }
     }
 }

--- a/OpenTabletDriver.Desktop/Reflection/DesktopPluginManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/DesktopPluginManager.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -39,7 +38,7 @@ namespace OpenTabletDriver.Desktop.Reflection
         protected DirectoryInfo TrashDirectory { get; }
         protected DirectoryInfo TemporaryDirectory { get; }
 
-        protected List<DesktopPluginContext> Plugins { get; } = new List<DesktopPluginContext>();
+        protected List<DesktopPluginContext> Plugins { get; } = [];
 
         public IReadOnlyCollection<DesktopPluginContext> GetLoadedPlugins() => Plugins;
 
@@ -253,7 +252,7 @@ namespace OpenTabletDriver.Desktop.Reflection
                 var types = pluginTypes.Where(t => t.Assembly == asm)
                     .Select(t => t.GetTypeInfo());
 
-                pluginTypes = new ConcurrentBag<TypeInfo>(pluginTypes.Except(types));
+                pluginTypes = [.. pluginTypes.Except(types)];
                 return true;
             }
             catch (Exception ex)

--- a/OpenTabletDriver.Desktop/Reflection/Metadata/PluginMetadataCollection.cs
+++ b/OpenTabletDriver.Desktop/Reflection/Metadata/PluginMetadataCollection.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
-using System.Linq;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
@@ -20,7 +19,7 @@ namespace OpenTabletDriver.Desktop.Reflection.Metadata
         }
 
         protected PluginMetadataCollection(IEnumerable<PluginMetadata> source)
-            : base(source.ToList())
+            : base([.. source])
         {
         }
 

--- a/OpenTabletDriver.Desktop/Reflection/PluginManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginManager.cs
@@ -21,7 +21,7 @@ namespace OpenTabletDriver.Desktop.Reflection
             };
 
 #pragma warning disable CS0618 // Type or member is obsolete
-            libTypes = OpenTabletDriver.Desktop.Extensions.GetLibTypes().ToArray();
+            libTypes = [.. OpenTabletDriver.Desktop.Extensions.GetLibTypes()];
 #pragma warning restore CS0618 // Type or member is obsolete
 
             var internalTypes = from asm in assemblies
@@ -31,7 +31,7 @@ namespace OpenTabletDriver.Desktop.Reflection
                                 where IsPlatformSupported(type)
                                 select type;
 
-            pluginTypes = new ConcurrentBag<TypeInfo>(internalTypes);
+            pluginTypes = [.. internalTypes];
         }
 
         public IReadOnlyCollection<TypeInfo> PluginTypes => pluginTypes;
@@ -94,7 +94,7 @@ namespace OpenTabletDriver.Desktop.Reflection
                            where !IsPluginIgnored(type)
                            select type;
 
-            return children.ToArray();
+            return [.. children];
         }
 
         public virtual string GetFriendlyName(string path)

--- a/OpenTabletDriver.Desktop/Reflection/PluginManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginManager.cs
@@ -57,7 +57,7 @@ namespace OpenTabletDriver.Desktop.Reflection
 
                         if (matchingConstructors.FirstOrDefault() is ConstructorInfo constructor)
                         {
-                            T obj = (T)constructor.Invoke(args);
+                            var obj = (T)constructor.Invoke(args);
 
                             if (obj != null)
                                 Inject(this, obj, type);

--- a/OpenTabletDriver.Desktop/Reflection/PluginSettingStore.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginSettingStore.cs
@@ -16,7 +16,7 @@ namespace OpenTabletDriver.Desktop.Reflection
         public PluginSettingStore(Type type, bool enable = true)
         {
             Path = type?.FullName;
-            Settings = type != null ? GetSettingsForType(type) : new ObservableCollection<PluginSetting>();
+            Settings = type != null ? GetSettingsForType(type) : [];
             Enable = enable;
         }
 
@@ -176,7 +176,7 @@ namespace OpenTabletDriver.Desktop.Reflection
                           select method;
 
             foreach (var method in methods)
-                method.Invoke(obj, Array.Empty<object>());
+                method.Invoke(obj, []);
         }
     }
 }

--- a/OpenTabletDriver.Desktop/Reflection/ServiceManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/ServiceManager.cs
@@ -5,7 +5,7 @@ namespace OpenTabletDriver.Desktop.Reflection
 {
     public class ServiceManager : IServiceManager
     {
-        private readonly Dictionary<Type, Func<object>> services = new();
+        private readonly Dictionary<Type, Func<object>> services = [];
 
         /// <summary>
         /// Adds a retrieval method for a service type.

--- a/OpenTabletDriver.Desktop/Reflection/ServiceManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/ServiceManager.cs
@@ -15,7 +15,7 @@ namespace OpenTabletDriver.Desktop.Reflection
         /// <returns>True if adding the service was successful, otherwise false.</returns>
         public bool AddService<T>(Func<T> value)
         {
-            return services.TryAdd(typeof(T), (value as Func<object>));
+            return services.TryAdd(typeof(T), value as Func<object>);
         }
 
         /// <summary>

--- a/OpenTabletDriver.Desktop/Settings.cs
+++ b/OpenTabletDriver.Desktop/Settings.cs
@@ -11,9 +11,9 @@ namespace OpenTabletDriver.Desktop
 {
     public class Settings : ViewModel
     {
-        private ProfileCollection profiles = new ProfileCollection();
+        private ProfileCollection profiles = [];
         private bool lockUsableAreaDisplay, lockUsableAreaTablet;
-        private PluginSettingStoreCollection tools = new PluginSettingStoreCollection();
+        private PluginSettingStoreCollection tools = [];
         private string revision = GetVersion();
 
         [JsonProperty(nameof(Revision))]

--- a/OpenTabletDriver.Desktop/Settings.cs
+++ b/OpenTabletDriver.Desktop/Settings.cs
@@ -11,45 +11,40 @@ namespace OpenTabletDriver.Desktop
 {
     public class Settings : ViewModel
     {
-        private ProfileCollection profiles = [];
-        private bool lockUsableAreaDisplay, lockUsableAreaTablet;
-        private PluginSettingStoreCollection tools = [];
-        private string revision = GetVersion();
-
         [JsonProperty(nameof(Revision))]
         public string Revision
         {
-            set => this.RaiseAndSetIfChanged(ref revision, value);
-            get => revision;
-        }
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
+        } = GetVersion();
 
         [JsonProperty(nameof(Profiles))]
         public ProfileCollection Profiles
         {
-            set => this.RaiseAndSetIfChanged(ref profiles, value);
-            get => profiles;
-        }
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
+        } = [];
 
         [JsonProperty(nameof(LockUsableAreaDisplay))]
         public bool LockUsableAreaDisplay
         {
-            set => this.RaiseAndSetIfChanged(ref this.lockUsableAreaDisplay, value);
-            get => this.lockUsableAreaDisplay;
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonProperty(nameof(LockUsableAreaTablet))]
         public bool LockUsableAreaTablet
         {
-            set => this.RaiseAndSetIfChanged(ref this.lockUsableAreaTablet, value);
-            get => this.lockUsableAreaTablet;
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         [JsonProperty(nameof(Tools))]
         public PluginSettingStoreCollection Tools
         {
-            set => RaiseAndSetIfChanged(ref this.tools, value);
-            get => this.tools;
-        }
+            set => RaiseAndSetIfChanged(ref field, value);
+            get;
+        } = [];
 
         public static Settings GetDefaults()
         {

--- a/OpenTabletDriver.Desktop/Updater/GitHubUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/GitHubUpdater.cs
@@ -10,7 +10,7 @@ namespace OpenTabletDriver.Desktop.Updater
 {
     public abstract partial class GitHubUpdater : Updater
     {
-        static private readonly string _binaryDirectory = BinaryDirectoryRegex().Match(AppContext.BaseDirectory) switch
+        private static readonly string _binaryDirectory = BinaryDirectoryRegex().Match(AppContext.BaseDirectory) switch
         {
             { Success: true } match => match.Groups[1].ToString(),
             _ => AppContext.BaseDirectory

--- a/OpenTabletDriver.Desktop/Updater/Updater.cs
+++ b/OpenTabletDriver.Desktop/Updater/Updater.cs
@@ -208,7 +208,7 @@ namespace OpenTabletDriver.Desktop.Updater
             return Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
         }
 
-        record Rollback(string Directory, string Binary, string AppData);
+        private record Rollback(string Directory, string Binary, string AppData);
     }
 
     public class UpdateException : Exception

--- a/OpenTabletDriver.Desktop/ViewModels/TabletDebuggerViewModel.cs
+++ b/OpenTabletDriver.Desktop/ViewModels/TabletDebuggerViewModel.cs
@@ -31,16 +31,15 @@ public sealed class TabletDebuggerViewModel : ViewModel, IDisposable
 
     public TabletDebuggerViewModel()
     {
-        _additionalStatistics.ChildCollectionChanged += (sender, args) => StatisticsCollectionChanged?.Invoke(sender, args);
+        AdditionalStatistics.ChildCollectionChanged += (sender, args) => StatisticsCollectionChanged?.Invoke(sender, args);
     }
 
     public void HandleReport(object? sender, DebugReportData data) => ReportData = data;
 
     #region View Model Properties (and backing fields)
-    private DebugReportData? _reportData;
     public DebugReportData? ReportData
     {
-        get => _reportData;
+        get;
         // TODO: only gather AdditionalStatistics if enabled
         private set
         {
@@ -48,7 +47,7 @@ public sealed class TabletDebuggerViewModel : ViewModel, IDisposable
             if (value != null && IgnoredReports.Contains(GetNameKeyForFilter(value.Tablet, value.Path))) return;
             if (value != null && IgnoredTablets.Contains(value.Tablet.Properties.Name)) return;
 
-            RaiseAndSetIfChanged(ref _reportData, value);
+            RaiseAndSetIfChanged(ref field, value);
             if (value == null) return;
             RaiseChanged(nameof(DeviceName));
 
@@ -170,13 +169,11 @@ public sealed class TabletDebuggerViewModel : ViewModel, IDisposable
         RaiseChanged(nameof(ReportRateString));
     }
 
-    private readonly Statistic _additionalStatistics = new("Additional Statistics");
-
     public Statistic AdditionalStatistics
     {
-        get => _additionalStatistics;
-        init => RaiseAndSetIfChanged(ref _additionalStatistics, value);
-    }
+        get;
+        init => RaiseAndSetIfChanged(ref field, value);
+    } = new("Additional Statistics");
 
     private double ReportRateAverage => 1000 / (_reportRates.Count > 0 ? _reportRates.Average() : 0);
     public string ReportRateString => $"{ReportRateAverage:0.00}";
@@ -198,52 +195,47 @@ public sealed class TabletDebuggerViewModel : ViewModel, IDisposable
         }
     }
 
-    private string _decodedTabletData = string.Empty;
     public string DecodedTabletData
     {
-        get => _decodedTabletData;
-        private set => RaiseAndSetIfChanged(ref _decodedTabletData, value);
-    }
+        get;
+        private set => RaiseAndSetIfChanged(ref field, value);
+    } = string.Empty;
 
-    private DecodingMode _decodingMode = _DEFAULT_DECODING_MODE;
     public DecodingMode DecodingMode
     {
-        get => _decodingMode;
+        get;
         set
         {
-            RaiseAndSetIfChanged(ref _decodingMode, value);
+            RaiseAndSetIfChanged(ref field, value);
             RaiseChanged(nameof(RawTabletData));
         }
-    }
+    } = _DEFAULT_DECODING_MODE;
 
-    private int _reportsRecorded;
     public int ReportsRecorded
     {
-        get => _reportsRecorded;
+        get;
         private set
         {
-            RaiseAndSetIfChanged(ref _reportsRecorded, value);
+            RaiseAndSetIfChanged(ref field, value);
 
             if (value > 0 && !HasReportsRecorded)
                 HasReportsRecorded = true;
         }
     }
 
-    private bool _hasReportsRecorded;
     public bool HasReportsRecorded
     {
-        get => _hasReportsRecorded;
-        private set => RaiseAndSetIfChanged(ref _hasReportsRecorded, value);
+        get;
+        private set => RaiseAndSetIfChanged(ref field, value);
     }
 
-    private bool _dataRecordingEnabled;
     public bool DataRecordingEnabled
     {
-        get => _dataRecordingEnabled;
+        get;
         [UsedImplicitly]
         set
         {
-            RaiseAndSetIfChanged(ref _dataRecordingEnabled, value);
+            RaiseAndSetIfChanged(ref field, value);
 
             if (value)
             {
@@ -259,18 +251,15 @@ public sealed class TabletDebuggerViewModel : ViewModel, IDisposable
         }
     }
 
-    private bool _isVisualizerEnabled = true;
     public bool IsVisualizerEnabled
     {
-        get => _isVisualizerEnabled;
-        set => RaiseAndSetIfChanged(ref _isVisualizerEnabled, value);
-    }
-
-    private bool _showAdditionalStatistics;
+        get;
+        set => RaiseAndSetIfChanged(ref field, value);
+    } = true;
     public bool ShowAdditionalStatistics
     {
-        get => _showAdditionalStatistics;
-        set => RaiseAndSetIfChanged(ref _showAdditionalStatistics, value);
+        get;
+        set => RaiseAndSetIfChanged(ref field, value);
     }
 
     public ReadOnlyCollection<string> SeenReports => _seenReports.ToArray().AsReadOnly();
@@ -310,14 +299,14 @@ public sealed class TabletDebuggerViewModel : ViewModel, IDisposable
 
     public void ResetStatistics()
     {
-        _additionalStatistics.Children.Clear();
+        AdditionalStatistics.Children.Clear();
     }
 
     private void StopDataRecordingAsNeeded()
     {
         // dump stats
-        if (_tabletRecordingStreamWriter != null && _additionalStatistics.Children.Count > 0)
-            foreach (string s in _additionalStatistics.DumpTreeAsStrings())
+        if (_tabletRecordingStreamWriter != null && AdditionalStatistics.Children.Count > 0)
+            foreach (string s in AdditionalStatistics.DumpTreeAsStrings())
                 _tabletRecordingStreamWriter?.WriteLine(s);
 
         _tabletRecordingStreamWriter?.Dispose();

--- a/OpenTabletDriver.Desktop/ViewModels/Utility/Statistics.cs
+++ b/OpenTabletDriver.Desktop/ViewModels/Utility/Statistics.cs
@@ -29,7 +29,7 @@ namespace OpenTabletDriver.Desktop.ViewModels.Utility
         // null: valid (full 'false -> true -> false' transition happened)
         // false: only seen false
         // true: have seen false and then true but haven't seen false after true
-        private readonly Dictionary<int, bool?> _seenButtons = new();
+        private readonly Dictionary<int, bool?> _seenButtons = [];
 
         internal Statistic(string name, object? value = null, string? unit = null, string? valueStringFormat = null)
         {

--- a/OpenTabletDriver.Desktop/ViewModels/Utility/Statistics.cs
+++ b/OpenTabletDriver.Desktop/ViewModels/Utility/Statistics.cs
@@ -21,10 +21,8 @@ namespace OpenTabletDriver.Desktop.ViewModels.Utility
 
     public class Statistic : INotifyPropertyChanged, IComparable
     {
-        private object? _value;
         private string? _unit;
         private string _valueStringFormat;
-        private bool _hidden;
 
         // null: valid (full 'false -> true -> false' transition happened)
         // false: only seen false
@@ -57,10 +55,10 @@ namespace OpenTabletDriver.Desktop.ViewModels.Utility
         /// </summary>
         public object? Value
         {
-            get => _value;
+            get;
             set
             {
-                SetField(ref _value, value);
+                SetField(ref field, value);
                 OnPropertyChanged(nameof(ValueString));
             }
         }
@@ -93,8 +91,8 @@ namespace OpenTabletDriver.Desktop.ViewModels.Utility
         /// </summary>
         public bool Hidden
         {
-            get => _hidden;
-            set => SetField(ref _hidden, value);
+            get;
+            set => SetField(ref field, value);
         }
 
         /// <summary>

--- a/OpenTabletDriver.Native/Linux/Evdev/Evdev.cs
+++ b/OpenTabletDriver.Native/Linux/Evdev/Evdev.cs
@@ -8,28 +8,28 @@ namespace OpenTabletDriver.Native.Linux.Evdev
         private const string libevdev = "libevdev.so.2";
 
         [DllImport(libevdev)]
-        public extern static IntPtr libevdev_new();
+        public static extern IntPtr libevdev_new();
 
         [DllImport(libevdev)]
-        public extern static void libevdev_set_name(IntPtr dev, string name);
+        public static extern void libevdev_set_name(IntPtr dev, string name);
 
         [DllImport(libevdev)]
-        public extern static int libevdev_enable_property(IntPtr dev, uint prop);
+        public static extern int libevdev_enable_property(IntPtr dev, uint prop);
 
         [DllImport(libevdev)]
-        public extern static int libevdev_enable_event_type(IntPtr dev, uint type);
+        public static extern int libevdev_enable_event_type(IntPtr dev, uint type);
 
         [DllImport(libevdev)]
-        public extern static int libevdev_enable_event_code(IntPtr dev, uint type, uint code, IntPtr data);
+        public static extern int libevdev_enable_event_code(IntPtr dev, uint type, uint code, IntPtr data);
 
         [DllImport(libevdev)]
-        public extern static int libevdev_uinput_create_from_device(IntPtr dev, int uinput_fd, out IntPtr uinput_dev);
+        public static extern int libevdev_uinput_create_from_device(IntPtr dev, int uinput_fd, out IntPtr uinput_dev);
 
         [DllImport(libevdev)]
-        public extern static void libevdev_uinput_destroy(IntPtr uinput_dev);
+        public static extern void libevdev_uinput_destroy(IntPtr uinput_dev);
 
         [DllImport(libevdev)]
-        public extern static int libevdev_uinput_write_event(IntPtr uinput_dev, uint type, uint code, int value);
+        public static extern int libevdev_uinput_write_event(IntPtr uinput_dev, uint type, uint code, int value);
 
         public const int LIBEVDEV_UINPUT_OPEN_MANAGED = -2;
     }

--- a/OpenTabletDriver.Native/Linux/Xorg/XLib.cs
+++ b/OpenTabletDriver.Native/Linux/Xorg/XLib.cs
@@ -13,7 +13,7 @@ namespace OpenTabletDriver.Native.Linux.Xorg
         private static readonly object Lock = new object();
 
         [DllImport(libX11, EntryPoint = "XOpenDisplay")]
-        private extern unsafe static IntPtr sys_XOpenDisplay(char* display);
+        private static extern unsafe IntPtr sys_XOpenDisplay(char* display);
         public static unsafe IntPtr XOpenDisplay(char* display)
         {
             lock (Lock)
@@ -21,7 +21,7 @@ namespace OpenTabletDriver.Native.Linux.Xorg
         }
 
         [DllImport(libX11, EntryPoint = "XCloseDisplay")]
-        public extern static int XCloseDisplay(IntPtr display);
+        public static extern int XCloseDisplay(IntPtr display);
 
         [DllImport(libX11, EntryPoint = "XDefaultRootWindow")]
         public static extern Window XDefaultRootWindow(Display display);

--- a/OpenTabletDriver.Native/Linux/Xorg/XLib.cs
+++ b/OpenTabletDriver.Native/Linux/Xorg/XLib.cs
@@ -10,7 +10,7 @@ namespace OpenTabletDriver.Native.Linux.Xorg
     public class XLib
     {
         private const string libX11 = "libX11.so.6";
-        private static object Lock = new object();
+        private static readonly object Lock = new object();
 
         [DllImport(libX11, EntryPoint = "XOpenDisplay")]
         private extern unsafe static IntPtr sys_XOpenDisplay(char* display);

--- a/OpenTabletDriver.Native/Linux/Xorg/XRandr.cs
+++ b/OpenTabletDriver.Native/Linux/Xorg/XRandr.cs
@@ -11,6 +11,6 @@ namespace OpenTabletDriver.Native.Linux.Xorg
         private const string libXRandr = "libXrandr.so.2";
 
         [DllImport(libXRandr, EntryPoint = "XRRGetMonitors")]
-        public unsafe extern static XRRMonitorInfo* XRRGetMonitors(Display dpy, Window window, bool get_active, out int nmonitors);
+        public static extern unsafe XRRMonitorInfo* XRRGetMonitors(Display dpy, Window window, bool get_active, out int nmonitors);
     }
 }

--- a/OpenTabletDriver.Native/OSX/ApplicationServices.cs
+++ b/OpenTabletDriver.Native/OSX/ApplicationServices.cs
@@ -7,7 +7,7 @@ namespace OpenTabletDriver.Native.OSX.ApplicationServices
     {
         private const string libas = "/System/Library/Frameworks/ApplicationServices.framework/ApplicationServices";
 
-        private static IntPtr handle = LibSystem.dlopen(libas, 0);
+        private static readonly IntPtr handle = LibSystem.dlopen(libas, 0);
 
         public static IntPtr kAXTrustedCheckOptionPrompt = LibSystem.GetConstant(handle, "kAXTrustedCheckOptionPrompt");
 

--- a/OpenTabletDriver.Native/OSX/CoreFoundation.cs
+++ b/OpenTabletDriver.Native/OSX/CoreFoundation.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace OpenTabletDriver.Native.OSX
 {
-    static public class CoreFoundation
+    public static class CoreFoundation
     {
         private const string CFLib = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation";
         private static readonly IntPtr handle = LibSystem.dlopen(CFLib, 0);

--- a/OpenTabletDriver.Native/OSX/CoreFoundation.cs
+++ b/OpenTabletDriver.Native/OSX/CoreFoundation.cs
@@ -6,7 +6,7 @@ namespace OpenTabletDriver.Native.OSX
     static public class CoreFoundation
     {
         private const string CFLib = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation";
-        private static IntPtr handle = LibSystem.dlopen(CFLib, 0);
+        private static readonly IntPtr handle = LibSystem.dlopen(CFLib, 0);
 
         public static IntPtr kCFBooleanTrue = LibSystem.GetConstant(handle, "kCFBooleanTrue");
         public static IntPtr kCFBooleanFalse = LibSystem.GetConstant(handle, "kCFBooleanFalse");

--- a/OpenTabletDriver.Native/OSX/LibQuarantine.cs
+++ b/OpenTabletDriver.Native/OSX/LibQuarantine.cs
@@ -2,11 +2,11 @@ using System.Runtime.InteropServices;
 
 namespace OpenTabletDriver.Native.OSX
 {
-    static public class LibQuarantine
+    public static class LibQuarantine
     {
         private const string QtLib = "/usr/lib/system/libquarantine.dylib";
 
         [DllImport(QtLib)]
-        static public extern int responsibility_get_pid_responsible_for_pid(int pid);
+        public static extern int responsibility_get_pid_responsible_for_pid(int pid);
     }
 }

--- a/OpenTabletDriver.Native/OSX/OSX.cs
+++ b/OpenTabletDriver.Native/OSX/OSX.cs
@@ -30,52 +30,52 @@ namespace OpenTabletDriver.Native.OSX
         public static extern void CFRelease(IntPtr handle);
 
         [DllImport(Quartz)]
-        public extern static CGEventRef CGEventCreate(CGEventSourceRef source);
+        public static extern CGEventRef CGEventCreate(CGEventSourceRef source);
 
         [DllImport(Quartz)]
-        public extern static CGPoint CGEventGetLocation(CGEventRef eventRef);
+        public static extern CGPoint CGEventGetLocation(CGEventRef eventRef);
 
         [DllImport(Quartz)]
-        public extern static CGEventRef CGEventCreateMouseEvent(CGEventSourceRef source, CGEventType mouseType,
+        public static extern CGEventRef CGEventCreateMouseEvent(CGEventSourceRef source, CGEventType mouseType,
             CGPoint mouseCursorPosition, CGMouseButton mouseButton);
 
         [DllImport(Quartz)]
-        public extern static CGEventRef CGEventCreateKeyboardEvent(CGEventSourceRef source, CGKeyCode virtualKey, bool keyDown);
+        public static extern CGEventRef CGEventCreateKeyboardEvent(CGEventSourceRef source, CGKeyCode virtualKey, bool keyDown);
 
         [DllImport(Quartz)]
-        public extern static CGEventRef CGEventSetType(CGEventRef eventRef, CGEventType type);
+        public static extern CGEventRef CGEventSetType(CGEventRef eventRef, CGEventType type);
 
         [DllImport(Quartz)]
-        public extern static CGEventRef CGEventSetIntegerValueField(CGEventRef eventRef, CGEventField field, long value);
+        public static extern CGEventRef CGEventSetIntegerValueField(CGEventRef eventRef, CGEventField field, long value);
 
         [DllImport(Quartz)]
-        public extern static void CGEventSetDoubleValueField(CGEventRef eventRef, CGEventField field, double value);
+        public static extern void CGEventSetDoubleValueField(CGEventRef eventRef, CGEventField field, double value);
 
         [DllImport(Quartz)]
-        public extern static void CGEventSetLocation(CGEventRef eventRef, CGPoint location);
+        public static extern void CGEventSetLocation(CGEventRef eventRef, CGPoint location);
 
         [DllImport(Quartz)]
-        public extern static CGEventRef CGEventCreateScrollWheelEvent2(CGEventRef eventRef, CGScrollEventUnit units, uint wheelCount, int wheel1, int wheel2, int wheel3);
+        public static extern CGEventRef CGEventCreateScrollWheelEvent2(CGEventRef eventRef, CGScrollEventUnit units, uint wheelCount, int wheel1, int wheel2, int wheel3);
 
         [DllImport(Quartz)]
-        public extern static void CGEventSetFlags(CGEventRef eventRef, ulong flags);
+        public static extern void CGEventSetFlags(CGEventRef eventRef, ulong flags);
 
         [DllImport(Quartz)]
-        public extern static CGEventSourceRef CGEventSourceCreate(int stateID);
+        public static extern CGEventSourceRef CGEventSourceCreate(int stateID);
 
         [DllImport(Quartz)]
-        public extern static ulong CGEventSourceFlagsState(int stateID);
+        public static extern ulong CGEventSourceFlagsState(int stateID);
 
         [DllImport(Quartz, EntryPoint = "CGEventPost")]
-        private extern static void _CGEventPost(CGEventTapLocation tap, CGEventRef eventRef);
+        private static extern void _CGEventPost(CGEventTapLocation tap, CGEventRef eventRef);
 
 
         [DllImport(Quartz)]
-        public extern static CGError CGGetActiveDisplayList(uint maxDisplays,
+        public static extern CGError CGGetActiveDisplayList(uint maxDisplays,
             [In, Out] CGDirectDisplayID[] activeDisplays, out uint displayCount);
 
         [DllImport(Quartz)]
-        public extern static CGRect CGDisplayBounds(CGDirectDisplayID displayID);
+        public static extern CGRect CGDisplayBounds(CGDirectDisplayID displayID);
 
         public static double GetDoubleClickInterval()
         {

--- a/OpenTabletDriver.Native/Windows/USB/PipeInfo.cs
+++ b/OpenTabletDriver.Native/Windows/USB/PipeInfo.cs
@@ -7,8 +7,8 @@ namespace OpenTabletDriver.Native.Windows.USB
     {
         public PipeType PipeType;
         public byte PipeID;
-        private byte sizePacket0;
-        private byte sizePacket1;
+        private readonly byte sizePacket0;
+        private readonly byte sizePacket1;
         public ushort MaximumPacketSize => (ushort)(sizePacket1 | (sizePacket0 << 8));
         public byte Interval;
     }

--- a/OpenTabletDriver.Native/Windows/USB/StringDescriptor.cs
+++ b/OpenTabletDriver.Native/Windows/USB/StringDescriptor.cs
@@ -15,7 +15,7 @@ namespace OpenTabletDriver.Native.Windows.USB
 
         public const int MaxSize = 255 + 2;
 
-        public unsafe static string GetString(StringDescriptor* descriptor)
+        public static unsafe string GetString(StringDescriptor* descriptor)
         {
             if (descriptor->bDescriptorType != DescriptorType.StringDescriptor && descriptor->bLength != 0)
                 throw new IOException($"Invalid descriptor type '{descriptor->bDescriptorType}'. Expected '{DescriptorType.StringDescriptor}'");
@@ -28,7 +28,7 @@ namespace OpenTabletDriver.Native.Windows.USB
             return deviceString;
         }
 
-        public unsafe static byte[] GetRaw(StringDescriptor* descriptor)
+        public static unsafe byte[] GetRaw(StringDescriptor* descriptor)
         {
             return new ReadOnlySpan<byte>(descriptor, descriptor->bLength).ToArray();
         }

--- a/OpenTabletDriver.Native/Windows/WinUSB.cs
+++ b/OpenTabletDriver.Native/Windows/WinUSB.cs
@@ -14,16 +14,16 @@ namespace OpenTabletDriver.Native.Windows
         public static extern bool WinUsb_Free(IntPtr interfaceHandle);
 
         [DllImport("winusb.dll", SetLastError = true)]
-        public static unsafe extern bool WinUsb_ReadPipe(SafeWinUsbInterfaceHandle interfaceHandle, byte pipeId, void* pBuffer, uint bufferLength, out uint lengthTransferred, NativeOverlapped* pOverlapped);
+        public static extern unsafe bool WinUsb_ReadPipe(SafeWinUsbInterfaceHandle interfaceHandle, byte pipeId, void* pBuffer, uint bufferLength, out uint lengthTransferred, NativeOverlapped* pOverlapped);
 
         [DllImport("winusb.dll", SetLastError = true)]
-        public static unsafe extern bool WinUsb_WritePipe(SafeWinUsbInterfaceHandle interfaceHandle, byte pipeId, void* pBuffer, uint bufferLength, out uint lengthTransferred, NativeOverlapped* pOverlapped);
+        public static extern unsafe bool WinUsb_WritePipe(SafeWinUsbInterfaceHandle interfaceHandle, byte pipeId, void* pBuffer, uint bufferLength, out uint lengthTransferred, NativeOverlapped* pOverlapped);
 
         [DllImport("winusb.dll", SetLastError = true)]
-        public static unsafe extern bool WinUsb_ControlTransfer(SafeWinUsbInterfaceHandle interfaceHandle, SetupPacket setupPacket, void* pBuffer, uint bufferLength, out uint lengthTransferred, NativeOverlapped* pOverlapped);
+        public static extern unsafe bool WinUsb_ControlTransfer(SafeWinUsbInterfaceHandle interfaceHandle, SetupPacket setupPacket, void* pBuffer, uint bufferLength, out uint lengthTransferred, NativeOverlapped* pOverlapped);
 
         [DllImport("winusb.dll", SetLastError = true)]
-        public static unsafe extern bool WinUsb_QueryInterfaceSettings(SafeWinUsbInterfaceHandle interfaceHandle, byte altInterfaceNum, InterfaceDescriptor* interfaceDescriptor);
+        public static extern unsafe bool WinUsb_QueryInterfaceSettings(SafeWinUsbInterfaceHandle interfaceHandle, byte altInterfaceNum, InterfaceDescriptor* interfaceDescriptor);
 
         [DllImport("winusb.dll", SetLastError = true)]
         public static extern bool WinUsb_QueryPipe(SafeWinUsbInterfaceHandle interfaceHandle, byte altInterfaceNum, byte pipeIndex, out PipeInfo pipeInfo);

--- a/OpenTabletDriver.Plugin/HPETDeltaStopwatch.cs
+++ b/OpenTabletDriver.Plugin/HPETDeltaStopwatch.cs
@@ -60,7 +60,7 @@ namespace OpenTabletDriver.Plugin.Timing
             return delta;
         }
 
-        private static Stopwatch internalWatch = Stopwatch.StartNew();
+        private static readonly Stopwatch internalWatch = Stopwatch.StartNew();
         protected TimeSpan start;
         protected TimeSpan end;
         protected bool isRunning;

--- a/OpenTabletDriver.Plugin/Log.cs
+++ b/OpenTabletDriver.Plugin/Log.cs
@@ -8,7 +8,7 @@ namespace OpenTabletDriver.Plugin
 {
     public static class Log
     {
-        private static List<LogMessage>? _backlog = new();
+        private static List<LogMessage>? _backlog = [];
         private static Action<LogMessage> _logAction = WriteBacklog;
         private static event EventHandler<LogMessage>? _output;
 
@@ -34,7 +34,7 @@ namespace OpenTabletDriver.Plugin
                 _output -= value;
                 if (_output == null)
                 {
-                    _backlog = new List<LogMessage>();
+                    _backlog = [];
                     _logAction = WriteBacklog;
                 }
             }

--- a/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
@@ -68,13 +68,13 @@ namespace OpenTabletDriver.Plugin.Output
             {
                 var transform = CalculateTransformation(Input, Output, Tablet.Properties.Specifications.Digitizer);
 
-                var halfDisplayWidth = Output?.Width / 2 ?? 0;
-                var halfDisplayHeight = Output?.Height / 2 ?? 0;
+                var halfDisplayWidth = (Output?.Width / 2) ?? 0;
+                var halfDisplayHeight = (Output?.Height / 2) ?? 0;
 
-                var minX = Output?.Position.X - halfDisplayWidth ?? 0;
-                var maxX = Output?.Position.X + Output?.Width - halfDisplayWidth ?? 0;
-                var minY = Output?.Position.Y - halfDisplayHeight ?? 0;
-                var maxY = Output?.Position.Y + Output?.Height - halfDisplayHeight ?? 0;
+                var minX = (Output?.Position.X - halfDisplayWidth) ?? 0;
+                var maxX = (Output?.Position.X + Output?.Width - halfDisplayWidth) ?? 0;
+                var minY = (Output?.Position.Y - halfDisplayHeight) ?? 0;
+                var maxY = (Output?.Position.Y + Output?.Height - halfDisplayHeight) ?? 0;
 
                 this.min = new Vector2(minX, minY);
                 this.max = new Vector2(maxX, maxY);

--- a/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/AbsoluteOutputMode.cs
@@ -12,7 +12,6 @@ namespace OpenTabletDriver.Plugin.Output
     public abstract class AbsoluteOutputMode : OutputMode
     {
         private Vector2 min, max;
-        private Area outputArea, inputArea;
 
         /// <summary>
         /// The area in which the tablet's input is transformed to.
@@ -21,10 +20,10 @@ namespace OpenTabletDriver.Plugin.Output
         {
             set
             {
-                this.inputArea = value;
+                field = value;
                 this.TransformationMatrix = CreateTransformationMatrix();
             }
-            get => this.inputArea;
+            get;
         }
 
         /// <summary>
@@ -34,10 +33,10 @@ namespace OpenTabletDriver.Plugin.Output
         {
             set
             {
-                this.outputArea = value;
+                field = value;
                 this.TransformationMatrix = CreateTransformationMatrix();
             }
-            get => this.outputArea;
+            get;
         }
 
         /// <summary>

--- a/OpenTabletDriver.Plugin/Output/AsyncPositionedPipelineElement.cs
+++ b/OpenTabletDriver.Plugin/Output/AsyncPositionedPipelineElement.cs
@@ -12,9 +12,7 @@ namespace OpenTabletDriver.Plugin.Output
     {
         private readonly object synchronizationObject = new object();
         private readonly HPETDeltaStopwatch consumeWatch = new HPETDeltaStopwatch(false);
-        private ITimer scheduler;
         private float? reportMsAvg;
-        private float frequency;
 
         /// <summary>
         /// The current state of the <see cref="AsyncPositionedPipelineElement{T}"/>.
@@ -30,21 +28,21 @@ namespace OpenTabletDriver.Plugin.Output
         {
             set
             {
-                this.scheduler = value;
+                field = value;
 
-                if (this.scheduler != null)
+                if (field != null)
                 {
-                    this.scheduler.Elapsed += () =>
+                    field.Elapsed += () =>
                     {
                         lock (synchronizationObject)
                         {
                             UpdateState();
                         }
                     };
-                    this.scheduler.Start();
+                    field.Start();
                 }
             }
-            get => this.scheduler;
+            get;
         }
 
         [Property("Frequency"), Unit("hz"), DefaultPropertyValue(1000.0f)]
@@ -52,13 +50,13 @@ namespace OpenTabletDriver.Plugin.Output
         {
             set
             {
-                this.frequency = value;
+                field = value;
                 if (Scheduler.Enabled)
                     Scheduler.Stop();
                 Scheduler.Interval = 1000f / value;
                 Scheduler.Start();
             }
-            get => this.frequency;
+            get;
         }
 
         public void Consume(T value)

--- a/OpenTabletDriver.Plugin/Output/AsyncPositionedPipelineElement.cs
+++ b/OpenTabletDriver.Plugin/Output/AsyncPositionedPipelineElement.cs
@@ -11,7 +11,7 @@ namespace OpenTabletDriver.Plugin.Output
     public abstract class AsyncPositionedPipelineElement<T> : IPositionedPipelineElement<T>, IDisposable
     {
         private readonly object synchronizationObject = new object();
-        private HPETDeltaStopwatch consumeWatch = new HPETDeltaStopwatch(false);
+        private readonly HPETDeltaStopwatch consumeWatch = new HPETDeltaStopwatch(false);
         private ITimer scheduler;
         private float? reportMsAvg;
         private float frequency;

--- a/OpenTabletDriver.Plugin/Output/IOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/IOutputMode.cs
@@ -32,11 +32,11 @@ namespace OpenTabletDriver.Plugin.Output
         /// <summary>
         /// Whether to disable pressure
         /// </summary>
-        public bool DisablePressure { set; get; }
+        bool DisablePressure { set; get; }
 
         /// <summary>
         /// Whether to disable tilt
         /// </summary>
-        public bool DisableTilt { set; get; }
+        bool DisableTilt { set; get; }
     }
 }

--- a/OpenTabletDriver.Plugin/Output/OutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/OutputMode.cs
@@ -13,9 +13,7 @@ namespace OpenTabletDriver.Plugin.Output
             Passthrough = true;
         }
 
-        private bool passthrough;
         private TabletReference tablet;
-        private IList<IPositionedPipelineElement<IDeviceReport>> elements;
         private IPipelineElement<IDeviceReport> entryElement;
 
         public event Action<IDeviceReport> Emit;
@@ -25,20 +23,20 @@ namespace OpenTabletDriver.Plugin.Output
             private set
             {
                 Action<IDeviceReport> output = this.OnOutput;
-                if (value && !passthrough)
+                if (value && !field)
                 {
                     this.entryElement = this;
                     Link(this, output);
-                    this.passthrough = true;
+                    field = true;
                 }
-                else if (!value && passthrough)
+                else if (!value && field)
                 {
                     this.entryElement = null;
                     Unlink(this, output);
-                    this.passthrough = false;
+                    field = false;
                 }
             }
-            get => this.passthrough;
+            get;
         }
 
         protected IList<IPositionedPipelineElement<IDeviceReport>> PreTransformElements { private set; get; } =
@@ -57,7 +55,7 @@ namespace OpenTabletDriver.Plugin.Output
         {
             set
             {
-                this.elements = value;
+                field = value;
 
                 Passthrough = false;
                 DestroyInternalLinks();
@@ -82,7 +80,7 @@ namespace OpenTabletDriver.Plugin.Output
                     PostTransformElements = Array.Empty<IPositionedPipelineElement<IDeviceReport>>();
                 }
             }
-            get => this.elements;
+            get;
         }
 
         private List<IPipelineElement<IDeviceReport>> ElementsAsPipeline

--- a/OpenTabletDriver.Plugin/Output/PipelineManager.cs
+++ b/OpenTabletDriver.Plugin/Output/PipelineManager.cs
@@ -104,7 +104,7 @@ namespace OpenTabletDriver.Plugin.Output
 
         protected IList<IPositionedPipelineElement<T>> GroupElements(IList<IPositionedPipelineElement<T>> elements, PipelinePosition position)
         {
-            return elements.Where(e => e.Position == position)?.ToArray() ?? Array.Empty<IPositionedPipelineElement<T>>();
+            return elements.Where(e => e.Position == position)?.ToArray() ?? [];
         }
     }
 }

--- a/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
@@ -13,7 +13,7 @@ namespace OpenTabletDriver.Plugin.Output
     [PluginIgnore]
     public abstract class RelativeOutputMode : OutputMode
     {
-        private HPETDeltaStopwatch stopwatch = new HPETDeltaStopwatch();
+        private readonly HPETDeltaStopwatch stopwatch = new HPETDeltaStopwatch();
         private Vector2? lastTransformedPos;
         private Vector2 lastReadPos;
         private bool outOfRange;

--- a/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
+++ b/OpenTabletDriver.Plugin/Output/RelativeOutputMode.cs
@@ -45,9 +45,6 @@ namespace OpenTabletDriver.Plugin.Output
             get => this.sensitivity;
         }
 
-        private float rotation;
-        private TimeSpan _resetTime;
-
         /// <summary>
         /// The angle of rotation to be applied to the input.
         /// </summary>
@@ -55,10 +52,10 @@ namespace OpenTabletDriver.Plugin.Output
         {
             set
             {
-                this.rotation = value;
+                field = value;
                 this.TransformationMatrix = CreateTransformationMatrix();
             }
-            get => this.rotation;
+            get;
         }
 
         /// <summary>
@@ -68,11 +65,11 @@ namespace OpenTabletDriver.Plugin.Output
         {
             set
             {
-                _resetTime = value;
+                field = value;
                 _resets = 0;
                 _warnedBadResets = false;
             }
-            get => _resetTime;
+            get;
         }
 
         protected override Matrix3x2 CreateTransformationMatrix()

--- a/OpenTabletDriver.Plugin/Platform/Pointer/IMouseScrollHandler.cs
+++ b/OpenTabletDriver.Plugin/Platform/Pointer/IMouseScrollHandler.cs
@@ -2,7 +2,7 @@ namespace OpenTabletDriver.Plugin.Platform.Pointer
 {
     public interface IMouseScrollHandler
     {
-        public void ScrollVertically(int amount);
-        public void ScrollHorizontally(int amount);
+        void ScrollVertically(int amount);
+        void ScrollHorizontally(int amount);
     }
 }

--- a/OpenTabletDriver.Plugin/Tablet/TabletConfiguration.cs
+++ b/OpenTabletDriver.Plugin/Tablet/TabletConfiguration.cs
@@ -29,7 +29,7 @@ namespace OpenTabletDriver.Plugin.Tablet
         /// </summary>
         [Required(ErrorMessage = $"Tablet {nameof(DigitizerIdentifiers)} are required")]
         [MinLength(1, ErrorMessage = "Requires at least 1 identifier")]
-        public List<DeviceIdentifier> DigitizerIdentifiers { set; get; } = new List<DeviceIdentifier>();
+        public List<DeviceIdentifier> DigitizerIdentifiers { set; get; } = [];
 
         /// <summary>
         /// The auxiliary device identifier.

--- a/OpenTabletDriver.Plugin/Tablet/Wheel/IWheelButtonReport.cs
+++ b/OpenTabletDriver.Plugin/Tablet/Wheel/IWheelButtonReport.cs
@@ -15,6 +15,6 @@ namespace OpenTabletDriver.Plugin.Tablet.Wheel
         /// The buttons per wheel, e.g. <c>[[True], [False]]</c> for multi-wheel.
         /// Or <c>[[True]]</c> for single wheel
         /// </summary>
-        public bool[][] WheelButtons { set; get; }
+        bool[][] WheelButtons { set; get; }
     }
 }

--- a/OpenTabletDriver.Plugin/Tablet/WheelSpecifications.cs
+++ b/OpenTabletDriver.Plugin/Tablet/WheelSpecifications.cs
@@ -11,8 +11,6 @@ namespace OpenTabletDriver.Plugin.Tablet
     /// </summary>
     public class WheelSpecifications
     {
-        private uint? _absoluteWheelMax;
-        private uint? _relativeWheelSteps;
 
         /// <summary>
         /// The number of device steps per 360 degrees of wheel rotation. Used to normalize step size across tablets.
@@ -24,12 +22,12 @@ namespace OpenTabletDriver.Plugin.Tablet
         /// </remarks>
         public uint? RelativeWheelSteps
         {
-            get => _relativeWheelSteps;
+            get;
             set
             {
                 if (AbsoluteWheelMax.HasValue && value != null)
                     throw new InvalidOperationException($"Can't set {nameof(RelativeWheelSteps)} when {nameof(AbsoluteWheelMax)} is set");
-                _relativeWheelSteps = value;
+                field = value;
             }
         }
 
@@ -43,12 +41,12 @@ namespace OpenTabletDriver.Plugin.Tablet
         /// </remarks>
         public uint? AbsoluteWheelMax
         {
-            get => _absoluteWheelMax;
+            get;
             set
             {
                 if (RelativeWheelSteps.HasValue && value != null)
                     throw new InvalidOperationException($"Can't set {nameof(AbsoluteWheelMax)} when {nameof(RelativeWheelSteps)} is set");
-                _absoluteWheelMax = value;
+                field = value;
             }
         }
 

--- a/OpenTabletDriver.Tests/ConfigurationTest/AttributesTest.cs
+++ b/OpenTabletDriver.Tests/ConfigurationTest/AttributesTest.cs
@@ -101,7 +101,7 @@ namespace OpenTabletDriver.Tests.ConfigurationTest
 
             Dictionary<string, string> ExtractValues(Dictionary<string, string>? dict)
             {
-                if (dict == null) return new Dictionary<string, string>();
+                if (dict == null) return [];
                 return dict;
             }
         }

--- a/OpenTabletDriver.Tests/ConfigurationTest/ConfigurationTest.cs
+++ b/OpenTabletDriver.Tests/ConfigurationTest/ConfigurationTest.cs
@@ -199,7 +199,7 @@ namespace OpenTabletDriver.Tests.ConfigurationTest
 
                 Debug.Assert(closestLpi.HasValue);
 
-                decimal suggestedSize = (maxLines / closestLpi.Value) * MILLIMETERS_PER_INCH;
+                decimal suggestedSize = maxLines / closestLpi.Value * MILLIMETERS_PER_INCH;
                 suggestedSize = Math.Round(suggestedSize, 8);
 
                 decimal millimetersPerLine = 1 / (closestLpi.Value / MILLIMETERS_PER_INCH);

--- a/OpenTabletDriver.Tests/ConfigurationTest/ConfigurationTest.cs
+++ b/OpenTabletDriver.Tests/ConfigurationTest/ConfigurationTest.cs
@@ -32,7 +32,7 @@ namespace OpenTabletDriver.Tests.ConfigurationTest
             var tabletFilename = testTabletConfiguration.File.Name;
             var tabletConfigString = testTabletConfiguration.FileContents.Value;
             var schema = TestData.TabletConfigurationSchema;
-            IList<string> errors = new List<string>();
+            IList<string> errors = [];
 
             var tabletConfig = JObject.Parse(tabletConfigString);
             try
@@ -184,7 +184,7 @@ namespace OpenTabletDriver.Tests.ConfigurationTest
             {
                 decimal? closestLpi = null;
 
-                var validLPIsArr = validLPIs as int[] ?? validLPIs.ToArray();
+                var validLPIsArr = validLPIs as int[] ?? [.. validLPIs];
                 foreach (decimal validLpi in validLPIsArr.OrderBy(x => x))
                 {
                     if (closestLpi == null)

--- a/OpenTabletDriver.Tests/ConfigurationTest/DeviceIdentifierTest.SelfTests.cs
+++ b/OpenTabletDriver.Tests/ConfigurationTest/DeviceIdentifierTest.SelfTests.cs
@@ -128,9 +128,7 @@ namespace OpenTabletDriver.Tests.ConfigurationTest
             {
                 VendorID = 1,
                 ProductID = 1,
-                DeviceStrings = new Dictionary<byte, string>
-                {
-                },
+                DeviceStrings = [],
                 InputReportLength = 1,
                 OutputReportLength = 1
             };

--- a/OpenTabletDriver.Tests/ConfigurationTest/TestData.cs
+++ b/OpenTabletDriver.Tests/ConfigurationTest/TestData.cs
@@ -25,7 +25,7 @@ namespace OpenTabletDriver.Tests.ConfigurationTest
             var result = new TheoryData<TestTabletConfiguration>();
             foreach (var configFile in Directory.EnumerateFiles(GetConfigDir(), "*.json", SearchOption.AllDirectories))
             {
-                FileInfo configFileInfo = new FileInfo(configFile);
+                var configFileInfo = new FileInfo(configFile);
                 var ttc = new TestTabletConfiguration
                 {
                     Configuration = new Lazy<TabletConfiguration>(() => Deserialize(configFileInfo)),

--- a/OpenTabletDriver.Tests/ConfigurationTest/TestData.cs
+++ b/OpenTabletDriver.Tests/ConfigurationTest/TestData.cs
@@ -75,7 +75,7 @@ namespace OpenTabletDriver.Tests.ConfigurationTest
         private static JSchema? tabletConfigurationSchema;
         public static JSchema TabletConfigurationSchema => tabletConfigurationSchema ??= GetTabletConfigSchema();
 
-        static JSchema GetTabletConfigSchema()
+        private static JSchema GetTabletConfigSchema()
         {
             var gen = new JSchemaGenerator
             {

--- a/OpenTabletDriver.Tests/ConfigurationTest/TestData.cs
+++ b/OpenTabletDriver.Tests/ConfigurationTest/TestData.cs
@@ -72,8 +72,7 @@ namespace OpenTabletDriver.Tests.ConfigurationTest
 
         #region Schema
 
-        private static JSchema? tabletConfigurationSchema;
-        public static JSchema TabletConfigurationSchema => tabletConfigurationSchema ??= GetTabletConfigSchema();
+        public static JSchema TabletConfigurationSchema => field ??= GetTabletConfigSchema();
 
         private static JSchema GetTabletConfigSchema()
         {

--- a/OpenTabletDriver.Tests/Fakes/FakeDirectory.cs
+++ b/OpenTabletDriver.Tests/Fakes/FakeDirectory.cs
@@ -4,6 +4,6 @@ namespace OpenTabletDriver.Tests.Fakes
 {
     public class FakeDirectory : FakeFileSystemEntry
     {
-        public List<FakeFileSystemEntry> Entries { get; } = new();
+        public List<FakeFileSystemEntry> Entries { get; } = [];
     }
 }

--- a/OpenTabletDriver.Tests/Fakes/FakeFile.cs
+++ b/OpenTabletDriver.Tests/Fakes/FakeFile.cs
@@ -1,9 +1,7 @@
-using System;
-
 namespace OpenTabletDriver.Tests.Fakes
 {
     public class FakeFile : FakeFileSystemEntry
     {
-        public byte[] Data { get; init; } = Array.Empty<byte>();
+        public byte[] Data { get; init; } = [];
     }
 }

--- a/OpenTabletDriver.Tests/Updater/UpdaterEnvironment.cs
+++ b/OpenTabletDriver.Tests/Updater/UpdaterEnvironment.cs
@@ -26,8 +26,8 @@ namespace OpenTabletDriver.Tests.Updater
             InitializeDirectory(RollBackDir);
         }
 
-        public List<FakeFileSystemEntry> BinaryFiles { get; } = new();
-        public List<FakeFileSystemEntry> AppDataFiles { get; } = new();
+        public List<FakeFileSystemEntry> BinaryFiles { get; } = [];
+        public List<FakeFileSystemEntry> AppDataFiles { get; } = [];
 
         internal void HookToUpdater(OTDUpdater updater)
         {

--- a/OpenTabletDriver.UX.Gtk/Program.cs
+++ b/OpenTabletDriver.UX.Gtk/Program.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace OpenTabletDriver.UX.Gtk
 {
-    class Program
+    internal class Program
     {
         [STAThread]
         public static void Main(string[] args)

--- a/OpenTabletDriver.UX.MacOS/PermissionHelper.cs
+++ b/OpenTabletDriver.UX.MacOS/PermissionHelper.cs
@@ -10,7 +10,7 @@ using OpenTabletDriver.Native.OSX.IOkit;
 
 namespace OpenTabletDriver.UX.MacOS
 {
-    static public class PermissionHelper
+    public static class PermissionHelper
     {
         public static bool HasPermissions()
         {

--- a/OpenTabletDriver.UX.MacOS/PermissionHelper.cs
+++ b/OpenTabletDriver.UX.MacOS/PermissionHelper.cs
@@ -106,7 +106,7 @@ namespace OpenTabletDriver.UX.MacOS
             alert.Buttons[2].Target = cancelHandler;
 
             //Prevent our alert obscuring the system permission dialog.
-            Thread thread = new Thread(() =>
+            var thread = new Thread(() =>
             {
                 Thread.Sleep(150);
                 NSApplication.SharedApplication.InvokeOnMainThread(() =>

--- a/OpenTabletDriver.UX.MacOS/PermissionHelper.cs
+++ b/OpenTabletDriver.UX.MacOS/PermissionHelper.cs
@@ -158,7 +158,7 @@ namespace OpenTabletDriver.UX.MacOS
                 _url = url;
             }
 
-            private string _url;
+            private readonly string _url;
 
             [Export("onClick:")]
             private void onClick(NSObject target)

--- a/OpenTabletDriver.UX.MacOS/PermissionHelper.cs
+++ b/OpenTabletDriver.UX.MacOS/PermissionHelper.cs
@@ -132,7 +132,7 @@ namespace OpenTabletDriver.UX.MacOS
 
         private class KillOnQuitHandler : NSObject
         {
-            static KillOnQuitHandler handler;
+            private static KillOnQuitHandler handler;
 
 #pragma warning disable CA1822
             [Export("handleQuitEvent:withReplyEvent:")]

--- a/OpenTabletDriver.UX.MacOS/PermissionHelper.cs
+++ b/OpenTabletDriver.UX.MacOS/PermissionHelper.cs
@@ -62,7 +62,7 @@ namespace OpenTabletDriver.UX.MacOS
             {
                 if (selfResponsible)
                 {
-                    var process = Process.Start("open", new[] { NSBundle.MainBundle.BundlePath, "-n" });
+                    var process = Process.Start("open", [NSBundle.MainBundle.BundlePath, "-n"]);
                     process.WaitForExit();
                 }
                 else

--- a/OpenTabletDriver.UX.MacOS/Program.cs
+++ b/OpenTabletDriver.UX.MacOS/Program.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace OpenTabletDriver.UX.MacOS
 {
-    class Program
+    internal class Program
     {
         [STAThread]
         public static void Main(string[] args)

--- a/OpenTabletDriver.UX.Wpf/Program.cs
+++ b/OpenTabletDriver.UX.Wpf/Program.cs
@@ -4,7 +4,7 @@ using Eto.Forms;
 
 namespace OpenTabletDriver.UX.Wpf
 {
-    class Program
+    internal class Program
     {
         [STAThread]
         public static void Main(string[] args)

--- a/OpenTabletDriver.UX.Wpf/Program.cs
+++ b/OpenTabletDriver.UX.Wpf/Program.cs
@@ -9,7 +9,7 @@ namespace OpenTabletDriver.UX.Wpf
         [STAThread]
         public static void Main(string[] args)
         {
-            WindowsIdentity identity = WindowsIdentity.GetCurrent();
+            var identity = WindowsIdentity.GetCurrent();
             WindowsPrincipal principal = new(identity);
             if (principal.IsInRole(WindowsBuiltInRole.Administrator))
             {

--- a/OpenTabletDriver.UX/App.cs
+++ b/OpenTabletDriver.UX/App.cs
@@ -153,12 +153,10 @@ namespace OpenTabletDriver.UX
 
         public static Uri Website { get; } = new Uri(@"https://github.com/OpenTabletDriver/OpenTabletDriver");
         public static string License { get; } = new StreamReader(Assembly.GetExecutingAssembly().GetManifestResourceStream("OpenTabletDriver.UX.LICENSE")).ReadToEnd();
-
-        private Settings settings;
         public Settings Settings
         {
-            set => this.RaiseAndSetIfChanged(ref this.settings, value);
-            get => this.settings;
+            set => this.RaiseAndSetIfChanged(ref field, value);
+            get;
         }
 
         private const string APPNAME = "OpenTabletDriver.UX";

--- a/OpenTabletDriver.UX/App.cs
+++ b/OpenTabletDriver.UX/App.cs
@@ -162,8 +162,8 @@ namespace OpenTabletDriver.UX
         }
 
         private const string APPNAME = "OpenTabletDriver.UX";
-        public readonly static bool EnableTrayIcon = (PluginPlatform.Windows | PluginPlatform.MacOS).HasFlag(SystemInterop.CurrentPlatform);
-        public readonly static bool EnableDaemonWatchdog = (PluginPlatform.Windows | PluginPlatform.MacOS).HasFlag(SystemInterop.CurrentPlatform);
+        public static readonly bool EnableTrayIcon = (PluginPlatform.Windows | PluginPlatform.MacOS).HasFlag(SystemInterop.CurrentPlatform);
+        public static readonly bool EnableDaemonWatchdog = (PluginPlatform.Windows | PluginPlatform.MacOS).HasFlag(SystemInterop.CurrentPlatform);
         public static DaemonWatchdog DaemonWatchdog;
 
         public WindowSingleton<StartupGreeterWindow> StartupGreeterWindow { get; } = new WindowSingleton<StartupGreeterWindow>();

--- a/OpenTabletDriver.UX/App.cs
+++ b/OpenTabletDriver.UX/App.cs
@@ -21,7 +21,7 @@ using OpenTabletDriver.UX.Windows.Updater;
 
 namespace OpenTabletDriver.UX
 {
-    class CommandLineOptions
+    internal class CommandLineOptions
     {
         public bool StartMinimized { get; set; }
         public bool SkipUpdate { get; set; }

--- a/OpenTabletDriver.UX/Controls/BindingDisplay.cs
+++ b/OpenTabletDriver.UX/Controls/BindingDisplay.cs
@@ -52,15 +52,14 @@ namespace OpenTabletDriver.UX.Controls
 
         public event EventHandler<EventArgs> StoreChanged;
 
-        private PluginSettingStore store;
         public PluginSettingStore Store
         {
             set
             {
-                this.store = value;
+                field = value;
                 StoreChanged?.Invoke(this, new EventArgs());
             }
-            get => this.store;
+            get;
         }
 
         public BindableBinding<BindingDisplay, PluginSettingStore> StoreBinding

--- a/OpenTabletDriver.UX/Controls/BindingDisplay.cs
+++ b/OpenTabletDriver.UX/Controls/BindingDisplay.cs
@@ -48,7 +48,7 @@ namespace OpenTabletDriver.UX.Controls
             };
         }
 
-        private Button mainButton, advancedButton;
+        private readonly Button mainButton, advancedButton;
 
         public event EventHandler<EventArgs> StoreChanged;
 

--- a/OpenTabletDriver.UX/Controls/Bindings/AuxiliaryBindingEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/AuxiliaryBindingEditor.cs
@@ -33,6 +33,6 @@ namespace OpenTabletDriver.UX.Controls.Bindings
             auxButtons.ItemSourceBinding.Bind(SettingsBinding.Child(c => (IList<PluginSettingStore>)c.AuxButtons));
         }
 
-        private BindingDisplayList auxButtons;
+        private readonly BindingDisplayList auxButtons;
     }
 }

--- a/OpenTabletDriver.UX/Controls/Bindings/BindingDisplayList.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/BindingDisplayList.cs
@@ -15,7 +15,7 @@ namespace OpenTabletDriver.UX.Controls.Bindings
 
         protected override Control CreateControl(int index, DirectBinding<PluginSettingStore> itemBinding)
         {
-            BindingDisplay display = new BindingDisplay();
+            var display = new BindingDisplay();
             display.StoreBinding.Bind(itemBinding);
 
             return new Group

--- a/OpenTabletDriver.UX/Controls/Bindings/BindingEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/BindingEditor.cs
@@ -8,15 +8,14 @@ namespace OpenTabletDriver.UX.Controls.Bindings
     {
         public DirectBinding<BindingSettings> SettingsBinding => ProfileBinding.Child(b => b.BindingSettings);
 
-        private Profile profile;
         public Profile Profile
         {
             set
             {
-                this.profile = value;
+                field = value;
                 this.OnProfileChanged();
             }
-            get => this.profile;
+            get;
         }
 
         public event EventHandler<EventArgs> ProfileChanged;

--- a/OpenTabletDriver.UX/Controls/Bindings/MouseBindingEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/MouseBindingEditor.cs
@@ -60,8 +60,8 @@ namespace OpenTabletDriver.UX.Controls.Bindings
             scrollDown.StoreBinding.Bind(SettingsBinding.Child(c => c.MouseScrollDown));
         }
 
-        private MouseBindingDisplayList mouseButtons;
-        private BindingDisplay scrollUp, scrollDown;
+        private readonly MouseBindingDisplayList mouseButtons;
+        private readonly BindingDisplay scrollUp, scrollDown;
 
         private class MouseBindingDisplayList : BindingDisplayList
         {

--- a/OpenTabletDriver.UX/Controls/Bindings/PenBindingEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/PenBindingEditor.cs
@@ -134,9 +134,9 @@ namespace OpenTabletDriver.UX.Controls.Bindings
             enableDragBindings.CheckedBinding.Cast<bool>().Bind(SettingsBinding.Child(c => c.EnableDragBindings));
         }
 
-        private BindingDisplay tipButton, eraserButton;
-        private FloatSlider tipThreshold, eraserThreshold;
-        private CheckBox disablePressure, disableTilt, enableDragBindings;
-        private BindingDisplayList penButtons;
+        private readonly BindingDisplay tipButton, eraserButton;
+        private readonly FloatSlider tipThreshold, eraserThreshold;
+        private readonly CheckBox disablePressure, disableTilt, enableDragBindings;
+        private readonly BindingDisplayList penButtons;
     }
 }

--- a/OpenTabletDriver.UX/Controls/Bindings/WheelBindingEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/WheelBindingEditor.cs
@@ -147,9 +147,9 @@ namespace OpenTabletDriver.UX.Controls.Bindings
                 Binding.Property((WheelBindingSettings wbs) => wbs.WheelButtons).Convert(x => x is { Count: > 0 }));
         }
 
-        private Group wheelButtonGroup;
-        private BindingDisplay clockwiseButton, counterClockwiseButton;
-        private FloatSlider clockwiseThreshold, counterClockwiseThreshold;
-        private BindingDisplayList wheelButtons;
+        private readonly Group wheelButtonGroup;
+        private readonly BindingDisplay clockwiseButton, counterClockwiseButton;
+        private readonly FloatSlider clockwiseThreshold, counterClockwiseThreshold;
+        private readonly BindingDisplayList wheelButtons;
     }
 }

--- a/OpenTabletDriver.UX/Controls/ControlPanel.cs
+++ b/OpenTabletDriver.UX/Controls/ControlPanel.cs
@@ -93,14 +93,14 @@ namespace OpenTabletDriver.UX.Controls
             });
         }
 
-        private TabControl tabControl;
-        private Placeholder placeholder;
-        private LogView logView;
-        private OutputModeEditor outputModeEditor;
-        private BindingEditor penBindingEditor, auxBindingEditor, mouseBindingEditor;
-        private List<BindingEditor> wheelBindingEditors = [];
-        private PluginSettingStoreCollectionEditor<IPositionedPipelineElement<IDeviceReport>> filterEditor;
-        private PluginSettingStoreCollectionEditor<ITool> toolEditor;
+        private readonly TabControl tabControl;
+        private readonly Placeholder placeholder;
+        private readonly LogView logView;
+        private readonly OutputModeEditor outputModeEditor;
+        private readonly BindingEditor penBindingEditor, auxBindingEditor, mouseBindingEditor;
+        private readonly List<BindingEditor> wheelBindingEditors = [];
+        private readonly PluginSettingStoreCollectionEditor<IPositionedPipelineElement<IDeviceReport>> filterEditor;
+        private readonly PluginSettingStoreCollectionEditor<ITool> toolEditor;
 
         private Profile profile;
         public Profile Profile

--- a/OpenTabletDriver.UX/Controls/ControlPanel.cs
+++ b/OpenTabletDriver.UX/Controls/ControlPanel.cs
@@ -102,15 +102,14 @@ namespace OpenTabletDriver.UX.Controls
         private readonly PluginSettingStoreCollectionEditor<IPositionedPipelineElement<IDeviceReport>> filterEditor;
         private readonly PluginSettingStoreCollectionEditor<ITool> toolEditor;
 
-        private Profile profile;
         public Profile Profile
         {
             set
             {
-                this.profile = value;
+                field = value;
                 this.OnProfileChanged();
             }
-            get => this.profile;
+            get;
         }
 
         public event EventHandler<EventArgs> ProfileChanged;

--- a/OpenTabletDriver.UX/Controls/Generic/FloatSlider.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/FloatSlider.cs
@@ -39,16 +39,14 @@ namespace OpenTabletDriver.UX.Controls
 
         private readonly Slider slider = new();
 
-        private float _value;
-
         public float Value
         {
             set
             {
-                this._value = value;
+                field = value;
                 ValueChanged?.Invoke(this, new EventArgs());
             }
-            get => this._value;
+            get;
         }
 
         public int Minimum

--- a/OpenTabletDriver.UX/Controls/Generic/GeneratedItemList.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/GeneratedItemList.cs
@@ -19,7 +19,6 @@ namespace OpenTabletDriver.UX.Controls.Generic
             Spacing = 5
         };
 
-        private IList<T> itemSource;
         public IList<T> ItemSource
         {
             set
@@ -28,14 +27,14 @@ namespace OpenTabletDriver.UX.Controls.Generic
                 if (ItemSource is INotifyCollectionChanged oldNotify)
                     oldNotify.CollectionChanged -= HandleCollectionChanged;
 
-                this.itemSource = value;
+                field = value;
                 this.OnItemSourceChanged();
 
                 // Hook the collection change event if applicable
                 if (ItemSource is INotifyCollectionChanged newNotify)
                     newNotify.CollectionChanged += HandleCollectionChanged;
             }
-            get => this.itemSource;
+            get;
         }
 
         public event EventHandler<EventArgs> ItemSourceChanged;

--- a/OpenTabletDriver.UX/Controls/Generic/GeneratedItemList.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/GeneratedItemList.cs
@@ -114,8 +114,7 @@ namespace OpenTabletDriver.UX.Controls.Generic
                 () => ItemSource[index],
                 (v) =>
                 {
-                    if (ItemSource != null)
-                        ItemSource[index] = v;
+                    ItemSource?[index] = v;
                 }
             );
 

--- a/OpenTabletDriver.UX/Controls/Generic/Group.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/Group.cs
@@ -28,26 +28,24 @@ namespace OpenTabletDriver.UX.Controls.Generic
         protected virtual Color HorizontalBackgroundColor => SystemColors.ControlBackground;
         protected virtual Color VerticalBackgroundColor => SystemColors.WindowBackground;
 
-        private string text;
         public string Text
         {
             set
             {
-                this.text = value;
+                field = value;
                 UpdateControlLayout();
             }
-            get => text;
+            get;
         }
 
-        private Control content;
         public new Control Content
         {
             set
             {
-                this.content = value;
+                field = value;
                 UpdateControlLayout();
             }
-            get => content;
+            get;
         }
 
         public Orientation Orientation { set; get; } = DEFAULT_ORIENTATION;

--- a/OpenTabletDriver.UX/Controls/Generic/Reflection/Extensions.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/Reflection/Extensions.cs
@@ -9,7 +9,7 @@ namespace OpenTabletDriver.UX.Controls.Generic.Reflection
 {
     public static class Extensions
     {
-        private static readonly Dictionary<TypeInfo, string> FriendlyNameCache = new();
+        private static readonly Dictionary<TypeInfo, string> FriendlyNameCache = [];
 
         public static string GetFriendlyName(this TypeInfo type)
         {

--- a/OpenTabletDriver.UX/Controls/Generic/Reflection/TypeDropDown.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/Reflection/TypeDropDown.cs
@@ -21,7 +21,7 @@ namespace OpenTabletDriver.UX.Controls.Generic.Reflection
         {
             if (SelectedItem != null)
             {
-                args ??= Array.Empty<object>();
+                args ??= [];
                 return AppInfo.PluginManager.ConstructObject<T>(SelectedItem.FullName);
             }
             return null;

--- a/OpenTabletDriver.UX/Controls/Generic/Reflection/TypeListBox.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/Reflection/TypeListBox.cs
@@ -23,7 +23,7 @@ namespace OpenTabletDriver.UX.Controls.Generic.Reflection
         {
             if (SelectedItem != null)
             {
-                args ??= Array.Empty<object>();
+                args ??= [];
                 return AppInfo.PluginManager.ConstructObject<T>(SelectedItem.FullName);
             }
             return null;

--- a/OpenTabletDriver.UX/Controls/Generic/TextContent.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/TextContent.cs
@@ -40,7 +40,7 @@ namespace OpenTabletDriver.UX.Controls.Generic
 
         public static implicit operator TextContent(string[] lines)
         {
-            return new TextContent(lines);
+            return [.. lines];
         }
     }
 }

--- a/OpenTabletDriver.UX/Controls/Generic/UnitGroup.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/UnitGroup.cs
@@ -10,15 +10,14 @@ namespace OpenTabletDriver.UX.Controls.Generic
             unitLabel.TextBinding.Bind(UnitBinding);
         }
 
-        private string unit;
         public string Unit
         {
             set
             {
-                this.unit = value;
+                field = value;
                 this.OnUnitChanged();
             }
-            get => this.unit;
+            get;
         }
 
         public event EventHandler<EventArgs> UnitChanged;
@@ -41,12 +40,11 @@ namespace OpenTabletDriver.UX.Controls.Generic
 
         private readonly Label unitLabel = new Label();
 
-        private Control content;
         public new Control Content
         {
             set
             {
-                this.content = value;
+                field = value;
                 base.Content = new StackLayout
                 {
                     Spacing = 5,
@@ -62,7 +60,7 @@ namespace OpenTabletDriver.UX.Controls.Generic
                     }
                 };
             }
-            get => this.content;
+            get;
         }
     }
 }

--- a/OpenTabletDriver.UX/Controls/Generic/UnitGroup.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/UnitGroup.cs
@@ -39,7 +39,7 @@ namespace OpenTabletDriver.UX.Controls.Generic
             }
         }
 
-        private Label unitLabel = new Label();
+        private readonly Label unitLabel = new Label();
 
         private Control content;
         public new Control Content

--- a/OpenTabletDriver.UX/Controls/LogView.cs
+++ b/OpenTabletDriver.UX/Controls/LogView.cs
@@ -153,7 +153,7 @@ namespace OpenTabletDriver.UX.Controls
         {
             if (messages.Any())
             {
-                StringBuilder sb = new StringBuilder();
+                var sb = new StringBuilder();
                 foreach (var message in messages)
                 {
                     var line = Log.GetStringFormat(message);

--- a/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
@@ -103,15 +103,14 @@ namespace OpenTabletDriver.UX.Controls.Output
         private readonly DirectBinding<float> tabletWidth;
         private readonly DirectBinding<float> tabletHeight;
 
-        private AbsoluteModeSettings settings;
         public AbsoluteModeSettings Settings
         {
             set
             {
-                this.settings = value;
+                field = value;
                 this.OnSettingsChanged();
             }
-            get => this.settings;
+            get;
         }
 
         public event EventHandler<EventArgs> SettingsChanged;
@@ -335,7 +334,6 @@ namespace OpenTabletDriver.UX.Controls.Output
             }
 
             private BooleanCommand lockArCmd, areaClippingCmd, ignoreOutsideAreaCmd;
-            private bool lockAspectRatio, areaClipping, ignoreOutsideArea;
 
             public event EventHandler<EventArgs> LockAspectRatioChanged;
             public event EventHandler<EventArgs> AreaClippingChanged;
@@ -349,30 +347,30 @@ namespace OpenTabletDriver.UX.Controls.Output
             {
                 set
                 {
-                    this.lockAspectRatio = value;
+                    field = value;
                     this.OnLockAspectRatioChanged();
                 }
-                get => this.lockAspectRatio;
+                get;
             }
 
             public bool AreaClipping
             {
                 set
                 {
-                    this.areaClipping = value;
+                    field = value;
                     this.OnAreaClippingChanged();
                 }
-                get => this.areaClipping;
+                get;
             }
 
             public bool IgnoreOutsideArea
             {
                 set
                 {
-                    this.ignoreOutsideArea = value;
+                    field = value;
                     this.OnIgnoreOutsideAreaChanged();
                 }
-                get => this.ignoreOutsideArea;
+                get;
             }
 
             public BindableBinding<TabletAreaEditor, bool> LockAspectRatioBinding

--- a/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
@@ -439,12 +439,11 @@ namespace OpenTabletDriver.UX.Controls.Output
                 };
 
                 base.ContextMenu.Items.AddRange(
-                    new Command[]
-                    {
+                    [
                         lockArCmd,
                         areaClippingCmd,
                         ignoreOutsideAreaCmd
-                    }
+                    ]
                 );
 
                 base.ContextMenu.Items.AddSeparator();

--- a/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
@@ -98,10 +98,10 @@ namespace OpenTabletDriver.UX.Controls.Output
         private bool handlingSettingsChanging;
         private float? prevDisplayWidth;
         private float? prevDisplayHeight;
-        private DirectBinding<float> displayWidth;
-        private DirectBinding<float> displayHeight;
-        private DirectBinding<float> tabletWidth;
-        private DirectBinding<float> tabletHeight;
+        private readonly DirectBinding<float> displayWidth;
+        private readonly DirectBinding<float> displayHeight;
+        private readonly DirectBinding<float> tabletWidth;
+        private readonly DirectBinding<float> tabletHeight;
 
         private AbsoluteModeSettings settings;
         public AbsoluteModeSettings Settings

--- a/OpenTabletDriver.UX/Controls/Output/Area/AreaControl.cs
+++ b/OpenTabletDriver.UX/Controls/Output/Area/AreaControl.cs
@@ -8,9 +8,6 @@ namespace OpenTabletDriver.UX.Controls.Output.Area
 {
     public abstract class AreaControl : Panel
     {
-        private AreaSettings area;
-        private bool lockToUsableArea;
-        private string unit, invalidForegroundError, invalidBackgroundError;
         protected IEnumerable<RectangleF> areaBounds;
         private RectangleF fullAreaBounds;
 
@@ -34,30 +31,30 @@ namespace OpenTabletDriver.UX.Controls.Output.Area
         {
             set
             {
-                this.area = value;
+                field = value;
                 this.OnAreaChanged();
             }
-            get => this.area;
+            get;
         }
 
         public bool LockToUsableArea
         {
             set
             {
-                this.lockToUsableArea = value;
+                field = value;
                 this.OnLockToUsableAreaChanged();
             }
-            get => this.lockToUsableArea;
+            get;
         }
 
         public string Unit
         {
             set
             {
-                this.unit = value;
+                field = value;
                 this.OnUnitChanged();
             }
-            get => this.unit;
+            get;
         }
 
         public virtual IEnumerable<RectangleF> AreaBounds
@@ -84,20 +81,20 @@ namespace OpenTabletDriver.UX.Controls.Output.Area
         {
             set
             {
-                this.invalidForegroundError = value;
+                field = value;
                 this.OnInvalidForegroundErrorChanged();
             }
-            get => this.invalidForegroundError;
+            get;
         }
 
         public string InvalidBackgroundError
         {
             set
             {
-                this.invalidBackgroundError = value;
+                field = value;
                 this.OnInvalidBackgroundErrorChanged();
             }
-            get => this.invalidBackgroundError;
+            get;
         }
 
         public BindableBinding<AreaControl, AreaSettings> AreaBinding

--- a/OpenTabletDriver.UX/Controls/Output/Area/AreaDisplay.cs
+++ b/OpenTabletDriver.UX/Controls/Output/Area/AreaDisplay.cs
@@ -27,9 +27,6 @@ namespace OpenTabletDriver.UX.Controls.Output.Area
             }
         }
 
-        private AreaSettings area;
-        private bool lockToUsableArea;
-        private string unit, invalidForegroundError, invalidBackgroundError;
         protected IEnumerable<RectangleF> areaBounds;
         private RectangleF fullAreaBounds;
         private readonly TextDrawer textDrawer = new();
@@ -54,30 +51,30 @@ namespace OpenTabletDriver.UX.Controls.Output.Area
         {
             set
             {
-                this.area = value;
+                field = value;
                 this.OnAreaChanged();
             }
-            get => this.area;
+            get;
         }
 
         public bool LockToUsableArea
         {
             set
             {
-                this.lockToUsableArea = value;
+                field = value;
                 this.OnLockToUsableAreaChanged();
             }
-            get => this.lockToUsableArea;
+            get;
         }
 
         public string Unit
         {
             set
             {
-                this.unit = value;
+                field = value;
                 this.OnUnitChanged();
             }
-            get => this.unit;
+            get;
         }
 
         public virtual IEnumerable<RectangleF> AreaBounds
@@ -104,20 +101,20 @@ namespace OpenTabletDriver.UX.Controls.Output.Area
         {
             set
             {
-                this.invalidForegroundError = value;
+                field = value;
                 this.OnInvalidForegroundErrorChanged();
             }
-            get => this.invalidForegroundError;
+            get;
         }
 
         public string InvalidBackgroundError
         {
             set
             {
-                this.invalidBackgroundError = value;
+                field = value;
                 this.OnInvalidBackgroundErrorChanged();
             }
-            get => this.invalidBackgroundError;
+            get;
         }
 
         public BindableBinding<AreaDisplay, AreaSettings> AreaBinding

--- a/OpenTabletDriver.UX/Controls/Output/Area/AreaEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/Area/AreaEditor.cs
@@ -120,13 +120,13 @@ namespace OpenTabletDriver.UX.Controls.Output.Area
             Display.InvalidBackgroundErrorBinding.Bind(InvalidBackgroundErrorBinding);
         }
 
-        private BooleanCommand lockToUsableArea = new BooleanCommand
+        private readonly BooleanCommand lockToUsableArea = new BooleanCommand
         {
             MenuText = "Lock to usable area"
         };
 
-        private UnitGroup widthGroup, heightGroup, xGroup, yGroup;
-        private MaskedTextBox<float> width, height, x, y;
+        private readonly UnitGroup widthGroup, heightGroup, xGroup, yGroup;
+        private readonly MaskedTextBox<float> width, height, x, y;
 
         protected StackLayout settingsPanel;
 

--- a/OpenTabletDriver.UX/Controls/Output/Area/RotationAreaEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/Area/RotationAreaEditor.cs
@@ -28,7 +28,7 @@ namespace OpenTabletDriver.UX.Controls.Output.Area
             rotation.ValueChanged += (_, _) => Display.Invalidate();
         }
 
-        private MaskedTextBox<float> rotation;
+        private readonly MaskedTextBox<float> rotation;
 
         protected override void CreateMenu()
         {

--- a/OpenTabletDriver.UX/Controls/Output/OutputModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/OutputModeEditor.cs
@@ -87,12 +87,12 @@ namespace OpenTabletDriver.UX.Controls.Output
             }
         }
 
-        private Panel editorContainer = new Panel();
-        private AbsoluteModeEditor absoluteModeEditor = new AbsoluteModeEditor();
-        private RelativeModeEditor relativeModeEditor = new RelativeModeEditor();
-        private TypeDropDown<IOutputMode> outputModeSelector = new TypeDropDown<IOutputMode> { Width = 300 };
-        private Label outputModeUnsupported = new Label { Text = "No supported output mode selected.", TextAlignment = TextAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
-        private Label tabletUnavailable = new Label { Text = "No tablets were detected or selected.", TextAlignment = TextAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
+        private readonly Panel editorContainer = new Panel();
+        private readonly AbsoluteModeEditor absoluteModeEditor = new AbsoluteModeEditor();
+        private readonly RelativeModeEditor relativeModeEditor = new RelativeModeEditor();
+        private readonly TypeDropDown<IOutputMode> outputModeSelector = new TypeDropDown<IOutputMode> { Width = 300 };
+        private readonly Label outputModeUnsupported = new Label { Text = "No supported output mode selected.", TextAlignment = TextAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
+        private readonly Label tabletUnavailable = new Label { Text = "No tablets were detected or selected.", TextAlignment = TextAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
 
         public void SetTabletSize(TabletReference tablet)
         {

--- a/OpenTabletDriver.UX/Controls/Output/OutputModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/OutputModeEditor.cs
@@ -52,15 +52,14 @@ namespace OpenTabletDriver.UX.Controls.Output
                 SetTabletSize(selectedTablet);
         });
 
-        private Profile profile;
         public Profile Profile
         {
             set
             {
-                this.profile = value;
+                field = value;
                 this.OnProfileChanged();
             }
-            get => this.profile;
+            get;
         }
 
         public event EventHandler<EventArgs> ProfileChanged;

--- a/OpenTabletDriver.UX/Controls/Output/RelativeModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/RelativeModeEditor.cs
@@ -66,15 +66,14 @@ namespace OpenTabletDriver.UX.Controls.Output
 
         private readonly MaskedTextBox<float> xSens, ySens, rotation, resetTime;
 
-        private RelativeModeSettings settings;
         public RelativeModeSettings Settings
         {
             set
             {
-                this.settings = value;
+                field = value;
                 this.OnSettingsChanged();
             }
-            get => this.settings;
+            get;
         }
 
         public event EventHandler<EventArgs> SettingsChanged;

--- a/OpenTabletDriver.UX/Controls/Output/RelativeModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/RelativeModeEditor.cs
@@ -64,7 +64,7 @@ namespace OpenTabletDriver.UX.Controls.Output
             ).Bind(SettingsBinding.Child(s => s.ResetTime));
         }
 
-        private MaskedTextBox<float> xSens, ySens, rotation, resetTime;
+        private readonly MaskedTextBox<float> xSens, ySens, rotation, resetTime;
 
         private RelativeModeSettings settings;
         public RelativeModeSettings Settings

--- a/OpenTabletDriver.UX/Controls/Placeholder.cs
+++ b/OpenTabletDriver.UX/Controls/Placeholder.cs
@@ -31,8 +31,8 @@ namespace OpenTabletDriver.UX.Controls
             label.TextBinding.Bind(TextBinding);
         }
 
-        private Label label;
-        private Panel extraPanel;
+        private readonly Label label;
+        private readonly Panel extraPanel;
 
         private string text;
         public string Text

--- a/OpenTabletDriver.UX/Controls/Placeholder.cs
+++ b/OpenTabletDriver.UX/Controls/Placeholder.cs
@@ -34,15 +34,14 @@ namespace OpenTabletDriver.UX.Controls
         private readonly Label label;
         private readonly Panel extraPanel;
 
-        private string text;
         public string Text
         {
             set
             {
-                this.text = value;
+                field = value;
                 this.OnTextChanged();
             }
-            get => this.text;
+            get;
         }
 
         public event EventHandler<EventArgs> TextChanged;
@@ -63,15 +62,14 @@ namespace OpenTabletDriver.UX.Controls
             }
         }
 
-        private Control extraContent;
         public Control ExtraContent
         {
             set
             {
-                this.extraContent = value;
+                field = value;
                 extraPanel.Content = value;
             }
-            get => this.extraContent;
+            get;
         }
     }
 }

--- a/OpenTabletDriver.UX/Controls/PluginSettingStoreCollectionEditor.cs
+++ b/OpenTabletDriver.UX/Controls/PluginSettingStoreCollectionEditor.cs
@@ -57,15 +57,14 @@ namespace OpenTabletDriver.UX.Controls
         private readonly TypeListBox<TSource> sourceSelector;
         private readonly ToggleablePluginSettingStoreEditor settingStoreEditor;
 
-        private PluginSettingStoreCollection storeCollection;
         public PluginSettingStoreCollection StoreCollection
         {
             set
             {
-                this.storeCollection = value;
+                field = value;
                 this.OnStoreCollectionChanged();
             }
-            get => this.storeCollection;
+            get;
         }
 
         public event EventHandler<EventArgs> StoreCollectionChanged;

--- a/OpenTabletDriver.UX/Controls/PluginSettingStoreCollectionEditor.cs
+++ b/OpenTabletDriver.UX/Controls/PluginSettingStoreCollectionEditor.cs
@@ -52,10 +52,10 @@ namespace OpenTabletDriver.UX.Controls
             AppInfo.PluginManager.AssembliesChanged += HandleAssembliesChanged;
         }
 
-        private Placeholder placeholder;
-        private Splitter mainContent;
-        private TypeListBox<TSource> sourceSelector;
-        private ToggleablePluginSettingStoreEditor settingStoreEditor;
+        private readonly Placeholder placeholder;
+        private readonly Splitter mainContent;
+        private readonly TypeListBox<TSource> sourceSelector;
+        private readonly ToggleablePluginSettingStoreEditor settingStoreEditor;
 
         private PluginSettingStoreCollection storeCollection;
         public PluginSettingStoreCollection StoreCollection

--- a/OpenTabletDriver.UX/Controls/PluginSettingStoreEditor.cs
+++ b/OpenTabletDriver.UX/Controls/PluginSettingStoreEditor.cs
@@ -21,15 +21,14 @@ namespace OpenTabletDriver.UX.Controls
 
         private readonly StackLayout layout;
 
-        private PluginSettingStore store;
         public PluginSettingStore Store
         {
             set
             {
-                this.store = value;
+                field = value;
                 this.OnStoreChanged();
             }
-            get => this.store;
+            get;
         }
 
         public event EventHandler<EventArgs> StoreChanged;

--- a/OpenTabletDriver.UX/Controls/PluginSettingStoreEditor.cs
+++ b/OpenTabletDriver.UX/Controls/PluginSettingStoreEditor.cs
@@ -19,7 +19,7 @@ namespace OpenTabletDriver.UX.Controls
             };
         }
 
-        private StackLayout layout;
+        private readonly StackLayout layout;
 
         private PluginSettingStore store;
         public PluginSettingStore Store

--- a/OpenTabletDriver.UX/Controls/PluginSettingStoreEditor.cs
+++ b/OpenTabletDriver.UX/Controls/PluginSettingStoreEditor.cs
@@ -64,7 +64,7 @@ namespace OpenTabletDriver.UX.Controls
 
         protected virtual IEnumerable<Control> GetHeaderControlsForStore(PluginSettingStore store)
         {
-            return Array.Empty<Control>();
+            return [];
         }
 
         private static IEnumerable<Control> GetControlsForStore(PluginSettingStore store)
@@ -82,7 +82,7 @@ namespace OpenTabletDriver.UX.Controls
                 }
             }
 
-            return Array.Empty<Control>();
+            return [];
         }
 
         private static IEnumerable<Control> GetControlsForType(PluginSettingStore store, Type type)

--- a/OpenTabletDriver.UX/Controls/TabletSwitcherPanel.cs
+++ b/OpenTabletDriver.UX/Controls/TabletSwitcherPanel.cs
@@ -57,10 +57,10 @@ namespace OpenTabletDriver.UX.Controls
             Application.Instance.AsyncInvoke(async void () => HandleTabletsChanged(this, await App.Driver.Instance.GetTablets()));
         }
 
-        private StackLayout layout;
-        private TabletSwitcher tabletSwitcher;
-        private ControlPanel controlPanel;
-        private Panel commandsPanel;
+        private readonly StackLayout layout;
+        private readonly TabletSwitcher tabletSwitcher;
+        private readonly ControlPanel controlPanel;
+        private readonly Panel commandsPanel;
 
         public Control CommandsControl
         {

--- a/OpenTabletDriver.UX/DaemonWatchdog.cs
+++ b/OpenTabletDriver.UX/DaemonWatchdog.cs
@@ -12,7 +12,7 @@ namespace OpenTabletDriver.UX
 
         private Process daemonProcess;
 
-        private readonly static ProcessStartInfo startInfo = SystemInterop.CurrentPlatform switch
+        private static readonly ProcessStartInfo startInfo = SystemInterop.CurrentPlatform switch
         {
             PluginPlatform.Windows => new ProcessStartInfo
             {

--- a/OpenTabletDriver.UX/Dialogs/RepositoryDialog.cs
+++ b/OpenTabletDriver.UX/Dialogs/RepositoryDialog.cs
@@ -112,11 +112,10 @@ namespace OpenTabletDriver.UX.Dialogs
                 base.Orientation = Orientation.Horizontal;
             }
 
-            private string inputText;
             public string InputText
             {
-                protected set => this.inputText = value;
-                get => this.inputText == null || this.inputText?.Length == 0 ? DefaultInputText : this.inputText;
+                protected set;
+                get => field == null || field?.Length == 0 ? DefaultInputText : field;
             }
 
             public string DefaultInputText { set; get; }

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -705,7 +705,7 @@ namespace OpenTabletDriver.UX
                 var diagnosticDump = await App.Driver.Instance.GetDiagnosticInfo();
 
                 var tablets = await App.Driver.Instance.GetTablets();
-                var tabletReferences = tablets as TabletReference[] ?? tablets.ToArray();
+                var tabletReferences = tablets as TabletReference[] ?? [.. tablets];
                 string tabletNames = tabletReferences.Length != 0
                     ? " " + string.Join(", ", tabletReferences.Select(x => x.Properties.Name))
                     : string.Empty;

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -109,7 +109,7 @@ namespace OpenTabletDriver.UX
         private const int DEFAULT_CLIENT_HEIGHT = 760;
 
         private MenuBar menu;
-        private Placeholder placeholder;
+        private readonly Placeholder placeholder;
         private TrayIcon trayIcon;
 
         public bool SilenceDaemonShutdown { get; set; }
@@ -450,8 +450,8 @@ namespace OpenTabletDriver.UX
                 SetTitle(tablets);
         });
 
-        private Button saveButton;
-        private Button applyButton;
+        private readonly Button saveButton;
+        private readonly Button applyButton;
 
         private async void LogToDriver(object sender, LogMessage message)
         {

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -624,8 +624,7 @@ namespace OpenTabletDriver.UX
         {
             LoadPresets();
 
-            if (trayIcon != null) // Check non-Linux
-                trayIcon.RefreshMenuItems();
+            trayIcon?.RefreshMenuItems();
 
             // Update File submenu
             var presets = AppInfo.PresetManager.GetPresets();

--- a/OpenTabletDriver.UX/Tools/CompositionScheduler.cs
+++ b/OpenTabletDriver.UX/Tools/CompositionScheduler.cs
@@ -10,7 +10,7 @@ namespace OpenTabletDriver.UX.Tools
     /// </summary>
     public static class CompositionScheduler
     {
-        private static Timer scheduler = new Timer(_ => Application.Instance.AsyncInvoke(OnCompose));
+        private static readonly Timer scheduler = new Timer(_ => Application.Instance.AsyncInvoke(OnCompose));
         private const int MAX_FRAMES_PER_SEC = 60;
 
         public static void Register(EventHandler handler)

--- a/OpenTabletDriver.UX/Tools/LogDataStore.cs
+++ b/OpenTabletDriver.UX/Tools/LogDataStore.cs
@@ -21,17 +21,16 @@ namespace OpenTabletDriver.UX.Tools
         private readonly Queue<LogMessage> messages;
         private Queue<LogMessage> filteredMessages;
 
-        private LogLevel filter = LogLevel.Info;
         public LogLevel Filter
         {
             set
             {
-                this.filter = value;
+                field = value;
                 filteredMessages = new Queue<LogMessage>(GetFilteredMessages());
                 OnCollectionChanged();
             }
-            get => this.filter;
-        }
+            get;
+        } = LogLevel.Info;
 
         public int Count => filteredMessages.Count;
 

--- a/OpenTabletDriver.UX/Tools/ParseTools.cs
+++ b/OpenTabletDriver.UX/Tools/ParseTools.cs
@@ -21,7 +21,7 @@ namespace OpenTabletDriver.UX.Tools
         public static string ToHexString(byte[] value)
         {
             if (value is byte[] array)
-                return "0x" + BitConverter.ToString(array).Replace("-", " 0x") ?? string.Empty;
+                return ("0x" + BitConverter.ToString(array).Replace("-", " 0x")) ?? string.Empty;
             else
                 return string.Empty;
         }

--- a/OpenTabletDriver.UX/TrayIcon.cs
+++ b/OpenTabletDriver.UX/TrayIcon.cs
@@ -29,7 +29,7 @@ namespace OpenTabletDriver.UX
         }
 
         public TrayIndicator Indicator { get; }
-        private MainForm window;
+        private readonly MainForm window;
 
         public void Dispose()
         {

--- a/OpenTabletDriver.UX/Windows/AboutWindow.cs
+++ b/OpenTabletDriver.UX/Windows/AboutWindow.cs
@@ -9,9 +9,9 @@ namespace OpenTabletDriver.UX.Windows
 {
     public class AboutWindow : DesktopForm
     {
-        const int LARGE_FONTSIZE = 14;
-        const int SPACING = 10;
-        const int TAB_CONTENT_WIDTH = 500;
+        private const int LARGE_FONTSIZE = 14;
+        private const int SPACING = 10;
+        private const int TAB_CONTENT_WIDTH = 500;
 
         private readonly string[] Developers = ["InfinityGhost", "X9VoiD", "gonX", "jamesbt365", "Kuuube", "AkiSakurai"];
         private readonly string[] Designers = ["InfinityGhost"];

--- a/OpenTabletDriver.UX/Windows/AreaConverterDialog.cs
+++ b/OpenTabletDriver.UX/Windows/AreaConverterDialog.cs
@@ -123,9 +123,9 @@ namespace OpenTabletDriver.UX.Windows
         }
 
         private readonly TypeDropDown<IAreaConverter> converterList = new TypeDropDown<IAreaConverter>();
-        private Group topGroup, leftGroup, bottomGroup, rightGroup;
-        private FloatNumberBox top, left, bottom, right;
-        private Button applyButton;
+        private readonly Group topGroup, leftGroup, bottomGroup, rightGroup;
+        private readonly FloatNumberBox top, left, bottom, right;
+        private readonly Button applyButton;
         private TabletReference selectedTablet;
 
         protected void OnSelectionChanged()

--- a/OpenTabletDriver.UX/Windows/Bindings/AdvancedBindingEditorDialog.cs
+++ b/OpenTabletDriver.UX/Windows/Bindings/AdvancedBindingEditorDialog.cs
@@ -75,8 +75,8 @@ namespace OpenTabletDriver.UX.Windows.Bindings
             settingStoreEditor.Store = currentBinding;
         }
 
-        private TypeDropDown<IBinding> bindingTypeDropDown;
-        private PluginSettingStoreEditor<IBinding> settingStoreEditor = new PluginSettingStoreEditor<IBinding>();
+        private readonly TypeDropDown<IBinding> bindingTypeDropDown;
+        private readonly PluginSettingStoreEditor<IBinding> settingStoreEditor = new PluginSettingStoreEditor<IBinding>();
 
         private void ClearBinding(object sender, EventArgs e)
         {

--- a/OpenTabletDriver.UX/Windows/Bindings/BindingEditorDialog.cs
+++ b/OpenTabletDriver.UX/Windows/Bindings/BindingEditorDialog.cs
@@ -99,15 +99,14 @@ namespace OpenTabletDriver.UX.Windows.Bindings
 
             private const string TOOLTIP = "Press a key, combination of keys, or a mouse button.";
 
-            private PluginSettingStore store;
             public PluginSettingStore Store
             {
                 set
                 {
-                    this.store = value;
+                    field = value;
                     Refresh();
                 }
-                get => this.store;
+                get;
             }
 
             public void Refresh()

--- a/OpenTabletDriver.UX/Windows/Bindings/BindingEditorDialog.cs
+++ b/OpenTabletDriver.UX/Windows/Bindings/BindingEditorDialog.cs
@@ -60,7 +60,7 @@ namespace OpenTabletDriver.UX.Windows.Bindings
             };
         }
 
-        private BindingController bindingController;
+        private readonly BindingController bindingController;
 
         private void ClearBinding(object sender, EventArgs e)
         {

--- a/OpenTabletDriver.UX/Windows/Plugins/MetadataViewer.cs
+++ b/OpenTabletDriver.UX/Windows/Plugins/MetadataViewer.cs
@@ -234,7 +234,7 @@ namespace OpenTabletDriver.UX.Windows.Plugins
         private static IEnumerable<PluginMetadata> GetRepoMetadataForPlugin(PluginMetadataCollection repo, PluginMetadata metadata, Version currentDriverVersion)
         {
             if (repo == null)
-                return Enumerable.Empty<PluginMetadata>();
+                return [];
 
             return from meta in repo
                    where PluginMetadata.Match(meta, metadata)

--- a/OpenTabletDriver.UX/Windows/Plugins/MetadataViewer.cs
+++ b/OpenTabletDriver.UX/Windows/Plugins/MetadataViewer.cs
@@ -171,15 +171,15 @@ namespace OpenTabletDriver.UX.Windows.Plugins
         public event Func<PluginMetadata, Task<bool>> RequestPluginUninstall;
 
         private PluginMetadata updatedMetadata;
-        private PluginMetadata metadata;
+
         public PluginMetadata Metadata
         {
             set
             {
-                this.metadata = value;
+                field = value;
                 this.OnMetadataChanged();
             }
-            get => this.metadata;
+            get;
         }
 
         public event EventHandler<EventArgs> MetadataChanged;

--- a/OpenTabletDriver.UX/Windows/Plugins/MetadataViewer.cs
+++ b/OpenTabletDriver.UX/Windows/Plugins/MetadataViewer.cs
@@ -157,15 +157,15 @@ namespace OpenTabletDriver.UX.Windows.Plugins
             AppInfo.PluginManager.AssembliesChanged += HandleAssembliesChanged;
         }
 
-        private Control content;
-        private StackLayout actions;
+        private readonly Control content;
+        private readonly StackLayout actions;
         private Placeholder placeholder;
 
-        private Label name, owner, description, driverVersion, maxDriverVersion, pluginVersion, license;
-        private Button sourceCode, wiki;
+        private readonly Label name, owner, description, driverVersion, maxDriverVersion, pluginVersion, license;
+        private readonly Button sourceCode, wiki;
 
-        private Version CurrentDriverVersion = Assembly.GetExecutingAssembly().GetName().Version;
-        private Button uninstallButton, installButton;
+        private readonly Version CurrentDriverVersion = Assembly.GetExecutingAssembly().GetName().Version;
+        private readonly Button uninstallButton, installButton;
 
         public event Func<PluginMetadata, Task<bool>> RequestPluginInstall;
         public event Func<PluginMetadata, Task<bool>> RequestPluginUninstall;
@@ -264,8 +264,8 @@ namespace OpenTabletDriver.UX.Windows.Plugins
                 this.Orientation = Orientation.Horizontal;
             }
 
-            private StackLayout panel;
-            private Panel container;
+            private readonly StackLayout panel;
+            private readonly Panel container;
 
             public new Control Content
             {

--- a/OpenTabletDriver.UX/Windows/Plugins/PluginDropPanel.cs
+++ b/OpenTabletDriver.UX/Windows/Plugins/PluginDropPanel.cs
@@ -32,15 +32,14 @@ namespace OpenTabletDriver.UX.Windows.Plugins
 
         public event Func<string, Task> RequestPluginInstall;
 
-        private Control content;
         public new Control Content
         {
             set
             {
-                this.content = value;
+                field = value;
                 base.Content = this.Content;
             }
-            get => this.content;
+            get;
         }
 
         private readonly Label dropTextLabel = new Label

--- a/OpenTabletDriver.UX/Windows/Plugins/PluginManagerWindow.cs
+++ b/OpenTabletDriver.UX/Windows/Plugins/PluginManagerWindow.cs
@@ -84,10 +84,10 @@ namespace OpenTabletDriver.UX.Windows.Plugins
             {
                 if (await App.Driver.Instance.DownloadPlugin(metadata))
                 {
-                    pluginList.SelectFirstOrDefault((m => PluginMetadata.Match(m, metadata)));
+                    pluginList.SelectFirstOrDefault(m => PluginMetadata.Match(m, metadata));
                     var contexts = AppInfo.PluginManager.GetLoadedPlugins();
                     // Unload then reload the plugins
-                    var current = contexts.FirstOrDefault((c => PluginMetadata.Match(c.GetMetadata(), metadata)));
+                    var current = contexts.FirstOrDefault(c => PluginMetadata.Match(c.GetMetadata(), metadata));
                     if (current != null)
                         UnloadPlugin(current);
 

--- a/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
+++ b/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
@@ -502,7 +502,7 @@ namespace OpenTabletDriver.UX.Windows.Tablet
 
         private void SetTitle(IEnumerable<TabletReference> tablets)
         {
-            StringBuilder sb = new StringBuilder("Tablet Debugger");
+            var sb = new StringBuilder("Tablet Debugger");
             var tabletReferenceArr = tablets as TabletReference[] ?? [.. tablets];
 
             if (tabletReferenceArr.Length != 0)

--- a/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
+++ b/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
@@ -503,7 +503,7 @@ namespace OpenTabletDriver.UX.Windows.Tablet
         private void SetTitle(IEnumerable<TabletReference> tablets)
         {
             StringBuilder sb = new StringBuilder("Tablet Debugger");
-            var tabletReferenceArr = tablets as TabletReference[] ?? tablets.ToArray();
+            var tabletReferenceArr = tablets as TabletReference[] ?? [.. tablets];
 
             if (tabletReferenceArr.Length != 0)
             {
@@ -525,7 +525,7 @@ namespace OpenTabletDriver.UX.Windows.Tablet
             if (DataContext is not TDVM viewmodel) return;
 
             var tabletNames = tablets.Select(x => x.Properties.Name);
-            UpdateFilterList(_debuggedTablets, tabletNames.ToArray(), viewmodel.IgnoredTablets);
+            UpdateFilterList(_debuggedTablets, [.. tabletNames], viewmodel.IgnoredTablets);
         }
 
         private class DebuggerGroup : Group

--- a/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
+++ b/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
@@ -270,8 +270,10 @@ namespace OpenTabletDriver.UX.Windows.Tablet
             {
                 string modeName = decodingMode.ToString();
 
-                var item = new RadioMenuItem(rootRadioButton);
-                item.Text = modeName;
+                var item = new RadioMenuItem(rootRadioButton)
+                {
+                    Text = modeName
+                };
                 item.BindDataContext(x => x.Checked,
                     Binding.Property((TDVM vm) => vm.DecodingMode).ToBool(decodingMode));
 

--- a/OpenTabletDriver.UX/Windows/Updater/UpdaterWindow.cs
+++ b/OpenTabletDriver.UX/Windows/Updater/UpdaterWindow.cs
@@ -33,7 +33,7 @@ namespace OpenTabletDriver.UX.Windows.Updater
         }
 
         public const string LATEST_RELEASE_URL = "https://github.com/OpenTabletDriver/OpenTabletDriver/releases/latest";
-        private TaskCompletionSource<bool> _updateAvailable = new();
+        private readonly TaskCompletionSource<bool> _updateAvailable = new();
         public Task<bool> HasUpdates() => _updateAvailable.Task;
 
         private async Task InitializeAsync()

--- a/OpenTabletDriver/ComponentProviders/DeviceHubsProvider.cs
+++ b/OpenTabletDriver/ComponentProviders/DeviceHubsProvider.cs
@@ -13,12 +13,11 @@ namespace OpenTabletDriver.ComponentProviders
     {
         public DeviceHubsProvider(IServiceProvider serviceProvider)
         {
-            DeviceHubs = Assembly.GetExecutingAssembly().DefinedTypes
+            DeviceHubs = [.. Assembly.GetExecutingAssembly().DefinedTypes
                 .Where(type => type.IsAssignableTo(typeof(IDeviceHub))
                     && type.GetCustomAttribute<DeviceHubAttribute>() != null
                     && (type.GetCustomAttribute<SupportedPlatformAttribute>()?.IsCurrentPlatform ?? true))
-                .Select(type => (IDeviceHub)ActivatorUtilities.CreateInstance(serviceProvider, type))
-                .ToArray();
+                .Select(type => (IDeviceHub)ActivatorUtilities.CreateInstance(serviceProvider, type))];
         }
 
         public IEnumerable<IDeviceHub> DeviceHubs { get; }

--- a/OpenTabletDriver/Devices/DeviceReader.cs
+++ b/OpenTabletDriver/Devices/DeviceReader.cs
@@ -22,7 +22,7 @@ namespace OpenTabletDriver.Devices
         }
 
         private readonly Thread workerThread;
-        private bool initialized, connected;
+        private bool initialized;
 
         /// <summary>
         /// The device endpoint in which is reporting data in the <see cref="ReportStream"/>.
@@ -65,10 +65,10 @@ namespace OpenTabletDriver.Devices
         {
             protected set
             {
-                connected = value;
+                field = value;
                 ConnectionStateChanged?.Invoke(this, Connected);
             }
-            get => connected;
+            get;
         }
 
         /// <summary>

--- a/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpoint.cs
+++ b/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpoint.cs
@@ -16,7 +16,7 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
             this.device = device;
         }
 
-        private HidDevice device;
+        private readonly HidDevice device;
 
         public int ProductID => device.ProductID;
         public int VendorID => device.VendorID;

--- a/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpointStream.cs
+++ b/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpointStream.cs
@@ -11,7 +11,7 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
             stream.ReadTimeout = int.MaxValue;
         }
 
-        private HidStream stream;
+        private readonly HidStream stream;
 
         public byte[] Read() => stream.Read();
         public void Write(byte[] buffer) => stream.Write(buffer);

--- a/OpenTabletDriver/Devices/RootHub.cs
+++ b/OpenTabletDriver/Devices/RootHub.cs
@@ -16,8 +16,8 @@ namespace OpenTabletDriver.Devices
     {
         public RootHub(IDeviceHubsProvider hubsProvider)
         {
-            internalHubs = hubsProvider.DeviceHubs.ToHashSet();
-            hubs = new HashSet<IDeviceHub>(internalHubs);
+            internalHubs = [.. hubsProvider.DeviceHubs];
+            hubs = [.. internalHubs];
             ForceEnumeration();
 
             foreach (var hub in hubs)
@@ -32,7 +32,7 @@ namespace OpenTabletDriver.Devices
         private readonly HashSet<IDeviceHub> internalHubs;
         private readonly HashSet<IDeviceHub> hubs;
         private List<IDeviceEndpoint>? oldEndpoints;
-        private readonly List<IDeviceEndpoint> endpoints = new();
+        private readonly List<IDeviceEndpoint> endpoints = [];
         private long version;
         private int currentlyDebouncing;
         private IServiceProvider? serviceProvider;
@@ -102,7 +102,7 @@ namespace OpenTabletDriver.Devices
             if (Interlocked.Increment(ref currentlyDebouncing) == 1)
             {
                 // This event is the first of a potential sequence of events, copy old endpoint list
-                oldEndpoints = new List<IDeviceEndpoint>(endpoints);
+                oldEndpoints = [.. endpoints];
             }
 
             lock (syncObject)
@@ -147,7 +147,7 @@ namespace OpenTabletDriver.Devices
 
         private void CommitHubChange()
         {
-            oldEndpoints = new List<IDeviceEndpoint>(endpoints);
+            oldEndpoints = [.. endpoints];
             ForceEnumeration();
             DevicesChanged?.Invoke(this, new DevicesChangedEventArgs(endpoints, oldEndpoints));
             oldEndpoints = null;

--- a/OpenTabletDriver/Devices/WinUSB/WinUSBRootHub.cs
+++ b/OpenTabletDriver/Devices/WinUSB/WinUSBRootHub.cs
@@ -29,7 +29,7 @@ namespace OpenTabletDriver.Devices.WinUSB
         private readonly GCHandle _callbackPin;
         private List<WinUSBInterface> _oldDevices;
         private List<WinUSBInterface> _currentDevices;
-        private readonly Dictionary<Guid, SafeCmNotificationHandle> _notificationHandles = new();
+        private readonly Dictionary<Guid, SafeCmNotificationHandle> _notificationHandles = [];
 
         public unsafe WinUSBRootHub()
         {

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -28,7 +28,7 @@ namespace OpenTabletDriver
         private readonly IReportParserProvider _reportParserProvider;
         private readonly IDeviceConfigurationProvider _deviceConfigurationProvider;
         private readonly object _detectSync = new object();
-        private ImmutableArray<InputDeviceTree> _inputDeviceTrees = ImmutableArray<InputDeviceTree>.Empty;
+        private ImmutableArray<InputDeviceTree> _inputDeviceTrees = [];
 
         public event EventHandler<IEnumerable<TabletReference>>? TabletsChanged;
 

--- a/OpenTabletDriver/InputDevice.cs
+++ b/OpenTabletDriver/InputDevice.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using OpenTabletDriver.Devices;
 using OpenTabletDriver.Plugin;
@@ -58,13 +57,13 @@ namespace OpenTabletDriver
             if (_featureInitDelayMs != 0)
                 Log.Debug("Device", $"{DELAY_ATTRIBUTE_KEY_NAME} is set in tablet configuration, will sleep for {_featureInitDelayMs}ms between FeatureInitReports");
 
-            foreach (byte index in Identifier.InitializationStrings ?? new List<byte>())
+            foreach (byte index in Identifier.InitializationStrings ?? [])
             {
                 Endpoint.GetDeviceString(index);
                 Log.Debug("Device", $"Initialized string index {index}");
             }
 
-            foreach (var report in Identifier.FeatureInitReport ?? new List<byte[]>())
+            foreach (var report in Identifier.FeatureInitReport ?? [])
             {
                 if (report == null || report.Length == 0)
                     continue;
@@ -82,7 +81,7 @@ namespace OpenTabletDriver
                 }
             }
 
-            foreach (var report in Identifier.OutputInitReport ?? new List<byte[]>())
+            foreach (var report in Identifier.OutputInitReport ?? [])
             {
                 if (report == null || report.Length == 0)
                     continue;

--- a/OpenTabletDriver/InputDeviceTree.cs
+++ b/OpenTabletDriver/InputDeviceTree.cs
@@ -31,7 +31,7 @@ namespace OpenTabletDriver
         }
 
         private bool connected = true;
-        private object sync = new object();
+        private readonly object sync = new object();
         private IList<InputDevice> inputDevices;
 
         public event EventHandler<EventArgs>? Disconnected;

--- a/OpenTabletDriver/Instance.cs
+++ b/OpenTabletDriver/Instance.cs
@@ -34,7 +34,7 @@ namespace OpenTabletDriver
         private const string MUTEX_PREFIX = @"Global\";
         private readonly static List<Instance> ownedInstances = new List<Instance>();
 
-        private Mutex mutex;
+        private readonly Mutex mutex;
 
         public string Name { get; }
         public bool AlreadyExists { protected set; get; }

--- a/OpenTabletDriver/Instance.cs
+++ b/OpenTabletDriver/Instance.cs
@@ -32,7 +32,7 @@ namespace OpenTabletDriver
         }
 
         private const string MUTEX_PREFIX = @"Global\";
-        private readonly static List<Instance> ownedInstances = new List<Instance>();
+        private static readonly List<Instance> ownedInstances = new List<Instance>();
 
         private readonly Mutex mutex;
 

--- a/OpenTabletDriver/Instance.cs
+++ b/OpenTabletDriver/Instance.cs
@@ -32,7 +32,7 @@ namespace OpenTabletDriver
         }
 
         private const string MUTEX_PREFIX = @"Global\";
-        private static readonly List<Instance> ownedInstances = new List<Instance>();
+        private static readonly List<Instance> ownedInstances = [];
 
         private readonly Mutex mutex;
 

--- a/OpenTabletDriver/SystemDrivers/InfoProviders/ProcessModuleQueryableDriverInfoProvider.cs
+++ b/OpenTabletDriver/SystemDrivers/InfoProviders/ProcessModuleQueryableDriverInfoProvider.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -47,7 +46,7 @@ namespace OpenTabletDriver.SystemDrivers.InfoProviders
                 return new DriverInfo
                 {
                     Name = FriendlyName,
-                    Processes = processes.Any() ? processes.ToArray() : Array.Empty<Process>(),
+                    Processes = processes.Any() ? [.. processes] : [],
                     Status = status
                 };
             }

--- a/OpenTabletDriver/SystemDrivers/InfoProviders/XPPenDriverInfoProvider.cs
+++ b/OpenTabletDriver/SystemDrivers/InfoProviders/XPPenDriverInfoProvider.cs
@@ -44,7 +44,7 @@ namespace OpenTabletDriver.SystemDrivers.InfoProviders
                 return new DriverInfo
                 {
                     Name = FriendlyName,
-                    Processes = processes.ToArray(),
+                    Processes = [.. processes],
                     Status = DriverStatus.Active | falsePositive
                 };
             }

--- a/OpenTabletDriver/SystemDrivers/InfoProviders/XPPenDriverInfoProvider.cs
+++ b/OpenTabletDriver/SystemDrivers/InfoProviders/XPPenDriverInfoProvider.cs
@@ -24,7 +24,7 @@ namespace OpenTabletDriver.SystemDrivers.InfoProviders
             "Pentablet",
         ];
 
-        private string[] Exclusions =
+        private readonly string[] Exclusions =
         [
             "Huion",
             "Gaomon",


### PR DESCRIPTION
Clean up codebase with C#'s suggested coding conventions. I'll skip the ones that go against what we prefer and will try to note them here.

**Try to get this in early for v0.6.8**

Can be verified by checking out `.editorconfig` from branch onto target branch and running `dotnet format OpenTabletDriver.sln` and then diffing this PR's contents with your results.

fixes #2318 

## Recommended style rules that deviate from our preference:

- [IDE0045](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0045)/[IDE0046](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0046): Use conditional expression (ternary) for assignment and return
  - Not set as warning because the changes it makes are sometimes less readable

## Style rules that have been chosen not to be enforced (yet):

- [IDE0003/IDE0009](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0003-ide0009): `this.` preferences
  - Enforcing `this.` qualification (or enforcing removal) has arguments for both ways. I think this should be handled on a case-by-case basis.

---

personal gonX notes:

for later rebases:
`git rebase -i origin/0.6.x`, change all to `edit`, into `dotnet format OpenTabletDriver.sln && git add . && git commit --amend --no-edit && git rebase --continue`