### PR TITLE
Add support for Gaomon PD1900

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/PD1900.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/PD1900.json
@@ -1,0 +1,32 @@
+{
+  "Name": "Gaomon PD1900",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 408.96,
+      "Height": 230.03,
+      "MaxX": 81792,
+      "MaxY": 46008
+    },
+    "Pen": {
+      "MaxPressure": 16383,
+      "ButtonCount": 2
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 9580,
+      "ProductID": 8220,
+      "InputReportLength": 14,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
+      "DeviceStrings": {
+        "201": "GM001_M244_\\d{6}$"
+      },
+      "InitializationStrings": [
+        200
+      ]
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -15,6 +15,7 @@
 | Gaomon PD1320                      |     Supported     |
 | Gaomon PD1560                      |     Supported     |
 | Gaomon PD1561                      |     Supported     |
+| Gaomon PD1900                      |     Supported     |
 | Gaomon PD2200                      |     Supported     |
 | Gaomon S620                        |     Supported     |
 | Genius G-Pen 560                   |     Supported     | Soft-buttons are bindable as aux buttons.


### PR DESCRIPTION
Add complete configuration for the [Gaomon Pro 19 4K (PD1900)](https://gaomon.net/products/gaomon-pro-19-pen-display). The PD1900 has a lot in common with the Huion Kamvas Pro 19 (GT1902) from the same manufacturer.

### Details

The PD1900 has no customizable buttons or dials. The pen (AP520) has 2 customizable buttons and no back eraser.

### Hardware footprint

* **Vendor ID:** `0x256C` (9580)
* **Product ID:** `0x201C` (8220)

### Verification

* [diagnostics.json](https://github.com/user-attachments/files/26158895/diagnostics.json)
* [string_dump.txt](https://github.com/user-attachments/files/26158901/string_dump.txt)

<img width="1011" height="1208" alt="debugger" src="https://github.com/user-attachments/assets/6416b51c-a963-4f47-b094-56152b316691" />