### PR TITLE
GitHub release notes: Add initial settings

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,35 @@
+changelog:
+  categories:
+    - title: Regressions fixed
+      labels:
+        - 'regression'
+    - title: Major Features
+      labels:
+        - 'breaking'
+    - title: Bug Fixes
+      labels:
+        - 'bug'
+    - title: Performance Enhancements
+      labels:
+        - 'performance'
+    - title: Daemon Enhancements
+      labels:
+        - 'daemon'
+    - title: UI Enhancements
+      labels:
+        - 'gui'
+    - title: Console (CLI) Enhancements
+      labels:
+        - 'console'
+    - title: Documentation
+      labels:
+        - 'documentation'
+    - title: Unit Tests
+      labels:
+        - 'tests'
+    - title: Dependencies
+      labels:
+        - 'dependencies'
+    - title: Other Changes
+      labels:
+        - '*'


### PR DESCRIPTION
Covers most of the pre-existing labels we have, with the remainder going into a fallback category

Fixes #3605 in the sense that labels are at least accounted for now, but doesn't quite get the release notes to the point the issue asks for. If this still isn't good enough we can try looking at it again for the next version, but this is at least an improvement over what we have.