### PR TITLE
[Avalonia] Forward-port tablet config name check

### DIFF
--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -5,17 +5,6 @@ on:
   pull_request:
 
 jobs:
-  test_labeler_paths:
-    runs-on: ubuntu-latest
-    name: Test for presence of all GitHub Labeler paths
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Test paths
-        run: |
-          ./tests/test_labeler_yaml.sh
-
   test_tabletconfigs_present_in_tabletsmd:
     runs-on: ubuntu-latest
     name: Test for presence of added/changed configuration files in TABLETS.md

--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -1,0 +1,39 @@
+name: Shell Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  test_labeler_paths:
+    runs-on: ubuntu-latest
+    name: Test for presence of all GitHub Labeler paths
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Test paths
+        run: |
+          ./tests/test_labeler_yaml.sh
+
+  test_tabletconfigs_present_in_tabletsmd:
+    runs-on: ubuntu-latest
+    name: Test for presence of added/changed configuration files in TABLETS.md
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full git history is needed to get a proper list of changed files
+          fetch-depth: 0
+
+      - name: Compare names of changed tablet configs with TABLETS.md
+        if: github.event_name != 'workflow_dispatch'
+        env:
+          GET_CONFIGS_FROM_CI: defined
+        run: |
+          ./tests/test_tabletconfigs_present_in_tabletsmd.sh
+
+      - name: Compare all names in tablet configs with TABLETS.md
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          ./tests/test_tabletconfigs_present_in_tabletsmd.sh

--- a/tests/test_tabletconfigs_present_in_tabletsmd.sh
+++ b/tests/test_tabletconfigs_present_in_tabletsmd.sh
@@ -32,6 +32,8 @@ if [ ${#configs[@]} -ne 0 ]; then
       fi
     fi
   done
+else
+  echo 'Pass: No configs to check'
 fi
 
 IFS="$oldifs"

--- a/tests/test_tabletconfigs_present_in_tabletsmd.sh
+++ b/tests/test_tabletconfigs_present_in_tabletsmd.sh
@@ -11,9 +11,7 @@ if [ ! -z "$GET_CONFIGS_FROM_CI" ]; then
   # git diff command uses a github action runner quirk where the diff between
   # HEAD^ and HEAD is equal to diffing commit merge base with pr tip
   mapfile -t configs < <(git diff --name-only --diff-filter=AM HEAD^ HEAD | grep '^OpenTabletDriver\.Configurations/Configurations/.*\.json')
-fi
-
-if [ -z "$configs" ]; then
+elif [ -z "$configs" ]; then
   # if still undefined, grab all configurations
   mapfile -t configs < <(find OpenTabletDriver.Configurations/Configurations/ -type f -iname '*.json')
 fi

--- a/tests/test_tabletconfigs_present_in_tabletsmd.sh
+++ b/tests/test_tabletconfigs_present_in_tabletsmd.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+oldifs="$IFS"
+IFS=$'\n'
+
+cd "$(dirname ${BASH_SOURCE[0]})"/..
+
+if [ ! -z "$GET_CONFIGS_FROM_CI" ]; then
+  # git diff command uses a github action runner quirk where the diff between
+  # HEAD^ and HEAD is equal to diffing commit merge base with pr tip
+  mapfile -t configs < <(git diff --name-only --diff-filter=AM HEAD^ HEAD | grep '^OpenTabletDriver\.Configurations/Configurations/.*\.json')
+fi
+
+if [ -z "$configs" ]; then
+  # if still undefined, grab all configurations
+  mapfile -t configs < <(find OpenTabletDriver.Configurations/Configurations/ -type f -iname '*.json')
+fi
+
+TABLETS="${TABLETS:-TABLETS.md}"
+
+unset failed
+
+if [ ${#configs[@]} -ne 0 ]; then
+  for conf in "${configs[@]}"; do
+    name=$(cat $conf| jq -r '.Name')
+    if ! grep -q "| $name " $TABLETS; then
+      echo "Failure: '$name' was not found in $TABLETS - was it spelled correctly?"
+      failed=y
+    else
+      if [ ! -z "$VERBOSE" ]; then
+        echo "Pass: '$name'"
+      fi
+    fi
+  done
+fi
+
+IFS="$oldifs"
+unset oldifs
+
+if [ ! -z "$failed" ]; then
+  exit 1
+fi


### PR DESCRIPTION
fix for #4074

## Summary
- Forward-port of #4098 to the `avalonia` branch via cherry picking
- Adds the `test_tabletconfigs_present_in_tabletsmd.sh` script and its CI workflow (`shell-tests.yml`)
- Original code by @gonX and no modifications were made to the cherry-picked commits

## Conflict Resolution
The first commit modified `shell-tests.yml`, which doesn't exist on `avalonia`. Git flagged a modify/delete conflict. Resolved by accepting the incoming file since the purpose of this PR is to bring it over.

## Test Results
The script executes correctly on `avalonia` but reports 21 pre-existing mismatches between tablet configs and TABLETS.md. This is caused by divergence between branches, not introduced by this PR. The script is supposed to catch these kinds of discrepancies. Fixing the mismatches it outside the scope of this port.