### PR TITLE
WindowsInput: Log errors when SendInput fails to insert events

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/Keyboard/WindowsVirtualKeyboard.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Keyboard/WindowsVirtualKeyboard.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using OpenTabletDriver.Native.Windows;
 using OpenTabletDriver.Native.Windows.Input;
+using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Platform.Keyboard;
 
 namespace OpenTabletDriver.Desktop.Interop.Input.Keyboard
@@ -30,7 +31,9 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Keyboard
             };
 
             var inputs = new INPUT[] { input };
-            SendInput((uint)inputs.Length, inputs, INPUT.Size);
+            var result = SendInput((uint)inputs.Length, inputs, INPUT.Size);
+            if (result != inputs.Length)
+                Log.Write("WindowsKeyboard", $"SendInput failed: {result}/{inputs.Length} events inserted", LogLevel.Error);
         }
 
         public void Press(string key)

--- a/OpenTabletDriver.Desktop/Interop/Input/WindowsVirtualMouse.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/WindowsVirtualMouse.cs
@@ -1,6 +1,7 @@
 using System;
 using OpenTabletDriver.Native.Windows;
 using OpenTabletDriver.Native.Windows.Input;
+using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Attributes;
 using OpenTabletDriver.Plugin.Platform.Pointer;
 
@@ -94,7 +95,9 @@ namespace OpenTabletDriver.Desktop.Interop.Input
         {
             if (_dirty)
             {
-                SendInput(1, inputs, INPUT.Size);
+                var result = SendInput(1, inputs, INPUT.Size);
+                if (result != 1)
+                    Log.Write("WindowsMouse", $"SendInput failed: {result}/1 events inserted", LogLevel.Error);
                 inputs[0].U.mi.dwFlags = 0;
                 inputs[0].U.mi.mouseData = 0;
                 inputs[0].U.mi.dx = 0;


### PR DESCRIPTION
Fixes #4531

## Summary
- Check the return value of `SendInput` in `WindowsVirtualKeyboard` and `WindowsVirtualMouse`
- Log an error when the number of successfully inserted events doesn't match the expected count
- Follows existing logging conventions used by Evdev input classes

## Context
Per the [SendInput docs](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-sendinput), the return value indicates how many events were actually inserted. A mismatch could help diagnose issues where virtual keyboards or mice silently fail.

## Concern Regarding User Privilege  
Note that [UIPI](https://learn.microsoft.com/en-us/windows/win32/winmsg/user-interface-privilege-isolation) blocks are not detectable. Windows intentionally reports neither the return value nor `GetLastError` when UIPI is the cause. Since UIPI is the most common reason for `SendInput` to silently fail, it may be worth including a hint in the log message (e.g., "try running as administrator") to guide users toward the fix.

Let me know if you want tme to change the log to this:

`Log.Write("WindowsKeyboard", $"SendInput failed: {result}/{inputs.Length} events inserted. If targeting an elevated application, try running as administrator.", LogLevel.Error);`

## Test plan
- Verified the project builds with 0 warnings and 0 errors (`build.sh macos`)
- Runtime testing requires a Windows environment