### PR TITLE
Configurations: Add Waltop Sirius Battery Free Tablet

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Waltop/Sirius Battery Free Tablet.json
+++ b/OpenTabletDriver.Configurations/Configurations/Waltop/Sirius Battery Free Tablet.json
@@ -1,0 +1,26 @@
+{
+  "Name": "Waltop Sirius Battery Free Tablet",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 254,
+      "Height": 152.4,
+      "MaxX": 20000,
+      "MaxY": 12000
+    },
+    "Pen": {
+      "MaxPressure": 1023,
+      "ButtonCount": 2
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 5935,
+      "ProductID": 1282,
+      "InputReportLength": 10,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Waltop.WaltopSiriusReportParser"
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusReportParser.cs
@@ -1,0 +1,25 @@
+using System.Diagnostics.CodeAnalysis;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Waltop
+{
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    public class WaltopSiriusReportParser : IReportParser<IDeviceReport>
+    {
+        public IDeviceReport Parse(byte[] data)
+        {
+            // Report ID 16 (0x10) = pen digitizer report
+            if (data[0] == 0x10 && data.Length >= 10)
+            {
+                bool inRange = (data[1] & 0x10) != 0;
+
+                if (!inRange)
+                    return new OutOfRangeReport(data);
+
+                return new WaltopSiriusTabletReport(data);
+            }
+
+            return new DeviceReport(data);
+        }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusTabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusTabletReport.cs
@@ -1,0 +1,50 @@
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Waltop
+{
+    public struct WaltopSiriusTabletReport : ITabletReport, ITiltReport, IEraserReport
+    {
+        public WaltopSiriusTabletReport(byte[] report)
+        {
+            Raw = report;
+
+            // Lower 2 bits of flags are a 2-bit enumeration:
+            //   0 = no button, 1 = tip, 2 = barrel (button 1), 3 = tablet pick (button 2)
+            int buttonEnum = report[1] & 0x03;
+            bool tipSwitch = buttonEnum == 1;
+
+            Position = new Vector2
+            {
+                X = Unsafe.ReadUnaligned<ushort>(ref report[2]),
+                Y = Unsafe.ReadUnaligned<ushort>(ref report[4])
+            };
+
+            // Only report pressure when tip is touching; device reports baseline ~5 on hover.
+            // Zero pressure when barrel buttons are pressed (matches Linux hid-waltop.c).
+            Pressure = tipSwitch ? Unsafe.ReadUnaligned<ushort>(ref report[6]) : 0u;
+
+            Tilt = new Vector2
+            {
+                X = (sbyte)report[8],
+                Y = (sbyte)(-report[9])
+            };
+
+            Eraser = (report[1] & 0x08) != 0;
+
+            PenButtons = new bool[]
+            {
+                buttonEnum == 2, // barrel switch (side button 1)
+                buttonEnum == 3, // tablet pick (side button 2)
+            };
+        }
+
+        public byte[] Raw { set; get; }
+        public Vector2 Position { set; get; }
+        public uint Pressure { set; get; }
+        public Vector2 Tilt { set; get; }
+        public bool Eraser { set; get; }
+        public bool[] PenButtons { set; get; }
+    }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -159,6 +159,7 @@
 | Wacom XD-0912-U                    |     Supported     |
 | Wacom XD-1212-U                    |     Supported     |
 | Wacom XD-1218-U                    |     Supported     |
+| Waltop Sirius Battery Free Tablet   |     Supported     |
 | Waltop Slim Tablet 5.8"            |     Supported     |
 | XenceLabs Pen Tablet Medium        |     Supported     |
 | XenceLabs Pen Tablet Small         |     Supported     |


### PR DESCRIPTION
## Summary

Add support for the Waltop Sirius Battery Free Tablet (VID `0x172F`, PID `0x0502`), also sold as the **Penpower Picasso**.

- Custom report parser for Report ID `0x10` which uses a 2-bit button enumeration in the flags byte
- Full support for absolute positioning, 1024 pressure levels, tilt, eraser, and 2 pen buttons
- Specifications verified against the HID report descriptor and Linux `hid-waltop.c`

## Device details

| Spec | Value |
|------|-------|
| VID / PID | `0x172F` / `0x0502` |
| Dimensions | 254mm x 152.4mm (10" x 6") |
| Resolution | 20000 x 12000 (2000 LPI) |
| Pressure | 1024 levels |
| Tilt | Supported (X/Y) |
| Pen buttons | 2 (barrel switch + tablet pick) |
| Known rebrands | Penpower Picasso, VisTablet Muse, PENTAGRAM Designer P 2700, Princeton PTB-S1BK |

## Report format (Report ID 16)

The flags byte (`data[1]`) uses a 2-bit enumeration rather than individual bit flags:

| `data[1] & 0x03` | Meaning |
|---|---|
| 0 | No button |
| 1 | Tip switch (pen touching) |
| 2 | Barrel switch (side button 1) |
| 3 | Tablet pick (side button 2) |

Bit 4 of the flags byte indicates In Range. The device reports a baseline pressure of ~5 during hover, which the parser zeros out to prevent false tip activation.

## Sources

- HID report descriptor from the physical device
- Linux kernel [`hid-waltop.c`](https://github.com/torvalds/linux/blob/master/drivers/hid/hid-waltop.c) (`USB_DEVICE_ID_WALTOP_SIRIUS_BATTERY_FREE_TABLET`)
- [DIGImend tablet documentation](https://digimend.github.io/tablets/Waltop_Sirius_Battery_Free_Tablet/)

## Testing

Tested on macOS 15.7 (Sequoia) with OTD v0.6.6.2. All features verified:
- Absolute positioning (hover + contact)
- Pressure sensitivity (0-1023)
- Tilt (X/Y)
- Both pen buttons independently
- Out-of-range detection

Self-verified as tablet owner.