### PR TITLE
Add support for XP-Pen Deco MW

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco MW.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco MW.json
@@ -1,0 +1,33 @@
+{
+  "Name": "XP-Pen Deco MW",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 203.2,
+      "Height": 127,
+      "MaxX": 40640,
+      "MaxY": 25400
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 8
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 10429,
+      "ProductID": 2358,
+      "InputReportLength": 14,
+      "OutputReportLength": 33,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenOffsetPressureReportParser",
+      "OutputInitReport": [
+        "ArAE"
+      ]
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -192,6 +192,7 @@
 | XP-Pen Deco Fun S (CT640)          |     Supported     |
 | XP-Pen Deco Fun XS (CT430)         |     Supported     |
 | XP-Pen Deco M                      |     Supported     |
+| XP-Pen Deco MW                     |     Supported     |
 | XP-Pen Deco L                      |     Supported     |
 | XP-Pen Deco LW                     |     Supported     |
 | XP-Pen Deco mini4                  |     Supported     |


### PR DESCRIPTION
The specifications are the same as the wired-only version. Support for the wired-only version was added in #3042
Similar #4385

Verification successful using my own tablet.
Diagnostics: [Diagnostics-067+856-ge035a640 XP-Pen Deco MW.json](https://github.com/user-attachments/files/26236283/Diagnostics-067%2B856-ge035a640.XP-Pen.Deco.MW.json)
Strings: [string-dump_10429-2358.txt](https://github.com/user-attachments/files/26236569/string-dump_10429-2358.txt)
