### PR TITLE
Add support Bosto BST-Y3 (BT-13HDK) pen tablet.

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Bosto/BST-Y3.json
+++ b/OpenTabletDriver.Configurations/Configurations/Bosto/BST-Y3.json
@@ -1,0 +1,33 @@
+{
+  "Name": "Bosto BST-Y3",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 292.1,
+      "Height": 162.56,
+      "MaxX": 8340,
+      "MaxY": 4680
+    },
+    "Pen": {
+      "MaxPressure": 8192,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 8
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 3793,
+      "ProductID": 30753,
+      "InputReportLength": 10,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "DeviceStrings": {
+        "3": "^A02017120201$"
+      },
+      "InitializationStrings": []
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/OpenTabletDriver.Configurations/Configurations/Bosto/BST-Y3.json
+++ b/OpenTabletDriver.Configurations/Configurations/Bosto/BST-Y3.json
@@ -4,8 +4,8 @@
     "Digitizer": {
       "Width": 292.1,
       "Height": 162.56,
-      "MaxX": 8340,
-      "MaxY": 4680
+      "MaxX": 17920,
+      "MaxY": 10240
     },
     "Pen": {
       "MaxPressure": 8192,

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -215,6 +215,8 @@
 | XP-Pen Star G960S                  |     Supported     |
 | XP-Pen Star G960S Plus             |     Supported     |
 | XP-Pen Deco 03                     |     Supported     |
+=======
+| Bosto BST-Y3                       |    Has Quirks     | Aux buttons not recognized
 | Bosto BT-12HD                      |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0.
 | FlooGoo FMA100                     |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 1. Might also need to change the configuration depending on the tablet used.
 | Gaomon S56K                        |    Has Quirks     | Windows: Might need Zadig's WinUSB to be installed on interface 0 or 1


### PR DESCRIPTION
This is to fix the original PR: https://github.com/OpenTabletDriver/OpenTabletDriver/pull/4485

I wasn't sure how to add the change to add to the prior PR, but I have included #4485's commit. I resolved the Lint error and corrected the max X/Y values.