### PR TITLE
Linux: Add raw hidraw fallback for devices with unparseable HID descriptors

### DIFF
--- a/OpenTabletDriver.Tests/Fakes/FakeHidDevice.cs
+++ b/OpenTabletDriver.Tests/Fakes/FakeHidDevice.cs
@@ -1,3 +1,4 @@
+using System;
 using HidSharp;
 
 namespace OpenTabletDriver.Tests.Fakes
@@ -15,6 +16,11 @@ namespace OpenTabletDriver.Tests.Fakes
         private int _productId;
         private int _vendorId;
         private int _releaseNumberBcd;
+        private byte[] _rawReportDescriptor = Array.Empty<byte>();
+        private Exception? _openException;
+        private Exception? _maxInputReportLengthException;
+        private Exception? _maxOutputReportLengthException;
+        private Exception? _maxFeatureReportLengthException;
 
         public override string DevicePath => _devicePath;
         public override bool CanOpen => _canOpen;
@@ -57,9 +63,21 @@ namespace OpenTabletDriver.Tests.Fakes
             return this;
         }
 
+        public FakeHidDevice WithOpenException(Exception? exception)
+        {
+            _openException = exception;
+            return this;
+        }
+
         public FakeHidDevice WithMaxInputReportLength(int length)
         {
             _maxInputReportLength = length;
+            return this;
+        }
+
+        public FakeHidDevice WithMaxInputReportLengthException(Exception? exception)
+        {
+            _maxInputReportLengthException = exception;
             return this;
         }
 
@@ -69,9 +87,21 @@ namespace OpenTabletDriver.Tests.Fakes
             return this;
         }
 
+        public FakeHidDevice WithMaxOutputReportLengthException(Exception? exception)
+        {
+            _maxOutputReportLengthException = exception;
+            return this;
+        }
+
         public FakeHidDevice WithMaxFeatureReportLength(int length)
         {
             _maxFeatureReportLength = length;
+            return this;
+        }
+
+        public FakeHidDevice WithMaxFeatureReportLengthException(Exception? exception)
+        {
+            _maxFeatureReportLengthException = exception;
             return this;
         }
 
@@ -93,9 +123,15 @@ namespace OpenTabletDriver.Tests.Fakes
             return this;
         }
 
+        public FakeHidDevice WithRawReportDescriptor(byte[] rawReportDescriptor)
+        {
+            _rawReportDescriptor = (byte[])rawReportDescriptor.Clone();
+            return this;
+        }
+
         protected override DeviceStream OpenDeviceDirectly(OpenConfiguration openConfig)
         {
-            return null!;
+            throw _openException ?? new NotSupportedException();
         }
 
         public override string GetFileSystemName() => _devicePath;
@@ -106,11 +142,19 @@ namespace OpenTabletDriver.Tests.Fakes
 
         public override string GetSerialNumber() => _serialNumber;
 
-        public override int GetMaxInputReportLength() => _maxInputReportLength;
+        public override int GetMaxInputReportLength() => _maxInputReportLengthException == null
+            ? _maxInputReportLength
+            : throw _maxInputReportLengthException;
 
-        public override int GetMaxOutputReportLength() => _maxOutputReportLength;
+        public override int GetMaxOutputReportLength() => _maxOutputReportLengthException == null
+            ? _maxOutputReportLength
+            : throw _maxOutputReportLengthException;
 
-        public override int GetMaxFeatureReportLength() => _maxFeatureReportLength;
+        public override int GetMaxFeatureReportLength() => _maxFeatureReportLengthException == null
+            ? _maxFeatureReportLength
+            : throw _maxFeatureReportLengthException;
+
+        public override byte[] GetRawReportDescriptor() => (byte[])_rawReportDescriptor.Clone();
 
         public override string GetDeviceString(int index) => $"DeviceString{index}";
     }

--- a/OpenTabletDriver.Tests/HidSharpEndpointTest.cs
+++ b/OpenTabletDriver.Tests/HidSharpEndpointTest.cs
@@ -1,4 +1,8 @@
+using System;
+using System.IO;
 using OpenTabletDriver.Devices.HidSharpBackend;
+using OpenTabletDriver.Interop;
+using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Tests.Fakes;
 using Xunit;
 
@@ -67,6 +71,51 @@ namespace OpenTabletDriver.Tests
 
             Assert.True(attributes.ContainsKey("USB_INTERFACE_NUMBER"));
             Assert.Equal(expectedInterface, attributes["USB_INTERFACE_NUMBER"]);
+        }
+
+        [Fact]
+        public void ReportLengths_FallBackToLinuxRawDescriptorInfo_WhenHidSharpParsingFails()
+        {
+            Skip.IfNot(SystemInterop.CurrentPlatform == PluginPlatform.Linux, "Linux-only fallback behavior.");
+
+            var fakeDevice = new FakeHidDevice()
+                .WithMaxInputReportLengthException(new InvalidOperationException("broken descriptor"))
+                .WithMaxOutputReportLengthException(new InvalidOperationException("broken descriptor"))
+                .WithMaxFeatureReportLengthException(new InvalidOperationException("broken descriptor"));
+
+            var fallbackInfo = new LinuxRawHidDescriptorInfo(192, 33, 17, false);
+            var endpoint = new HidSharpEndpoint(fakeDevice, _ => fallbackInfo);
+
+            Assert.Equal(192, endpoint.InputReportLength);
+            Assert.Equal(33, endpoint.OutputReportLength);
+            Assert.Equal(17, endpoint.FeatureReportLength);
+        }
+
+        [Fact]
+        public void Open_FallsBackToLinuxRawHidStream_WhenHidSharpOpenFails()
+        {
+            Skip.IfNot(SystemInterop.CurrentPlatform == PluginPlatform.Linux, "Linux-only fallback behavior.");
+
+            var path = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllBytes(path, new byte[] { 0x01, 0x02, 0x03 });
+
+                var fakeDevice = new FakeHidDevice()
+                    .WithDevicePath(path)
+                    .WithOpenException(new IOException("broken descriptor"));
+
+                var fallbackInfo = new LinuxRawHidDescriptorInfo(3, 0, 0, true);
+                var endpoint = new HidSharpEndpoint(fakeDevice, _ => fallbackInfo);
+
+                using var stream = endpoint.Open();
+
+                Assert.IsType<LinuxRawHidStream>(stream);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
         }
     }
 }

--- a/OpenTabletDriver.Tests/LinuxRawHidDescriptorInfoTest.cs
+++ b/OpenTabletDriver.Tests/LinuxRawHidDescriptorInfoTest.cs
@@ -1,0 +1,92 @@
+using OpenTabletDriver.Devices.HidSharpBackend;
+using Xunit;
+
+namespace OpenTabletDriver.Tests
+{
+    public class LinuxRawHidDescriptorInfoTest
+    {
+        [Fact]
+        public void TryParse_AddsSyntheticReportIdSlot_WhenDescriptorHasNoReportIds()
+        {
+            var descriptor = new byte[]
+            {
+                0x75, 0x08,
+                0x95, 0x03,
+                0x81, 0x02,
+                0x95, 0x02,
+                0x91, 0x02,
+                0x95, 0x04,
+                0xB1, 0x02
+            };
+
+            Assert.True(LinuxRawHidDescriptorInfo.TryParse(descriptor, out var info));
+            Assert.False(info.ReportsUseID);
+            Assert.Equal(4, info.InputReportLength);
+            Assert.Equal(3, info.OutputReportLength);
+            Assert.Equal(5, info.FeatureReportLength);
+        }
+
+        [Fact]
+        public void TryParse_UsesLargestReportAcrossReportIds()
+        {
+            var descriptor = new byte[]
+            {
+                0x85, 0x01,
+                0x75, 0x08,
+                0x95, 0x03,
+                0x81, 0x02,
+                0x95, 0x02,
+                0x91, 0x02,
+                0x85, 0x02,
+                0x95, 0x05,
+                0x81, 0x02,
+                0x95, 0x04,
+                0xB1, 0x02
+            };
+
+            Assert.True(LinuxRawHidDescriptorInfo.TryParse(descriptor, out var info));
+            Assert.True(info.ReportsUseID);
+            Assert.Equal(6, info.InputReportLength);
+            Assert.Equal(3, info.OutputReportLength);
+            Assert.Equal(5, info.FeatureReportLength);
+        }
+
+        [Fact]
+        public void TryParse_IgnoresMalformedUnitExponent()
+        {
+            var descriptor = new byte[]
+            {
+                0x85, 0x01,
+                0x75, 0x08,
+                0x95, 0x02,
+                0x55, 0xFD,
+                0x81, 0x02
+            };
+
+            Assert.True(LinuxRawHidDescriptorInfo.TryParse(descriptor, out var info));
+            Assert.True(info.ReportsUseID);
+            Assert.Equal(3, info.InputReportLength);
+        }
+
+        [Fact]
+        public void TryParse_RestoresGlobalStateAcrossPushAndPop()
+        {
+            var descriptor = new byte[]
+            {
+                0x85, 0x01,
+                0x75, 0x08,
+                0x95, 0x01,
+                0xA4,
+                0x75, 0x10,
+                0x95, 0x02,
+                0x81, 0x02,
+                0xB4,
+                0xB1, 0x02
+            };
+
+            Assert.True(LinuxRawHidDescriptorInfo.TryParse(descriptor, out var info));
+            Assert.Equal(5, info.InputReportLength);
+            Assert.Equal(2, info.FeatureReportLength);
+        }
+    }
+}

--- a/OpenTabletDriver.Tests/LinuxRawHidStreamTest.cs
+++ b/OpenTabletDriver.Tests/LinuxRawHidStreamTest.cs
@@ -1,0 +1,82 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using OpenTabletDriver.Devices.HidSharpBackend;
+using Xunit;
+
+namespace OpenTabletDriver.Tests
+{
+    public class LinuxRawHidStreamTest
+    {
+        [Fact]
+        public void Read_DoesNotTruncateLargeReports()
+        {
+            var path = CreateTempFile(Enumerable.Range(0, 192).Select(i => (byte)i).ToArray());
+            try
+            {
+                var info = new LinuxRawHidDescriptorInfo(192, 0, 0, true);
+                using var stream = new LinuxRawHidStream(path, info);
+
+                var report = stream.Read();
+
+                Assert.Equal(192, report.Length);
+                Assert.Equal(Enumerable.Range(0, 192).Select(i => (byte)i), report);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void Read_PrependsSyntheticReportId_WhenDescriptorHasNoReportIds()
+        {
+            var path = CreateTempFile(new byte[] { 0x10, 0x20, 0x30 });
+            try
+            {
+                var info = new LinuxRawHidDescriptorInfo(4, 0, 0, false);
+                using var stream = new LinuxRawHidStream(path, info);
+
+                var report = stream.Read();
+
+                Assert.Equal(new byte[] { 0x00, 0x10, 0x20, 0x30 }, report);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void GetFeature_PrependsSyntheticReportId_WhenDescriptorHasNoReportIds()
+        {
+            var path = CreateTempFile(Array.Empty<byte>());
+            try
+            {
+                var info = new LinuxRawHidDescriptorInfo(0, 0, 4, false);
+                using var stream = new LinuxRawHidStream(path, info, (_, _, data) =>
+                {
+                    Marshal.Copy(new byte[] { 0xAB, 0xCD }, 0, data, 2);
+                    return 2;
+                });
+
+                var buffer = new byte[4];
+                stream.GetFeature(buffer);
+
+                Assert.Equal(new byte[] { 0x00, 0xAB, 0xCD, 0x00 }, buffer);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        private static string CreateTempFile(byte[] contents)
+        {
+            var path = Path.GetTempFileName();
+            File.WriteAllBytes(path, contents);
+            return path;
+        }
+    }
+}

--- a/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpoint.cs
+++ b/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpoint.cs
@@ -67,6 +67,8 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
         }
         public string GetDeviceString(byte index) => device.GetDeviceString(index);
 
+        // Device matching happens before Open(), so Linux needs a second source of
+        // report-length metadata when HidSharp's descriptor parser throws.
         private int GetReportLength(Func<HidDevice, int> getter, Func<LinuxRawHidDescriptorInfo, int> fallbackSelector)
         {
             if (device.TryGet(getter, out var length))
@@ -77,6 +79,8 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
                 : -1;
         }
 
+        // Cache the raw hidraw descriptor parse so the metadata path and the stream
+        // fallback both operate on the same view of the device's report layout.
         private bool TryGetLinuxFallbackInfo(out LinuxRawHidDescriptorInfo fallbackInfo)
         {
             fallbackInfo = null;

--- a/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpoint.cs
+++ b/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpoint.cs
@@ -34,7 +34,26 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
         public bool CanOpen => device.SafeGet(d => d.CanOpen, false);
         public IDictionary<string, string> DeviceAttributes => GetDeviceAttributes(DevicePath, () => device.GetReportDescriptor());
 
-        public IDeviceEndpointStream Open() => device.TryOpen(out var stream) ? new HidSharpEndpointStream(stream) : null;
+        public IDeviceEndpointStream Open()
+        {
+            if (device.TryOpen(out var stream))
+                return new HidSharpEndpointStream(stream);
+
+            // Fallback for devices with HID descriptors that HidSharp cannot parse
+            // (e.g. UnitExponent encoded as a signed byte instead of a 4-bit nibble).
+            // The kernel's hidraw interface exposes raw reports without requiring a
+            // parseable descriptor, so we can still read from the device via file I/O.
+            if (SystemInterop.CurrentPlatform == PluginPlatform.Linux)
+            {
+                try
+                {
+                    return new LinuxRawHidStream(device.GetFileSystemName());
+                }
+                catch { }
+            }
+
+            return null;
+        }
         public string GetDeviceString(byte index) => device.GetDeviceString(index);
 
         private static Dictionary<string, string> GetDeviceAttributes(string devicePath, Func<ReportDescriptor> reportDescriptorFunc)

--- a/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpoint.cs
+++ b/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpoint.cs
@@ -14,17 +14,26 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
     public class HidSharpEndpoint : IDeviceEndpoint
     {
         internal HidSharpEndpoint(HidDevice device)
+            : this(device, LinuxRawHidDescriptorInfo.TryCreateFromDevice)
+        {
+        }
+
+        internal HidSharpEndpoint(HidDevice device, Func<string, LinuxRawHidDescriptorInfo> linuxFallbackInfoProvider)
         {
             this.device = device;
+            this.linuxFallbackInfoProvider = linuxFallbackInfoProvider;
         }
 
         private HidDevice device;
+        private readonly Func<string, LinuxRawHidDescriptorInfo> linuxFallbackInfoProvider;
+        private bool linuxFallbackInfoInitialized;
+        private LinuxRawHidDescriptorInfo linuxFallbackInfo;
 
         public int ProductID => device.ProductID;
         public int VendorID => device.VendorID;
-        public int InputReportLength => device.SafeGet(d => d.GetMaxInputReportLength(), -1);
-        public int OutputReportLength => device.SafeGet(d => d.GetMaxOutputReportLength(), -1);
-        public int FeatureReportLength => device.SafeGet(d => d.GetMaxFeatureReportLength(), -1);
+        public int InputReportLength => GetReportLength(d => d.GetMaxInputReportLength(), i => i.InputReportLength);
+        public int OutputReportLength => GetReportLength(d => d.GetMaxOutputReportLength(), i => i.OutputReportLength);
+        public int FeatureReportLength => GetReportLength(d => d.GetMaxFeatureReportLength(), i => i.FeatureReportLength);
 
         public string Manufacturer => device.SafeGet(d => d.GetManufacturer(), "Unknown Manufacturer");
         public string ProductName => device.SafeGet(d => d.GetProductName(), "Unknown Product Name");
@@ -43,11 +52,13 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
             // (e.g. UnitExponent encoded as a signed byte instead of a 4-bit nibble).
             // The kernel's hidraw interface exposes raw reports without requiring a
             // parseable descriptor, so we can still read from the device via file I/O.
-            if (SystemInterop.CurrentPlatform == PluginPlatform.Linux)
+            if (TryGetLinuxFallbackInfo(out var fallbackInfo))
             {
                 try
                 {
-                    return new LinuxRawHidStream(device.GetFileSystemName());
+                    var fileSystemName = GetLinuxFileSystemName();
+                    if (!string.IsNullOrWhiteSpace(fileSystemName))
+                        return new LinuxRawHidStream(fileSystemName, fallbackInfo);
                 }
                 catch { }
             }
@@ -55,6 +66,37 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
             return null;
         }
         public string GetDeviceString(byte index) => device.GetDeviceString(index);
+
+        private int GetReportLength(Func<HidDevice, int> getter, Func<LinuxRawHidDescriptorInfo, int> fallbackSelector)
+        {
+            if (device.TryGet(getter, out var length))
+                return length;
+
+            return TryGetLinuxFallbackInfo(out var fallbackInfo)
+                ? fallbackSelector(fallbackInfo)
+                : -1;
+        }
+
+        private bool TryGetLinuxFallbackInfo(out LinuxRawHidDescriptorInfo fallbackInfo)
+        {
+            fallbackInfo = null;
+            if (SystemInterop.CurrentPlatform != PluginPlatform.Linux)
+                return false;
+
+            if (!linuxFallbackInfoInitialized)
+            {
+                var fileSystemName = GetLinuxFileSystemName();
+                linuxFallbackInfo = string.IsNullOrWhiteSpace(fileSystemName)
+                    ? null
+                    : linuxFallbackInfoProvider(fileSystemName);
+                linuxFallbackInfoInitialized = true;
+            }
+
+            fallbackInfo = linuxFallbackInfo;
+            return fallbackInfo != null;
+        }
+
+        private string GetLinuxFileSystemName() => device.SafeGet(d => d.GetFileSystemName(), null);
 
         private static Dictionary<string, string> GetDeviceAttributes(string devicePath, Func<ReportDescriptor> reportDescriptorFunc)
         {

--- a/OpenTabletDriver/Devices/HidSharpBackend/LinuxHidrawInterop.cs
+++ b/OpenTabletDriver/Devices/HidSharpBackend/LinuxHidrawInterop.cs
@@ -3,10 +3,18 @@ using System.Runtime.InteropServices;
 
 namespace OpenTabletDriver.Devices.HidSharpBackend
 {
+    /// <summary>
+    /// Minimal hidraw interop used by the Linux fallback. The fallback bypasses
+    /// HidSharp's descriptor parser, so it needs direct access to the raw hidraw
+    /// descriptor ioctls and feature-report ioctls.
+    /// </summary>
     internal static class LinuxHidrawInterop
     {
         internal const int HidMaxDescriptorSize = 4096;
 
+        /// <summary>
+        /// Mirrors <c>struct hidraw_report_descriptor</c> from <c>linux/hidraw.h</c>.
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         internal struct HidrawReportDescriptor
         {
@@ -25,6 +33,8 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
         [DllImport("libc", SetLastError = true)]
         internal static extern int ioctl(int fd, nuint request, ref HidrawReportDescriptor data);
 
+        // We only need the descriptor-size and descriptor read commands here; the
+        // stream uses the feature-report commands further below.
         internal static readonly nuint HIDIOCGRDESCSIZE = IOR(72, 0x01, sizeof(int));
         internal static readonly nuint HIDIOCGRDESC = IOR(72, 0x02, Marshal.SizeOf(typeof(HidrawReportDescriptor)));
 

--- a/OpenTabletDriver/Devices/HidSharpBackend/LinuxHidrawInterop.cs
+++ b/OpenTabletDriver/Devices/HidSharpBackend/LinuxHidrawInterop.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace OpenTabletDriver.Devices.HidSharpBackend
+{
+    internal static class LinuxHidrawInterop
+    {
+        internal const int HidMaxDescriptorSize = 4096;
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct HidrawReportDescriptor
+        {
+            public uint Size;
+
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = HidMaxDescriptorSize)]
+            public byte[] Value;
+        }
+
+        [DllImport("libc", SetLastError = true)]
+        internal static extern int ioctl(int fd, nuint request, IntPtr data);
+
+        [DllImport("libc", SetLastError = true)]
+        internal static extern int ioctl(int fd, nuint request, out int data);
+
+        [DllImport("libc", SetLastError = true)]
+        internal static extern int ioctl(int fd, nuint request, ref HidrawReportDescriptor data);
+
+        internal static readonly nuint HIDIOCGRDESCSIZE = IOR(72, 0x01, sizeof(int));
+        internal static readonly nuint HIDIOCGRDESC = IOR(72, 0x02, Marshal.SizeOf(typeof(HidrawReportDescriptor)));
+
+        internal static nuint HIDIOCSFEATURE(int len) => IOWR(72, 0x06, len);
+        internal static nuint HIDIOCGFEATURE(int len) => IOWR(72, 0x07, len);
+
+        private static nuint IOR(uint type, uint nr, int size) => IOC(2u, type, nr, (uint)size);
+        private static nuint IOWR(uint type, uint nr, int size) => IOC(3u, type, nr, (uint)size);
+
+        private static nuint IOC(uint direction, uint type, uint nr, uint size) =>
+            (nuint)((direction << 30) | (size << 16) | (type << 8) | nr);
+    }
+}

--- a/OpenTabletDriver/Devices/HidSharpBackend/LinuxRawHidDescriptorInfo.cs
+++ b/OpenTabletDriver/Devices/HidSharpBackend/LinuxRawHidDescriptorInfo.cs
@@ -4,6 +4,13 @@ using System.IO;
 
 namespace OpenTabletDriver.Devices.HidSharpBackend
 {
+    /// <summary>
+    /// Report-shape metadata extracted from hidraw without constructing HidSharp's
+    /// <see cref="HidSharp.Reports.ReportDescriptor"/>. This is intentionally a
+    /// tolerant parser: it only reconstructs the parts needed for matching and raw
+    /// streaming, so malformed items such as the signed-byte UnitExponent variant
+    /// do not block the fallback.
+    /// </summary>
     internal sealed class LinuxRawHidDescriptorInfo
     {
         internal LinuxRawHidDescriptorInfo(int inputReportLength, int outputReportLength, int featureReportLength, bool reportsUseID)
@@ -19,6 +26,10 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
         public int FeatureReportLength { get; }
         public bool ReportsUseID { get; }
 
+        /// <summary>
+        /// Reads the raw hidraw descriptor directly from the kernel and extracts
+        /// only the report lengths and report-ID usage required by the fallback.
+        /// </summary>
         internal static LinuxRawHidDescriptorInfo TryCreateFromDevice(string devicePath)
         {
             if (string.IsNullOrWhiteSpace(devicePath))
@@ -54,6 +65,11 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
             }
         }
 
+        /// <summary>
+        /// Parses enough of the HID descriptor to recover the maximum report
+        /// lengths. Global items that affect report sizing are honored; metadata
+        /// items that do not affect layout are ignored.
+        /// </summary>
         internal static bool TryParse(byte[] descriptor, out LinuxRawHidDescriptorInfo info)
         {
             info = null;
@@ -116,6 +132,8 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
                                 break;
 
                             case 0x08:
+                                // The public stream contract expects a leading report-ID slot
+                                // even when the kernel delivers unnumbered reports directly.
                                 if (value == 0 || value > int.MaxValue)
                                     return false;
 
@@ -242,6 +260,7 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
             if (bits == 0)
                 return 0;
 
+            // Match HidSharp's public contract: lengths include the report ID byte.
             return ((bits + 7) / 8) + 1;
         }
 

--- a/OpenTabletDriver/Devices/HidSharpBackend/LinuxRawHidDescriptorInfo.cs
+++ b/OpenTabletDriver/Devices/HidSharpBackend/LinuxRawHidDescriptorInfo.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace OpenTabletDriver.Devices.HidSharpBackend
+{
+    internal sealed class LinuxRawHidDescriptorInfo
+    {
+        internal LinuxRawHidDescriptorInfo(int inputReportLength, int outputReportLength, int featureReportLength, bool reportsUseID)
+        {
+            InputReportLength = inputReportLength;
+            OutputReportLength = outputReportLength;
+            FeatureReportLength = featureReportLength;
+            ReportsUseID = reportsUseID;
+        }
+
+        public int InputReportLength { get; }
+        public int OutputReportLength { get; }
+        public int FeatureReportLength { get; }
+        public bool ReportsUseID { get; }
+
+        internal static LinuxRawHidDescriptorInfo TryCreateFromDevice(string devicePath)
+        {
+            if (string.IsNullOrWhiteSpace(devicePath))
+                return null;
+
+            try
+            {
+                using var stream = new FileStream(devicePath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+                var fd = stream.SafeFileHandle.DangerousGetHandle().ToInt32();
+
+                if (LinuxHidrawInterop.ioctl(fd, LinuxHidrawInterop.HIDIOCGRDESCSIZE, out var size) < 0
+                    || size <= 0
+                    || size > LinuxHidrawInterop.HidMaxDescriptorSize)
+                {
+                    return null;
+                }
+
+                var rawDescriptor = new LinuxHidrawInterop.HidrawReportDescriptor()
+                {
+                    Size = (uint)size,
+                    Value = new byte[LinuxHidrawInterop.HidMaxDescriptorSize]
+                };
+
+                if (LinuxHidrawInterop.ioctl(fd, LinuxHidrawInterop.HIDIOCGRDESC, ref rawDescriptor) < 0)
+                    return null;
+
+                Array.Resize(ref rawDescriptor.Value, size);
+                return TryParse(rawDescriptor.Value, out var info) ? info : null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        internal static bool TryParse(byte[] descriptor, out LinuxRawHidDescriptorInfo info)
+        {
+            info = null;
+            if (descriptor == null)
+                return false;
+
+            var reports = new Dictionary<int, ReportBitLengths>();
+            var global = new GlobalState();
+            var stack = new Stack<GlobalState>();
+            bool reportsUseID = false;
+
+            for (int index = 0; index < descriptor.Length;)
+            {
+                var prefix = descriptor[index++];
+                if (prefix == 0xFE)
+                {
+                    if (index + 1 >= descriptor.Length)
+                        return false;
+
+                    var dataSize = descriptor[index++];
+                    index++; // long item tag
+
+                    if (index + dataSize > descriptor.Length)
+                        return false;
+
+                    index += dataSize;
+                    continue;
+                }
+
+                var size = GetItemSize(prefix & 0x03);
+                if (index + size > descriptor.Length)
+                    return false;
+
+                if (!TryReadUInt32(descriptor, index, size, out var value))
+                    return false;
+
+                index += size;
+
+                var type = (prefix >> 2) & 0x03;
+                var tag = (prefix >> 4) & 0x0F;
+
+                switch (type)
+                {
+                    case 0x00:
+                        if (tag == 0x08 || tag == 0x09 || tag == 0x0B)
+                        {
+                            if (!TryAccumulateBits(reports, global, tag))
+                                return false;
+                        }
+                        break;
+
+                    case 0x01:
+                        switch (tag)
+                        {
+                            case 0x07:
+                                if (value > int.MaxValue)
+                                    return false;
+
+                                global.ReportSizeBits = (int)value;
+                                break;
+
+                            case 0x08:
+                                if (value == 0 || value > int.MaxValue)
+                                    return false;
+
+                                reportsUseID = true;
+                                global.ReportID = (int)value;
+                                GetOrCreateReport(reports, global.ReportID);
+                                break;
+
+                            case 0x09:
+                                if (value > int.MaxValue)
+                                    return false;
+
+                                global.ReportCount = (int)value;
+                                break;
+
+                            case 0x0A:
+                                stack.Push(global);
+                                break;
+
+                            case 0x0B:
+                                if (stack.Count == 0)
+                                    return false;
+
+                                global = stack.Pop();
+                                break;
+                        }
+                        break;
+                }
+            }
+
+            int maxInputBits = 0;
+            int maxOutputBits = 0;
+            int maxFeatureBits = 0;
+
+            foreach (var report in reports.Values)
+            {
+                maxInputBits = Math.Max(maxInputBits, report.InputBits);
+                maxOutputBits = Math.Max(maxOutputBits, report.OutputBits);
+                maxFeatureBits = Math.Max(maxFeatureBits, report.FeatureBits);
+            }
+
+            info = new LinuxRawHidDescriptorInfo(
+                ToReportLength(maxInputBits),
+                ToReportLength(maxOutputBits),
+                ToReportLength(maxFeatureBits),
+                reportsUseID);
+
+            return true;
+        }
+
+        private static int GetItemSize(int sizeCode) => sizeCode == 0x03 ? 4 : sizeCode;
+
+        private static bool TryReadUInt32(byte[] buffer, int offset, int count, out uint value)
+        {
+            value = 0;
+
+            if (count < 0 || count > sizeof(uint))
+                return false;
+
+            for (int index = 0; index < count; index++)
+                value |= (uint)buffer[offset + index] << (index * 8);
+
+            return true;
+        }
+
+        private static bool TryAccumulateBits(Dictionary<int, ReportBitLengths> reports, GlobalState global, int tag)
+        {
+            if (global.ReportSizeBits < 0 || global.ReportCount < 0)
+                return false;
+
+            int bits;
+            try
+            {
+                bits = checked(global.ReportSizeBits * global.ReportCount);
+            }
+            catch (OverflowException)
+            {
+                return false;
+            }
+
+            var report = GetOrCreateReport(reports, global.ReportID);
+
+            try
+            {
+                checked
+                {
+                    switch (tag)
+                    {
+                        case 0x08:
+                            report.InputBits += bits;
+                            break;
+
+                        case 0x09:
+                            report.OutputBits += bits;
+                            break;
+
+                        case 0x0B:
+                            report.FeatureBits += bits;
+                            break;
+                    }
+                }
+            }
+            catch (OverflowException)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static ReportBitLengths GetOrCreateReport(Dictionary<int, ReportBitLengths> reports, int reportID)
+        {
+            if (!reports.TryGetValue(reportID, out var report))
+            {
+                report = new ReportBitLengths();
+                reports.Add(reportID, report);
+            }
+
+            return report;
+        }
+
+        private static int ToReportLength(int bits)
+        {
+            if (bits == 0)
+                return 0;
+
+            return ((bits + 7) / 8) + 1;
+        }
+
+        private struct GlobalState
+        {
+            public int ReportSizeBits;
+            public int ReportCount;
+            public int ReportID;
+        }
+
+        private sealed class ReportBitLengths
+        {
+            public int InputBits { get; set; }
+            public int OutputBits { get; set; }
+            public int FeatureBits { get; set; }
+        }
+    }
+}

--- a/OpenTabletDriver/Devices/HidSharpBackend/LinuxRawHidStream.cs
+++ b/OpenTabletDriver/Devices/HidSharpBackend/LinuxRawHidStream.cs
@@ -12,28 +12,45 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
     /// </summary>
     internal sealed class LinuxRawHidStream : IDeviceEndpointStream
     {
-        private const int MaxReportSize = 64;
         private readonly FileStream _stream;
+        private readonly LinuxRawHidDescriptorInfo _descriptorInfo;
+        private readonly Func<int, nuint, IntPtr, int> _ioctl;
 
-        [DllImport("libc", SetLastError = true)]
-        private static extern int ioctl(int fd, nuint request, IntPtr data);
-
-        // hidraw ioctl commands: IOWR('H', nr, len) = (3 << 30) | (len << 16) | ('H' << 8) | nr
-        private static nuint HIDIOCSFEATURE(int len) => (nuint)((3u << 30) | ((uint)len << 16) | (72u << 8) | 6u);
-        private static nuint HIDIOCGFEATURE(int len) => (nuint)((3u << 30) | ((uint)len << 16) | (72u << 8) | 7u);
-
-        public LinuxRawHidStream(string devicePath)
+        public LinuxRawHidStream(string devicePath, LinuxRawHidDescriptorInfo descriptorInfo)
+            : this(CreateStream(devicePath), descriptorInfo, LinuxHidrawInterop.ioctl)
         {
-            _stream = new FileStream(devicePath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+        }
+
+        internal LinuxRawHidStream(string devicePath, LinuxRawHidDescriptorInfo descriptorInfo, Func<int, nuint, IntPtr, int> ioctlHandler)
+            : this(CreateStream(devicePath), descriptorInfo, ioctlHandler)
+        {
+        }
+
+        private LinuxRawHidStream(FileStream stream, LinuxRawHidDescriptorInfo descriptorInfo, Func<int, nuint, IntPtr, int> ioctlHandler)
+        {
+            _stream = stream;
+            _descriptorInfo = descriptorInfo;
+            _ioctl = ioctlHandler;
         }
 
         public byte[] Read()
         {
-            var buffer = new byte[MaxReportSize];
-            var count = _stream.Read(buffer, 0, buffer.Length);
-            if (count != buffer.Length)
-                Array.Resize(ref buffer, count);
-            return buffer;
+            if (_descriptorInfo.ReportsUseID)
+            {
+                var buffer = new byte[_descriptorInfo.InputReportLength];
+                var count = _stream.Read(buffer, 0, buffer.Length);
+                if (count != buffer.Length)
+                    Array.Resize(ref buffer, count);
+
+                return buffer;
+            }
+
+            var payloadLength = Math.Max(0, _descriptorInfo.InputReportLength - 1);
+            var payload = new byte[payloadLength];
+            var countRead = _stream.Read(payload, 0, payload.Length);
+            var bufferWithSyntheticReportId = new byte[countRead + 1];
+            Array.Copy(payload, 0, bufferWithSyntheticReportId, 1, countRead);
+            return bufferWithSyntheticReportId;
         }
 
         public void Write(byte[] buffer) => _stream.Write(buffer, 0, buffer.Length);
@@ -42,25 +59,39 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
         {
             fixed (byte* ptr = buffer)
             {
-                if (ioctl(GetFd(), HIDIOCSFEATURE(buffer.Length), (IntPtr)ptr) < 0)
+                if (_ioctl(GetFd(), LinuxHidrawInterop.HIDIOCSFEATURE(buffer.Length), (IntPtr)ptr) < 0)
                     throw new IOException("SetFeature failed.");
             }
         }
 
         public unsafe void GetFeature(byte[] buffer)
         {
+            if (!_descriptorInfo.ReportsUseID && buffer.Length < 2)
+                throw new ArgumentOutOfRangeException(nameof(buffer), "Unnumbered feature reports require a synthetic report ID slot.");
+
             fixed (byte* ptr = buffer)
             {
-                int result = ioctl(GetFd(), HIDIOCGFEATURE(buffer.Length), (IntPtr)ptr);
+                var requestLength = _descriptorInfo.ReportsUseID ? buffer.Length : buffer.Length - 1;
+                var requestBuffer = _descriptorInfo.ReportsUseID ? (IntPtr)ptr : (IntPtr)(ptr + 1);
+
+                if (!_descriptorInfo.ReportsUseID)
+                    buffer[1] = buffer[0];
+
+                int result = _ioctl(GetFd(), LinuxHidrawInterop.HIDIOCGFEATURE(requestLength), requestBuffer);
                 if (result < 0)
                     throw new IOException("GetFeature failed.");
-                if (result < buffer.Length)
-                    Array.Clear(buffer, result, buffer.Length - result);
+
+                var clearOffset = _descriptorInfo.ReportsUseID ? result : result + 1;
+                if (clearOffset < buffer.Length)
+                    Array.Clear(buffer, clearOffset, buffer.Length - clearOffset);
             }
         }
 
         private int GetFd() => _stream.SafeFileHandle.DangerousGetHandle().ToInt32();
 
         public void Dispose() => _stream.Dispose();
+
+        private static FileStream CreateStream(string devicePath) =>
+            new FileStream(devicePath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
     }
 }

--- a/OpenTabletDriver/Devices/HidSharpBackend/LinuxRawHidStream.cs
+++ b/OpenTabletDriver/Devices/HidSharpBackend/LinuxRawHidStream.cs
@@ -1,0 +1,66 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using OpenTabletDriver.Plugin.Devices;
+
+namespace OpenTabletDriver.Devices.HidSharpBackend
+{
+    /// <summary>
+    /// A raw Linux hidraw stream for devices whose HID report descriptors cannot be parsed by HidSharp.
+    /// Falls back to direct file I/O since the kernel's hidraw interface exposes raw reports without
+    /// requiring the report descriptor to be parseable.
+    /// </summary>
+    internal sealed class LinuxRawHidStream : IDeviceEndpointStream
+    {
+        private const int MaxReportSize = 64;
+        private readonly FileStream _stream;
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int ioctl(int fd, nuint request, IntPtr data);
+
+        // hidraw ioctl commands: IOWR('H', nr, len) = (3 << 30) | (len << 16) | ('H' << 8) | nr
+        private static nuint HIDIOCSFEATURE(int len) => (nuint)((3u << 30) | ((uint)len << 16) | (72u << 8) | 6u);
+        private static nuint HIDIOCGFEATURE(int len) => (nuint)((3u << 30) | ((uint)len << 16) | (72u << 8) | 7u);
+
+        public LinuxRawHidStream(string devicePath)
+        {
+            _stream = new FileStream(devicePath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+        }
+
+        public byte[] Read()
+        {
+            var buffer = new byte[MaxReportSize];
+            var count = _stream.Read(buffer, 0, buffer.Length);
+            if (count != buffer.Length)
+                Array.Resize(ref buffer, count);
+            return buffer;
+        }
+
+        public void Write(byte[] buffer) => _stream.Write(buffer, 0, buffer.Length);
+
+        public unsafe void SetFeature(byte[] buffer)
+        {
+            fixed (byte* ptr = buffer)
+            {
+                if (ioctl(GetFd(), HIDIOCSFEATURE(buffer.Length), (IntPtr)ptr) < 0)
+                    throw new IOException("SetFeature failed.");
+            }
+        }
+
+        public unsafe void GetFeature(byte[] buffer)
+        {
+            fixed (byte* ptr = buffer)
+            {
+                int result = ioctl(GetFd(), HIDIOCGFEATURE(buffer.Length), (IntPtr)ptr);
+                if (result < 0)
+                    throw new IOException("GetFeature failed.");
+                if (result < buffer.Length)
+                    Array.Clear(buffer, result, buffer.Length - result);
+            }
+        }
+
+        private int GetFd() => _stream.SafeFileHandle.DangerousGetHandle().ToInt32();
+
+        public void Dispose() => _stream.Dispose();
+    }
+}

--- a/OpenTabletDriver/Devices/HidSharpBackend/LinuxRawHidStream.cs
+++ b/OpenTabletDriver/Devices/HidSharpBackend/LinuxRawHidStream.cs
@@ -9,6 +9,10 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
     /// A raw Linux hidraw stream for devices whose HID report descriptors cannot be parsed by HidSharp.
     /// Falls back to direct file I/O since the kernel's hidraw interface exposes raw reports without
     /// requiring the report descriptor to be parseable.
+    ///
+    /// The important constraint is that callers still expect HidSharp-style report
+    /// buffers. In particular, OpenTabletDriver parsers expect a leading report-ID
+    /// slot even for devices whose descriptor defines only unnumbered reports.
     /// </summary>
     internal sealed class LinuxRawHidStream : IDeviceEndpointStream
     {
@@ -45,6 +49,8 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
                 return buffer;
             }
 
+            // HidSharp prepends a synthetic 0x00 report ID for unnumbered devices;
+            // keep that shape so existing parsers do not need a Linux-specific path.
             var payloadLength = Math.Max(0, _descriptorInfo.InputReportLength - 1);
             var payload = new byte[payloadLength];
             var countRead = _stream.Read(payload, 0, payload.Length);
@@ -75,12 +81,17 @@ namespace OpenTabletDriver.Devices.HidSharpBackend
                 var requestBuffer = _descriptorInfo.ReportsUseID ? (IntPtr)ptr : (IntPtr)(ptr + 1);
 
                 if (!_descriptorInfo.ReportsUseID)
+                    // The kernel buffer starts at the payload for unnumbered reports.
+                    // Mirror HidSharp by shifting the caller's synthetic report ID out
+                    // of the ioctl buffer before issuing HIDIOCGFEATURE.
                     buffer[1] = buffer[0];
 
                 int result = _ioctl(GetFd(), LinuxHidrawInterop.HIDIOCGFEATURE(requestLength), requestBuffer);
                 if (result < 0)
                     throw new IOException("GetFeature failed.");
 
+                // HidSharp clears the unread tail of the feature buffer; keep that
+                // behavior so initialization reports remain deterministic.
                 var clearOffset = _descriptorInfo.ReportsUseID ? result : result + 1;
                 if (clearOffset < buffer.Length)
                     Array.Clear(buffer, clearOffset, buffer.Length - clearOffset);


### PR DESCRIPTION
## Summary
- Adds `LinuxRawHidStream`, a fallback `IDeviceEndpointStream` that uses direct file I/O and ioctl for devices whose HID report descriptors cannot be parsed by HidSharp (e.g. `UnitExponent` encoded as a signed byte instead of a 4-bit nibble)
- Adds `LinuxRawHidDescriptorInfo`, a tolerant HID descriptor parser that extracts only report lengths and report-ID usage, bypassing the metadata items that cause HidSharp to throw
- `HidSharpEndpoint.Open()` falls back to `LinuxRawHidStream` when `TryOpen()` fails on Linux
- `HidSharpEndpoint` report length properties now fall back to the raw descriptor parser, so `Driver.cs` device matching works even when HidSharp returns -1

## Motivation
HidSharpCore's `Unit.DecodeExponent()` throws `ArgumentOutOfRangeException` for devices that encode `UnitExponent` as a signed byte (values like `0xFD`, `0xFE`) rather than the 4-bit nibble the parser expects. This causes `TryOpen()` to fail and report lengths to return -1, making the device undetectable. The proper fix belongs upstream in HidSharpCore; this is a workaround within OTD.

## Test plan
- [x] Builds cleanly on Linux
- [x] 25 new/existing tests pass (`LinuxRawHidDescriptorInfoTest`, `LinuxRawHidStreamTest`, `HidSharpEndpointTest`)
- [x] Verified with Waltop Sirius Battery Free Tablet (172f:0502) — device with malformed descriptor
- [ ] Verify no regression on devices that work normally with HidSharp

🤖 Generated with [Claude Code](https://claude.com/claude-code)