### PR TITLE
Add more labels to autogenerated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,6 +6,9 @@ changelog:
     - title: Major Features
       labels:
         - 'breaking'
+    - title: Tablet Configurations
+      labels:
+        - 'configuration'
     - title: Bug Fixes
       labels:
         - 'bug'
@@ -27,9 +30,15 @@ changelog:
     - title: Unit Tests
       labels:
         - 'tests'
+    - title: Build scripts
+      labels:
+        - 'packaging'
     - title: Dependencies
       labels:
         - 'dependencies'
+    - title: Other non-code changes
+      labels:
+        - 'meta'
     - title: Other Changes
       labels:
         - '*'

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,6 +1,6 @@
 changelog:
   categories:
-    - title: Regressions fixed
+    - title: Regressions Fixed
       labels:
         - 'regression'
     - title: Major Features


### PR DESCRIPTION
Adds:

- `configuration`
- `packaging`
- `meta`