### PR TITLE
PR Labeler: Add Evdev glob to linux/gtk label

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -87,6 +87,7 @@ tests:
     - 'OpenTabletDriver.UX.Gtk/**'
     - 'generate-rules.sh'
     - '**/*Linux*' # TODO: verify that this works 1/3
+    - '**/*Evdev*'
 
 'windows/wpf':
 - changed-files:


### PR DESCRIPTION
Fixes #4343

Added **/*Evdev* to the linux/gtk glob list in pr-labeler.yml.

The existing labeler test script passes. Though it only verifies that globs match at least one file, not that all relevant files are covered, so it was passing before too. The issue was just silent mislabeling.