### PR TITLE
[Avalonia] Build: Fix invalid regex for git dirty detection

### DIFF
--- a/eng/bash/lib.sh
+++ b/eng/bash/lib.sh
@@ -65,7 +65,7 @@ if [ -z "$VERSION_SUFFIX" ]; then
     fi
 
     describe_remainder="$(sed -E s/"${GIT_TAG_REGEX}"/\\9/ <<< "$GIT_DESCRIBE")"
-    if [[ $describe_remainder =~ ^*dirty*$ ]]; then
+    if [[ $describe_remainder =~ ^.*dirty.*$ ]]; then
       # tag dirty if dirty
       VERSION_SUFFIX="${VERSION_SUFFIX:-}"-dirty
     fi


### PR DESCRIPTION
Fixes #4178

- Changed `^*dirty*$` to `^.*dirty.*$` in `eng/bash/lib.sh` on the avalonia branch.
- Syntax check passes and the regex correctly matches dirty suffixes.
- The `0.6.x` branch already has the correct regex.