### PR TITLE
DebugReportData: Fall back to DeviceReport for unknown report types

### DIFF
--- a/OpenTabletDriver.Desktop/RPC/DebugReportData.cs
+++ b/OpenTabletDriver.Desktop/RPC/DebugReportData.cs
@@ -25,8 +25,21 @@ namespace OpenTabletDriver.Desktop.RPC
 
         public object ToObject()
         {
-            var type = AppInfo.PluginManager.PluginTypes.First(t => t.FullName == Path);
-            return Data.ToObject(type);
+            var type = AppInfo.PluginManager.PluginTypes.FirstOrDefault(t => t.FullName == Path);
+
+            // Debug captures can outlive the plugin/parser assembly that produced them.
+            // If the concrete report type is no longer available locally, keep the debugger
+            // usable by falling back to a raw DeviceReport instead of throwing.
+            if (type == null)
+                return ToFallbackDeviceReport();
+
+            return Data.ToObject(type) ?? ToFallbackDeviceReport();
+        }
+
+        private DeviceReport ToFallbackDeviceReport()
+        {
+            var raw = Data[nameof(IDeviceReport.Raw)]?.ToObject<byte[]>();
+            return new DeviceReport(raw ?? []);
         }
     }
 }


### PR DESCRIPTION
## Summary
This change makes tablet debugger report deserialization resilient when the concrete report type referenced by a debug payload is not available in the current desktop/plugin environment.

Instead of throwing while resolving the type, `DebugReportData.ToObject()` now falls back to a raw `DeviceReport` built from the serialized `Raw` bytes. This keeps the debugger usable for recorded or forwarded reports that outlive the parser/plugin assembly that originally produced them.

## Problem
The previous implementation assumed that every incoming `DebugReportData.Path` could always be resolved from `AppInfo.PluginManager.PluginTypes`.

In practice that assumption is not stable:
- debug captures can be replayed after plugin/parser assemblies have changed
- a desktop instance may not have the same parser types loaded as the daemon or original capture source
- deserialization can also return `null` even when the type lookup succeeds

Before this change, the code used `First(...)` and let that failure propagate. In the tablet debugger path, that exception is not handled locally, so it bubbles to the global UX unhandled-exception handler instead of degrading gracefully.

## Changes
- replace `First(...)` with `FirstOrDefault(...)` when resolving the report type
- add an explicit fallback path that constructs `DeviceReport` from the serialized raw bytes
- use the same fallback when `Data.ToObject(type)` returns `null`
- document the behavior with a short code comment explaining why fallback is intentional

## Result
When the concrete report type is unknown, the debugger still receives a valid `IDeviceReport` instance and can continue displaying the raw packet data instead of erroring out.

Known parser types continue through the normal deserialization path unchanged.

## Verification
- `dotnet build OpenTabletDriver.Desktop/OpenTabletDriver.Desktop.csproj --no-restore`

## Notes
This is intentionally scoped to the debugger/report reconstruction path only. It does not change report parsing in the driver or daemon.