### PR TITLE
Add support for UGEE UE12 Plus

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/UGEE/UE12 Plus.json
+++ b/OpenTabletDriver.Configurations/Configurations/UGEE/UE12 Plus.json
@@ -1,0 +1,39 @@
+{
+  "Name": "UGEE UE12 Plus",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 263.22,
+      "Height": 148.055,
+      "MaxX": 52644,
+      "MaxY": 29611
+    },
+    "Pen": {
+      "MaxPressure": 16383,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 8
+    },
+    "Wheels": [
+      {
+        "RelativeWheelSteps": 24,
+        "ButtonCount": 0
+      }
+    ]
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 10429,
+      "ProductID": 10507,
+      "InputReportLength": 12,
+      "OutputReportLength": 20,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
+      "OutputInitReport": [
+        "ArAE"
+      ]
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -84,6 +84,7 @@
 | UGEE S1060                         |     Supported     |
 | UGEE U1200                         |     Supported     |
 | UGEE U1600                         |     Supported     |
+| UGEE UE12 Plus                     |     Supported     |
 | VEIKK A15                          |     Supported     |
 | VEIKK A15 V2                       |     Supported     |
 | VEIKK S640                         |     Supported     |


### PR DESCRIPTION
Adds complete configuration for the UGEE UE12 Plus drawing monitor.

### Details
The UE12 Plus utilizes the same internal architecture as modern XP-Pen tablets. 
* Pen tracking, pressure, and the 2 barrel buttons map perfectly.
* The 8 physical auxiliary buttons are bitmasked on Byte Index 2.
* The physical scroll wheel outputs standard `0x01` and `0x02` analog deltas on Byte Index 7. 

Because the default `XP_PenReportParser` natively passes these offsets to `XP_PenAuxReport` (and correctly implements `IRelativeWheelReport`), no custom C# parser is needed. The tablet is fully supported by simply applying the standard parser and defining the `Wheels` block in the specification schema.

### Hardware Footprint
* **Vendor ID:** `0x28BD` (10429)
* **Product ID:** `0x290B` (10507)

### Verification
Successfully compiled and tested locally on Arch Linux (Wayland). 
:heavy_check_mark: Buttons
:heavy_check_mark: Wheel
:heavy_check_mark: Pen buttons
:heavy_check_mark: Display and drawing area

### Diagnostics file
[Diagnostics-067-r853g94e9d388 UGEE UE12 Plus.json](https://github.com/user-attachments/files/26155560/Diagnostics-067-r853g94e9d388.UGEE.UE12.Plus.json)

### Screenshot
MaxX MaxY
<img width="954" height="601" alt="image" src="https://github.com/user-attachments/assets/fe38efad-7386-40ad-9f3b-ea46810d0a55" />
Max Pressure
<img width="954" height="601" alt="image" src="https://github.com/user-attachments/assets/4e55cdd3-8a1e-4d69-9273-32cb635df0c6" />

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/f83adf66-6f3b-4018-983f-f89b4e0f2e96" />

