### PR TITLE
Remove OutputReportLength from UGEE S640

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/UGEE/S640.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/S640.json
@@ -20,17 +20,6 @@
       "VendorID": 10429,
       "ProductID": 2359,
       "InputReportLength": 12,
-      "OutputReportLength": 21,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
-      "OutputInitReport": [
-        "ArAE"
-      ]
-    },
-    {
-      "VendorID": 10429,
-      "ProductID": 2359,
-      "InputReportLength": 12,
-      "OutputReportLength": 12,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
       "OutputInitReport": [
         "ArAE"


### PR DESCRIPTION
Got a third case of this having a different OtputReportLength. Might as well remove it since theres no conflict with other identifiers.

Diag for this third variant: [dsfsfdsa.json](https://github.com/user-attachments/files/26152907/dsfsfdsa.json)
Verification: https://discord.com/channels/615607687467761684/723399565780189234/1484706156059557928

Endpoints on each variant:
Variant 1 (#2316, https://discord.com/channels/615607687467761684/982168546991824906/982169059338633236):
```
    {
      "DevicePath": "\\\\?\\hid#vid_28bd&pid_0937&mi_00&col03#7&2269c6c9&0&0002#{4d1e55b2-f16f-11cf-88cb-001111000030}\\kbd",
      "Manufacturer": "UGTABLET",
      "ProductName": "UGEE S640",
      "SerialNumber": "000000",
      "FriendlyName": "UGEE S640",
      "VendorID": 10429,
      "ProductID": 2359,
      "InputReportLength": 8,
      "OutputReportLength": 0,
      "FeatureReportLength": 0,
      "CanOpen": false
    },
    {
      "DevicePath": "\\\\?\\hid#vid_28bd&pid_0937&mi_00&col02#7&2269c6c9&0&0001#{4d1e55b2-f16f-11cf-88cb-001111000030}",
      "Manufacturer": "UGTABLET",
      "ProductName": "UGEE S640",
      "SerialNumber": "000000",
      "FriendlyName": "UGEE S640",
      "VendorID": 10429,
      "ProductID": 2359,
      "InputReportLength": 8,
      "OutputReportLength": 0,
      "FeatureReportLength": 0,
      "CanOpen": false
    },
    {
      "DevicePath": "\\\\?\\hid#vid_28bd&pid_0937&mi_02#7&2544b4bb&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}",
      "Manufacturer": "UGTABLET",
      "ProductName": "UGEE S640",
      "SerialNumber": "000000",
      "FriendlyName": "UGEE S640",
      "VendorID": 10429,
      "ProductID": 2359,
      "InputReportLength": 12,
      "OutputReportLength": 21,
      "FeatureReportLength": 0,
      "CanOpen": true
    },
    {
      "DevicePath": "\\\\?\\hid#vid_28bd&pid_0937&mi_01#7&16d76f9&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}",
      "Manufacturer": "UGTABLET",
      "ProductName": "UGEE S640",
      "SerialNumber": "000000",
      "FriendlyName": "UGEE S640",
      "VendorID": 10429,
      "ProductID": 2359,
      "InputReportLength": 10,
      "OutputReportLength": 0,
      "FeatureReportLength": 0,
      "CanOpen": false
    },
    {
      "DevicePath": "\\\\?\\hid#vid_28bd&pid_0937&mi_00&col01#7&2269c6c9&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}",
      "Manufacturer": "UGTABLET",
      "ProductName": "UGEE S640",
      "SerialNumber": "000000",
      "FriendlyName": "UGEE S640",
      "VendorID": 10429,
      "ProductID": 2359,
      "InputReportLength": 8,
      "OutputReportLength": 0,
      "FeatureReportLength": 0,
      "CanOpen": false
    }
```

Variant 2 (#2897):
```
    {
      "VendorID": 10429,
      "ProductID": 2359,
      "InputReportLength": 12,
      "OutputReportLength": 12,
      "FeatureReportLength": 0,
      "Manufacturer": "UGTABLET",
      "ProductName": "UGEE S640",
      "FriendlyName": "UGEE S640",
      "SerialNumber": "000000",
      "DevicePath": "/sys/devices/pci0000:00/0000:00:08.1/0000:08:00.4/usb3/3-1/3-1:1.2/0003:28BD:0937.0010/hidraw/hidraw6",
      "CanOpen": true
    },
    {
      "VendorID": 10429,
      "ProductID": 2359,
      "InputReportLength": 8,
      "OutputReportLength": 0,
      "FeatureReportLength": 0,
      "Manufacturer": "UGTABLET",
      "ProductName": "UGEE S640",
      "FriendlyName": "UGEE S640",
      "SerialNumber": "000000",
      "DevicePath": "/sys/devices/pci0000:00/0000:00:08.1/0000:08:00.4/usb3/3-1/3-1:1.0/0003:28BD:0937.000E/hidraw/hidraw4",
      "CanOpen": true
    },
    {
      "VendorID": 10429,
      "ProductID": 2359,
      "InputReportLength": 10,
      "OutputReportLength": 0,
      "FeatureReportLength": 0,
      "Manufacturer": "UGTABLET",
      "ProductName": "UGEE S640",
      "FriendlyName": "UGEE S640",
      "SerialNumber": "000000",
      "DevicePath": "/sys/devices/pci0000:00/0000:00:08.1/0000:08:00.4/usb3/3-1/3-1:1.1/0003:28BD:0937.000F/hidraw/hidraw5",
      "CanOpen": true
    }
```

Variant 3:
```
    {
      "DevicePath": "/sys/devices/pci0000:00/0000:00:14.0/usb1/1-2/1-2:1.2/0003:28BD:0937.0008/hidraw/hidraw4",
      "Manufacturer": "Hanvon ugee",
      "ProductName": "S640",
      "SerialNumber": "",
      "FriendlyName": "S640",
      "VendorID": 10429,
      "ProductID": 2359,
      "InputReportLength": 12,
      "OutputReportLength": 14,
      "FeatureReportLength": 0,
      "CanOpen": true,
      "DeviceAttributes": {
        "USB_INTERFACE_NUMBER": "2",
        "HID_REPORTS": "02:FF0A:0001"
      }
    },
    {
      "DevicePath": "/sys/devices/pci0000:00/0000:00:14.0/usb1/1-2/1-2:1.1/0003:28BD:0937.0007/hidraw/hidraw3",
      "Manufacturer": "Hanvon ugee",
      "ProductName": "S640",
      "SerialNumber": "",
      "FriendlyName": "S640",
      "VendorID": 10429,
      "ProductID": 2359,
      "InputReportLength": 10,
      "OutputReportLength": 0,
      "FeatureReportLength": 0,
      "CanOpen": true,
      "DeviceAttributes": {
        "USB_INTERFACE_NUMBER": "1",
        "HID_REPORTS": "07:000D:0002"
      }
    },
    {
      "DevicePath": "/sys/devices/pci0000:00/0000:00:14.0/usb1/1-2/1-2:1.0/0003:28BD:0937.0006/hidraw/hidraw2",
      "Manufacturer": "Hanvon ugee",
      "ProductName": "S640",
      "SerialNumber": "",
      "FriendlyName": "S640",
      "VendorID": 10429,
      "ProductID": 2359,
      "InputReportLength": 8,
      "OutputReportLength": 0,
      "FeatureReportLength": 0,
      "CanOpen": true,
      "DeviceAttributes": {
        "USB_INTERFACE_NUMBER": "0",
        "HID_REPORTS": "09:0001:0002, 06:0001:0006"
      }
    }
```