### PR TITLE
Bindings: Auxiliary button labels, press highlighting, and wheel grouping

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Waltop/Sirius Battery Free Tablet.json
+++ b/OpenTabletDriver.Configurations/Configurations/Waltop/Sirius Battery Free Tablet.json
@@ -52,41 +52,57 @@
       {
         "AbsoluteWheelMax": 7,
         "AngleOfZeroReading": 90.0,
+        "Name": "Scroll",
+        "Group": "Left Dial",
         "ButtonCount": 0
       },
       {
         "AbsoluteWheelMax": 7,
         "AngleOfZeroReading": 90.0,
+        "Name": "Scroll",
+        "Group": "Right Dial",
         "ButtonCount": 0
       },
       {
         "AbsoluteWheelMax": 7,
         "AngleOfZeroReading": 90.0,
+        "Name": "Scroll Aux",
+        "Group": "Left Dial",
         "ButtonCount": 0
       },
       {
         "AbsoluteWheelMax": 7,
         "AngleOfZeroReading": 90.0,
+        "Name": "Scroll Aux",
+        "Group": "Right Dial",
         "ButtonCount": 0
       },
       {
         "AbsoluteWheelMax": 7,
         "AngleOfZeroReading": 90.0,
+        "Name": "Multimedia",
+        "Group": "Left Dial",
         "ButtonCount": 0
       },
       {
         "AbsoluteWheelMax": 7,
         "AngleOfZeroReading": 90.0,
+        "Name": "Multimedia",
+        "Group": "Right Dial",
         "ButtonCount": 0
       },
       {
         "AbsoluteWheelMax": 7,
         "AngleOfZeroReading": 90.0,
+        "Name": "Multimedia Aux",
+        "Group": "Left Dial",
         "ButtonCount": 0
       },
       {
         "AbsoluteWheelMax": 7,
         "AngleOfZeroReading": 90.0,
+        "Name": "Multimedia Aux",
+        "Group": "Right Dial",
         "ButtonCount": 0
       }
     ]

--- a/OpenTabletDriver.Configurations/Configurations/Waltop/Sirius Battery Free Tablet.json
+++ b/OpenTabletDriver.Configurations/Configurations/Waltop/Sirius Battery Free Tablet.json
@@ -22,7 +22,11 @@
       "InputReportLength": 10,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.Waltop.WaltopSiriusReportParser",
       "FeatureInitReport": [
-        "AhAB"
+        "AhAB",
+        "AhEP",
+        "AhgE",
+        "AhL/",
+        "AhcA"
       ]
     }
   ],

--- a/OpenTabletDriver.Configurations/Configurations/Waltop/Sirius Battery Free Tablet.json
+++ b/OpenTabletDriver.Configurations/Configurations/Waltop/Sirius Battery Free Tablet.json
@@ -4,12 +4,15 @@
     "Digitizer": {
       "Width": 254,
       "Height": 152.4,
-      "MaxX": 20000,
-      "MaxY": 12000
+      "MaxX": 40000,
+      "MaxY": 24000
     },
     "Pen": {
       "MaxPressure": 1023,
-      "ButtonCount": 2
+      "ButtonCount": 1
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 14
     }
   },
   "DigitizerIdentifiers": [
@@ -17,7 +20,10 @@
       "VendorID": 5935,
       "ProductID": 1282,
       "InputReportLength": 10,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Waltop.WaltopSiriusReportParser"
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Waltop.WaltopSiriusReportParser",
+      "FeatureInitReport": [
+        "AhAB"
+      ]
     }
   ],
   "Attributes": {

--- a/OpenTabletDriver.Configurations/Configurations/Waltop/Sirius Battery Free Tablet.json
+++ b/OpenTabletDriver.Configurations/Configurations/Waltop/Sirius Battery Free Tablet.json
@@ -24,6 +24,36 @@
         "AbsoluteWheelMax": 7,
         "AngleOfZeroReading": 90.0,
         "ButtonCount": 0
+      },
+      {
+        "AbsoluteWheelMax": 7,
+        "AngleOfZeroReading": 90.0,
+        "ButtonCount": 0
+      },
+      {
+        "AbsoluteWheelMax": 7,
+        "AngleOfZeroReading": 90.0,
+        "ButtonCount": 0
+      },
+      {
+        "AbsoluteWheelMax": 7,
+        "AngleOfZeroReading": 90.0,
+        "ButtonCount": 0
+      },
+      {
+        "AbsoluteWheelMax": 7,
+        "AngleOfZeroReading": 90.0,
+        "ButtonCount": 0
+      },
+      {
+        "AbsoluteWheelMax": 7,
+        "AngleOfZeroReading": 90.0,
+        "ButtonCount": 0
+      },
+      {
+        "AbsoluteWheelMax": 7,
+        "AngleOfZeroReading": 90.0,
+        "ButtonCount": 0
       }
     ]
   },

--- a/OpenTabletDriver.Configurations/Configurations/Waltop/Sirius Battery Free Tablet.json
+++ b/OpenTabletDriver.Configurations/Configurations/Waltop/Sirius Battery Free Tablet.json
@@ -12,7 +12,41 @@
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {
-      "ButtonCount": 32
+      "ButtonCount": 32,
+      "ButtonNames": [
+        "Left Eraser",
+        "Left Shift",
+        "Left Tab",
+        "Left Alt",
+        "Left Ctrl",
+        "Right Eraser",
+        "Right Shift",
+        "Right Tab",
+        "Right Alt",
+        "Right Ctrl",
+        "V/H Scroll Select",
+        "Zoom/Volume Select",
+        "KB Direction Select",
+        "Dial Subfunction Switch",
+        "Up",
+        "Down",
+        "Left",
+        "Right",
+        "Page Up",
+        "Page Down",
+        "Home",
+        "End",
+        "K1",
+        "K2",
+        "K3",
+        "K4",
+        "K5",
+        "K6",
+        "K7",
+        "K8",
+        "K9",
+        "K10"
+      ]
     },
     "Wheels": [
       {

--- a/OpenTabletDriver.Configurations/Configurations/Waltop/Sirius Battery Free Tablet.json
+++ b/OpenTabletDriver.Configurations/Configurations/Waltop/Sirius Battery Free Tablet.json
@@ -12,8 +12,20 @@
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {
-      "ButtonCount": 14
-    }
+      "ButtonCount": 32
+    },
+    "Wheels": [
+      {
+        "AbsoluteWheelMax": 7,
+        "AngleOfZeroReading": 90.0,
+        "ButtonCount": 0
+      },
+      {
+        "AbsoluteWheelMax": 7,
+        "AngleOfZeroReading": 90.0,
+        "ButtonCount": 0
+      }
+    ]
   },
   "DigitizerIdentifiers": [
     {

--- a/OpenTabletDriver.Configurations/Configurations/Waltop/Sirius Battery Free Tablet.json
+++ b/OpenTabletDriver.Configurations/Configurations/Waltop/Sirius Battery Free Tablet.json
@@ -9,7 +9,7 @@
     },
     "Pen": {
       "MaxPressure": 1023,
-      "ButtonCount": 1
+      "ButtonCount": 2
     },
     "AuxiliaryButtons": {
       "ButtonCount": 14

--- a/OpenTabletDriver.Configurations/Configurations/Waltop/Sirius Battery Free Tablet.json
+++ b/OpenTabletDriver.Configurations/Configurations/Waltop/Sirius Battery Free Tablet.json
@@ -1,0 +1,26 @@
+{
+  "Name": "Waltop Sirius Battery Free Tablet",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 254,
+      "Height": 152.4,
+      "MaxX": 20000,
+      "MaxY": 12000
+    },
+    "Pen": {
+      "MaxPressure": 1023,
+      "ButtonCount": 2
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 5935,
+      "ProductID": 1282,
+      "InputReportLength": 10,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Waltop.WaltopSiriusReportParser"
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusAuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusAuxReport.cs
@@ -1,0 +1,47 @@
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Waltop
+{
+    /// <summary>
+    /// Frame button report for Waltop Sirius Battery Free Tablet in tablet mode.
+    /// Report ID 0x0A, subreport ID 0x0E.
+    ///
+    /// Byte layout (from DIGImend reverse engineering):
+    ///   data[0] = Report ID (0x0A)
+    ///   data[1] = Subreport ID (0x0E)
+    ///   data[2] = bit 0: Left eraser,  bit 1: Left Shift,  bit 2: Left Tab,
+    ///             bit 3: Left Alt,     bit 4: Left Ctrl,   bit 5: Right eraser,
+    ///             bit 6: Right Shift,  bit 7: Right Tab
+    ///   data[3] = bit 0: Right Alt,    bit 1: Right Ctrl,
+    ///             bit 2: V/H scroll,   bit 3: Zoom/volume,
+    ///             bit 4: KB direction,  bit 5: Dial subfunction switch
+    /// </summary>
+    public struct WaltopSiriusAuxReport : IAuxReport
+    {
+        public WaltopSiriusAuxReport(byte[] report)
+        {
+            Raw = report;
+
+            AuxButtons = new bool[]
+            {
+                (report[2] & 0x01) != 0, // Left eraser
+                (report[2] & 0x02) != 0, // Left Shift
+                (report[2] & 0x04) != 0, // Left Tab
+                (report[2] & 0x08) != 0, // Left Alt
+                (report[2] & 0x10) != 0, // Left Ctrl
+                (report[2] & 0x20) != 0, // Right eraser
+                (report[2] & 0x40) != 0, // Right Shift
+                (report[2] & 0x80) != 0, // Right Tab
+                (report[3] & 0x01) != 0, // Right Alt
+                (report[3] & 0x02) != 0, // Right Ctrl
+                (report[3] & 0x04) != 0, // V/H scroll select
+                (report[3] & 0x08) != 0, // Zoom/volume select
+                (report[3] & 0x10) != 0, // KB direction select
+                (report[3] & 0x20) != 0, // Dial subfunction switch
+            };
+        }
+
+        public byte[] Raw { set; get; }
+        public bool[] AuxButtons { set; get; }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusAuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusAuxReport.cs
@@ -15,30 +15,32 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
     ///   data[3] = bit 0: Right Alt,    bit 1: Right Ctrl,
     ///             bit 2: V/H scroll,   bit 3: Zoom/volume,
     ///             bit 4: KB direction,  bit 5: Dial subfunction switch
+    ///
+    /// Aux button indices 0-13 in the shared 32-element layout.
     /// </summary>
     public struct WaltopSiriusAuxReport : IAuxReport
     {
+        private const int TotalAuxButtons = 32;
+
         public WaltopSiriusAuxReport(byte[] report)
         {
             Raw = report;
+            AuxButtons = new bool[TotalAuxButtons];
 
-            AuxButtons = new bool[]
-            {
-                (report[2] & 0x01) != 0, // Left eraser
-                (report[2] & 0x02) != 0, // Left Shift
-                (report[2] & 0x04) != 0, // Left Tab
-                (report[2] & 0x08) != 0, // Left Alt
-                (report[2] & 0x10) != 0, // Left Ctrl
-                (report[2] & 0x20) != 0, // Right eraser
-                (report[2] & 0x40) != 0, // Right Shift
-                (report[2] & 0x80) != 0, // Right Tab
-                (report[3] & 0x01) != 0, // Right Alt
-                (report[3] & 0x02) != 0, // Right Ctrl
-                (report[3] & 0x04) != 0, // V/H scroll select
-                (report[3] & 0x08) != 0, // Zoom/volume select
-                (report[3] & 0x10) != 0, // KB direction select
-                (report[3] & 0x20) != 0, // Dial subfunction switch
-            };
+            AuxButtons[0]  = (report[2] & 0x01) != 0; // Left eraser
+            AuxButtons[1]  = (report[2] & 0x02) != 0; // Left Shift
+            AuxButtons[2]  = (report[2] & 0x04) != 0; // Left Tab
+            AuxButtons[3]  = (report[2] & 0x08) != 0; // Left Alt
+            AuxButtons[4]  = (report[2] & 0x10) != 0; // Left Ctrl
+            AuxButtons[5]  = (report[2] & 0x20) != 0; // Right eraser
+            AuxButtons[6]  = (report[2] & 0x40) != 0; // Right Shift
+            AuxButtons[7]  = (report[2] & 0x80) != 0; // Right Tab
+            AuxButtons[8]  = (report[3] & 0x01) != 0; // Right Alt
+            AuxButtons[9]  = (report[3] & 0x02) != 0; // Right Ctrl
+            AuxButtons[10] = (report[3] & 0x04) != 0; // V/H scroll select
+            AuxButtons[11] = (report[3] & 0x08) != 0; // Zoom/volume select
+            AuxButtons[12] = (report[3] & 0x10) != 0; // KB direction select
+            AuxButtons[13] = (report[3] & 0x20) != 0; // Dial subfunction switch
         }
 
         public byte[] Raw { set; get; }

--- a/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusBorderReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusBorderReport.cs
@@ -1,0 +1,47 @@
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Waltop
+{
+    /// <summary>
+    /// Border location report for Waltop Sirius Battery Free Tablet.
+    /// Report ID 0x05, 8 bytes. Emitted when the pen is near the tablet edge.
+    ///
+    /// Byte layout:
+    ///   data[1] bits 0-1: proximity, bit 2: tip, bit 3: lower button, bit 4: upper button
+    ///   data[2]: border (1=bottom, 2=top, 4=left, 8=right)
+    ///   data[3]: position along border (horizontal: 0x01-0x28, vertical: 0x01-0x18)
+    ///
+    /// The top border contains 10 virtual buttons (K1-K10), each spanning 4 positions
+    /// with 1-position gaps: K1=0x01-0x04, K2=0x05-0x08, ... K10=0x25-0x28.
+    /// A button is considered pressed when the tip bit is set (pen tapping, not just hovering).
+    ///
+    /// Aux button indices 22-31 in the shared 32-element layout.
+    /// </summary>
+    public struct WaltopSiriusBorderReport : IAuxReport
+    {
+        private const int TotalAuxButtons = 32;
+        private const int VirtualButtonOffset = 22;
+        private const int VirtualButtonCount = 10;
+        private const byte TopBorder = 2;
+
+        public WaltopSiriusBorderReport(byte[] data)
+        {
+            Raw = data;
+            AuxButtons = new bool[TotalAuxButtons];
+
+            bool tip = (data[1] & 0x04) != 0;
+            byte border = data[2];
+            byte position = data[3];
+
+            if (tip && border == TopBorder && position >= 1 && position <= 0x28)
+            {
+                int buttonIndex = (position - 1) / 4;
+                if (buttonIndex < VirtualButtonCount)
+                    AuxButtons[VirtualButtonOffset + buttonIndex] = true;
+            }
+        }
+
+        public byte[] Raw { set; get; }
+        public bool[] AuxButtons { set; get; }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusDialReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusDialReport.cs
@@ -1,0 +1,50 @@
+using OpenTabletDriver.Plugin.Tablet.Wheel;
+
+namespace OpenTabletDriver.Configurations.Parsers.Waltop
+{
+    /// <summary>
+    /// Dial report for Waltop Sirius Battery Free Tablet in tablet mode.
+    /// Report ID 0x0A, subreport IDs 0x02/0x03/0x04. 8 bytes.
+    ///
+    /// The firmware sends different subreport IDs depending on the active dial mode
+    /// (selected via frame buttons), but the byte layout is identical:
+    ///   0x02 = Scroll mode
+    ///   0x03 = Zoom/volume mode (subfunction switch OFF)
+    ///   0x04 = Zoom/volume mode (subfunction switch ON)
+    ///
+    /// Limitation: all three subreports map to the same wheel report type, so the
+    /// Scroll/Multimedia mode toggle on the tablet has no effect — the user-configured
+    /// wheel bindings apply regardless of mode. Direction mode (Report 0x0D) is
+    /// handled separately by WaltopSiriusKeyDialReport and IS distinguishable.
+    ///
+    /// Byte layout:
+    ///   data[0] = Report ID (0x0A)
+    ///   data[1] = Subreport ID (0x02, 0x03, or 0x04)
+    ///   data[2] = Rotation delta: -1 (CCW), 0 (none), +1 (CW)
+    ///   data[3-5] = Padding (zero)
+    ///   data[6] = Right wheel finger position (0=no finger, 1-8 clockwise from 12 o'clock)
+    ///   data[7] = Left wheel finger position (0=no finger, 1-8 clockwise from 12 o'clock)
+    ///
+    /// The rotation delta (byte 2) does not indicate which wheel produced it.
+    /// The active wheel is inferred from the absolute finger position bytes.
+    /// </summary>
+    public struct WaltopSiriusDialReport : IAbsoluteWheelReport
+    {
+        public WaltopSiriusDialReport(byte[] data)
+        {
+            Raw = data;
+
+            byte leftPos = data[7];
+            byte rightPos = data[6];
+
+            AnalogPositions =
+            [
+                leftPos != 0 ? leftPos - 1u : null,
+                rightPos != 0 ? rightPos - 1u : null
+            ];
+        }
+
+        public byte[] Raw { set; get; }
+        public uint?[] AnalogPositions { set; get; }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusDialReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusDialReport.cs
@@ -9,15 +9,15 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
     /// The firmware sends different subreport IDs depending on the active dial mode
     /// (selected via frame buttons), but the byte layout is identical:
     ///   0x02 = Scroll mode
-    ///   0x03 = Zoom/volume mode (subfunction switch OFF)
-    ///   0x04 = Zoom/volume mode (subfunction switch ON)
+    ///   0x03 = Multimedia mode (auxiliary OFF)
+    ///   0x04 = Multimedia mode (auxiliary ON)
     ///
-    /// Each subreport ID and subfunction switch combination maps to a different pair
+    /// Each subreport ID and auxiliary toggle combination maps to a different pair
     /// of wheel indices, allowing users to assign separate wheel bindings per mode:
-    ///   0x02 + subfunc OFF (Scroll):     positions at indices [0, 1]
-    ///   0x02 + subfunc ON  (Scroll alt): positions at indices [2, 3]
-    ///   0x03 (Zoom/volume, subfunc OFF): positions at indices [4, 5]
-    ///   0x04 (Zoom/volume, subfunc ON):  positions at indices [6, 7]
+    ///   0x02 + aux OFF (Scroll):         positions at indices [0, 1]
+    ///   0x02 + aux ON  (Scroll Aux):     positions at indices [2, 3]
+    ///   0x03 (Multimedia):               positions at indices [4, 5]
+    ///   0x04 (Multimedia Aux):           positions at indices [6, 7]
     /// Raw positions (1-8) are converted to 0-based (0-7); 0 means no finger (null).
     /// Inactive indices are null, which resets the corresponding WheelBindings.
     /// Direction mode (Report 0x0D) is handled separately by WaltopSiriusKeyDialReport.

--- a/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusDialReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusDialReport.cs
@@ -12,10 +12,15 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
     ///   0x03 = Zoom/volume mode (subfunction switch OFF)
     ///   0x04 = Zoom/volume mode (subfunction switch ON)
     ///
-    /// Limitation: all three subreports map to the same wheel report type, so the
-    /// Scroll/Multimedia mode toggle on the tablet has no effect — the user-configured
-    /// wheel bindings apply regardless of mode. Direction mode (Report 0x0D) is
-    /// handled separately by WaltopSiriusKeyDialReport and IS distinguishable.
+    /// Each subreport ID and subfunction switch combination maps to a different pair
+    /// of wheel indices, allowing users to assign separate wheel bindings per mode:
+    ///   0x02 + subfunc OFF (Scroll):     positions at indices [0, 1]
+    ///   0x02 + subfunc ON  (Scroll alt): positions at indices [2, 3]
+    ///   0x03 (Zoom/volume, subfunc OFF): positions at indices [4, 5]
+    ///   0x04 (Zoom/volume, subfunc ON):  positions at indices [6, 7]
+    /// Raw positions (1-8) are converted to 0-based (0-7); 0 means no finger (null).
+    /// Inactive indices are null, which resets the corresponding WheelBindings.
+    /// Direction mode (Report 0x0D) is handled separately by WaltopSiriusKeyDialReport.
     ///
     /// Byte layout:
     ///   data[0] = Report ID (0x0A)
@@ -30,18 +35,26 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
     /// </summary>
     public struct WaltopSiriusDialReport : IAbsoluteWheelReport
     {
-        public WaltopSiriusDialReport(byte[] data)
+        public WaltopSiriusDialReport(byte[] data, bool subfunctionSwitch)
         {
             Raw = data;
 
-            byte leftPos = data[7];
-            byte rightPos = data[6];
+            int offset = data[1] switch
+            {
+                0x02 => subfunctionSwitch ? 2 : 0,
+                0x03 => 4,
+                0x04 => 6,
+                _ => 0
+            };
 
-            AnalogPositions =
-            [
-                leftPos != 0 ? leftPos - 1u : null,
-                rightPos != 0 ? rightPos - 1u : null
-            ];
+            AnalogPositions = new uint?[8];
+            AnalogPositions[offset] = RawToPosition(data[7]);
+            AnalogPositions[offset + 1] = RawToPosition(data[6]);
+        }
+
+        private static uint? RawToPosition(byte raw)
+        {
+            return raw == 0 ? null : (uint)(raw - 1);
         }
 
         public byte[] Raw { set; get; }

--- a/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusKeyDialReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusKeyDialReport.cs
@@ -1,0 +1,56 @@
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Waltop
+{
+    /// <summary>
+    /// Keyboard-direction dial report for Waltop Sirius Battery Free Tablet.
+    /// Report ID 0x0D, 8 bytes. Active when the "Keyboard direction" frame button is selected.
+    ///
+    /// Only data[3] carries the payload — a HID keyboard usage code:
+    ///
+    ///   Subfunction switch OFF:
+    ///     0x52 = Up,    0x51 = Down
+    ///     0x4F = Right, 0x50 = Left
+    ///
+    ///   Subfunction switch ON:
+    ///     0x4B = Page Up,   0x4E = Page Down
+    ///     0x4A = Home,      0x4D = End
+    ///
+    /// Aux button indices 14-21 in the shared 32-element layout:
+    ///   [14]=Up, [15]=Down, [16]=Left, [17]=Right,
+    ///   [18]=PageUp, [19]=PageDown, [20]=Home, [21]=End.
+    /// Only one button is active at a time; all false when data[3] == 0 (release).
+    /// </summary>
+    public struct WaltopSiriusKeyDialReport : IAuxReport
+    {
+        private const int TotalAuxButtons = 32;
+        private const int KeyDialOffset = 14;
+
+        public WaltopSiriusKeyDialReport(byte[] data)
+        {
+            Raw = data;
+            AuxButtons = new bool[TotalAuxButtons];
+
+            byte key = data[3];
+
+            int index = key switch
+            {
+                0x52 => KeyDialOffset + 0, // Up
+                0x51 => KeyDialOffset + 1, // Down
+                0x50 => KeyDialOffset + 2, // Left
+                0x4F => KeyDialOffset + 3, // Right
+                0x4B => KeyDialOffset + 4, // Page Up
+                0x4E => KeyDialOffset + 5, // Page Down
+                0x4A => KeyDialOffset + 6, // Home
+                0x4D => KeyDialOffset + 7, // End
+                _ => -1
+            };
+
+            if (index >= 0)
+                AuxButtons[index] = true;
+        }
+
+        public byte[] Raw { set; get; }
+        public bool[] AuxButtons { set; get; }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusReportParser.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using OpenTabletDriver.Plugin.Tablet;
 
@@ -27,9 +26,11 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
     ///   - Pick button (lower physical):   produces bit 3 ~8% of the time, bit 4 ~92%
     ///
     /// When a button press begins (any button bit set after idle), the classifier accumulates
-    /// a log-likelihood ratio from each report. Once the ratio exceeds a confidence threshold,
-    /// the button identity is locked until release (all button bits clear). This typically
-    /// converges within 2-5 reports (~10-25ms at 200 RPS), well below perceptible latency.
+    /// a log-likelihood ratio from each report. Until the ratio exceeds a confidence threshold,
+    /// side-button output is intentionally suppressed to avoid false binding edges. Once the
+    /// threshold is crossed, the button identity is locked until release (all button bits clear).
+    /// This typically converges within 2-5 reports (~10-25ms at 200 RPS), well below
+    /// perceptible latency.
     /// </summary>
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public class WaltopSiriusReportParser : IReportParser<IDeviceReport>
@@ -58,7 +59,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
 
                     if (!inRange)
                     {
-                        _state = ButtonState.Idle;
+                        ResetClassifier();
                         return new OutOfRangeReport(data);
                     }
 
@@ -83,7 +84,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
                         case ButtonState.Classifying:
                             if (!anyButton)
                             {
-                                _state = ButtonState.Idle;
+                                ResetClassifier();
                                 break;
                             }
                             _llr += bit4 ? LlrBit4 : LlrBit3;
@@ -97,24 +98,18 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
                                 _state = ButtonState.LockedPick;
                                 reportPick = true;
                             }
-                            else
-                            {
-                                // Not yet decided — provisionally report the more likely button
-                                reportBarrel = _llr > 0;
-                                reportPick = _llr <= 0;
-                            }
                             break;
 
                         case ButtonState.LockedBarrel:
                             if (!anyButton)
-                                _state = ButtonState.Idle;
+                                ResetClassifier();
                             else
                                 reportBarrel = true;
                             break;
 
                         case ButtonState.LockedPick:
                             if (!anyButton)
-                                _state = ButtonState.Idle;
+                                ResetClassifier();
                             else
                                 reportPick = true;
                             break;
@@ -136,6 +131,12 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
                 default:
                     return new DeviceReport(data);
             }
+        }
+
+        private void ResetClassifier()
+        {
+            _state = ButtonState.Idle;
+            _llr = 0;
         }
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusReportParser.cs
@@ -6,52 +6,37 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
     /// <summary>
     /// Report parser for Waltop Sirius Battery Free Tablet in tablet mode (4000 LPI).
     ///
-    /// Problem:
-    /// The pen uses EMR (electromagnetic resonance) where barrel buttons work by switching
-    /// capacitors into the pen's resonant circuit. Button states are physically mutually
-    /// exclusive — only one button can be active at a time. In default mode (Report ID 0x10),
-    /// the firmware correctly encodes this as a 2-bit enumeration (values 2=barrel, 3=pick).
+    /// Tablet mode is activated by the following FeatureInitReport sequence
+    /// (HID Set Feature, Report ID 0x02, 3 bytes each):
     ///
-    /// However, in tablet mode (Report ID 0x02, required for 4000 LPI), the firmware encodes
-    /// buttons as individual bits (data[5] bit 3 and bit 4). In practice the pen can still
-    /// emit mixed frames at press onset (including both bits set), so button identity cannot
-    /// be trusted from a single report.
+    ///   02 10 01  — switch to tablet mode (4000 LPI, Report ID 0x02 pen reports)
+    ///   02 11 0F  — enable macro/frame key reporting (Report ID 0x0A)
+    ///   02 18 04  — set resolution mode
+    ///   02 12 FF  — enable EMR autogain
+    ///   02 17 00  — enable firmware signal filtering
     ///
-    /// Solution:
-    /// A Sequential Probability Ratio Test (SPRT) classifier exploits the statistical
-    /// difference between the two buttons. Empirical measurement in default mode (where
-    /// buttons are cleanly identified) showed:
-    ///   - Barrel button (upper physical): produces bit 3 ~99% of the time, bit 4 ~1%
-    ///   - Pick button (lower physical):   produces bit 3 ~8% of the time, bit 4 ~92%
+    /// These match the initialization sequence used by the yamato6537/waltop-linux
+    /// kernel driver. The autogain and filter commands may improve EMR signal quality.
     ///
-    /// When a button press begins (any side-button bit set after idle), the classifier accumulates
-    /// a log-likelihood ratio from decisive reports only. Mixed frames (both bits set) are treated
-    /// as ambiguous and do not bias the decision. Until enough decisive observations are gathered
-    /// and the ratio exceeds the confidence threshold, side-button output is intentionally
-    /// suppressed to avoid false binding edges. Once the threshold is crossed, the button identity
-    /// is locked until a short release hysteresis expires or the pen leaves range.
+    /// In tablet mode, pen side buttons are encoded as individual bits in data[5]:
+    /// bit 3 and bit 4. The signal is noisy — the dominant bit identifies the button
+    /// (~92% of frames), but sporadic flips to the other bit occur (~8%).
+    ///
+    /// A simple majority-vote over the first few decisive frames locks the button
+    /// identity until release. This converges within 2-3 frames (~10-15ms at 200 RPS).
     /// </summary>
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public class WaltopSiriusReportParser : IReportParser<IDeviceReport>
     {
         private enum ButtonState { Idle, Classifying, LockedBarrel, LockedPick }
-        private enum Observation { None, Bit3Only, Bit4Only, Ambiguous }
 
-        // Log-likelihood ratio increments per observation, derived from empirical
-        // button signal distributions measured in default mode:
-        //   bit3 observation: log(P(bit3|barrel) / P(bit3|pick)) = log(0.99/0.08) = +2.516
-        //   bit4 observation: log(P(bit4|barrel) / P(bit4|pick)) = log(0.01/0.92) = -4.522
-        // Positive LLR = evidence for barrel, negative = evidence for pick.
-        private const double LlrBit3 = 2.516;
-        private const double LlrBit4 = -4.522;
-        private const double Threshold = 4.6; // ln(99) ≈ 4.6, corresponds to ~99% confidence
-        private const int MinimumDecisiveObservations = 3;
-        private const int ReleaseHysteresisFrames = 2;
+        private const int VotesNeeded = 3;
+        private const int ReleaseFrames = 2;
 
         private ButtonState _state = ButtonState.Idle;
-        private double _llr;
-        private int _decisiveObservations;
-        private int _clearFrames;
+        private int _bit3Count;
+        private int _bit4Count;
+        private int _clearCount;
 
         public IDeviceReport Parse(byte[] data)
         {
@@ -63,12 +48,13 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
 
                     if (!inRange)
                     {
-                        ResetClassifier();
+                        _state = ButtonState.Idle;
                         return new OutOfRangeReport(data);
                     }
 
-                    var observation = GetObservation(data[5]);
-                    bool anyButton = observation != Observation.None;
+                    bool bit3 = (data[5] & 0x08) != 0;
+                    bool bit4 = (data[5] & 0x10) != 0;
+                    bool anyButton = bit3 || bit4;
 
                     bool reportBarrel = false;
                     bool reportPick = false;
@@ -78,34 +64,33 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
                         case ButtonState.Idle:
                             if (anyButton)
                             {
+                                _bit3Count = 0;
+                                _bit4Count = 0;
+                                _clearCount = 0;
                                 _state = ButtonState.Classifying;
-                                _llr = 0;
                                 goto case ButtonState.Classifying;
                             }
                             break;
 
                         case ButtonState.Classifying:
-                            if (observation == Observation.None)
+                            if (!anyButton)
                             {
-                                if (++_clearFrames >= ReleaseHysteresisFrames)
-                                    ResetClassifier();
+                                if (++_clearCount >= ReleaseFrames)
+                                    _state = ButtonState.Idle;
                                 break;
                             }
 
-                            _clearFrames = 0;
+                            _clearCount = 0;
 
-                            if (observation == Observation.Ambiguous)
-                                break;
+                            if (bit3 && !bit4) _bit3Count++;
+                            if (bit4 && !bit3) _bit4Count++;
 
-                            _decisiveObservations++;
-                            _llr += observation == Observation.Bit4Only ? LlrBit4 : LlrBit3;
-
-                            if (_decisiveObservations >= MinimumDecisiveObservations && _llr >= Threshold)
+                            if (_bit3Count >= VotesNeeded)
                             {
                                 _state = ButtonState.LockedBarrel;
                                 reportBarrel = true;
                             }
-                            else if (_decisiveObservations >= MinimumDecisiveObservations && _llr <= -Threshold)
+                            else if (_bit4Count >= VotesNeeded)
                             {
                                 _state = ButtonState.LockedPick;
                                 reportPick = true;
@@ -113,31 +98,31 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
                             break;
 
                         case ButtonState.LockedBarrel:
-                            if (observation == Observation.None)
+                            if (!anyButton)
                             {
-                                if (++_clearFrames >= ReleaseHysteresisFrames)
-                                    ResetClassifier();
+                                if (++_clearCount >= ReleaseFrames)
+                                    _state = ButtonState.Idle;
                                 else
                                     reportBarrel = true;
                             }
                             else
                             {
-                                _clearFrames = 0;
+                                _clearCount = 0;
                                 reportBarrel = true;
                             }
                             break;
 
                         case ButtonState.LockedPick:
-                            if (observation == Observation.None)
+                            if (!anyButton)
                             {
-                                if (++_clearFrames >= ReleaseHysteresisFrames)
-                                    ResetClassifier();
+                                if (++_clearCount >= ReleaseFrames)
+                                    _state = ButtonState.Idle;
                                 else
                                     reportPick = true;
                             }
                             else
                             {
-                                _clearFrames = 0;
+                                _clearCount = 0;
                                 reportPick = true;
                             }
                             break;
@@ -145,8 +130,8 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
 
                     byte classifiedFlags = (byte)(
                         (data[5] & 0x07) |           // preserve proximity (bits 0-1) + tip (bit 2)
-                        (reportBarrel ? 0x08 : 0) |  // bit 3 = barrel
-                        (reportPick ? 0x10 : 0)      // bit 4 = pick
+                        (reportBarrel ? 0x08 : 0) |  // bit 3 = barrel (upper button)
+                        (reportPick ? 0x10 : 0)      // bit 4 = pick (lower button)
                     );
 
                     return new WaltopSiriusTabletReport(data, classifiedFlags);
@@ -159,25 +144,6 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
                 default:
                     return new DeviceReport(data);
             }
-        }
-
-        private void ResetClassifier()
-        {
-            _state = ButtonState.Idle;
-            _llr = 0;
-            _decisiveObservations = 0;
-            _clearFrames = 0;
-        }
-
-        private static Observation GetObservation(byte flags)
-        {
-            return (flags & 0x18) switch
-            {
-                0x08 => Observation.Bit3Only,
-                0x10 => Observation.Bit4Only,
-                0x18 => Observation.Ambiguous,
-                _ => Observation.None
-            };
         }
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusReportParser.cs
@@ -13,10 +13,9 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
     /// the firmware correctly encodes this as a 2-bit enumeration (values 2=barrel, 3=pick).
     ///
     /// However, in tablet mode (Report ID 0x02, required for 4000 LPI), the firmware encodes
-    /// buttons as individual bits (data[5] bit 3 and bit 4). Because the EMR signal is
-    /// inherently ambiguous between the two button states, the firmware produces a noisy
-    /// alternating pattern on both bits — making it appear as if neither button can be
-    /// reliably identified from a single report.
+    /// buttons as individual bits (data[5] bit 3 and bit 4). In practice the pen can still
+    /// emit mixed frames at press onset (including both bits set), so button identity cannot
+    /// be trusted from a single report.
     ///
     /// Solution:
     /// A Sequential Probability Ratio Test (SPRT) classifier exploits the statistical
@@ -25,17 +24,18 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
     ///   - Barrel button (upper physical): produces bit 3 ~99% of the time, bit 4 ~1%
     ///   - Pick button (lower physical):   produces bit 3 ~8% of the time, bit 4 ~92%
     ///
-    /// When a button press begins (any button bit set after idle), the classifier accumulates
-    /// a log-likelihood ratio from each report. Until the ratio exceeds a confidence threshold,
-    /// side-button output is intentionally suppressed to avoid false binding edges. Once the
-    /// threshold is crossed, the button identity is locked until release (all button bits clear).
-    /// This typically converges within 2-5 reports (~10-25ms at 200 RPS), well below
-    /// perceptible latency.
+    /// When a button press begins (any side-button bit set after idle), the classifier accumulates
+    /// a log-likelihood ratio from decisive reports only. Mixed frames (both bits set) are treated
+    /// as ambiguous and do not bias the decision. Until enough decisive observations are gathered
+    /// and the ratio exceeds the confidence threshold, side-button output is intentionally
+    /// suppressed to avoid false binding edges. Once the threshold is crossed, the button identity
+    /// is locked until a short release hysteresis expires or the pen leaves range.
     /// </summary>
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public class WaltopSiriusReportParser : IReportParser<IDeviceReport>
     {
         private enum ButtonState { Idle, Classifying, LockedBarrel, LockedPick }
+        private enum Observation { None, Bit3Only, Bit4Only, Ambiguous }
 
         // Log-likelihood ratio increments per observation, derived from empirical
         // button signal distributions measured in default mode:
@@ -45,9 +45,13 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
         private const double LlrBit3 = 2.516;
         private const double LlrBit4 = -4.522;
         private const double Threshold = 4.6; // ln(99) ≈ 4.6, corresponds to ~99% confidence
+        private const int MinimumDecisiveObservations = 3;
+        private const int ReleaseHysteresisFrames = 2;
 
         private ButtonState _state = ButtonState.Idle;
         private double _llr;
+        private int _decisiveObservations;
+        private int _clearFrames;
 
         public IDeviceReport Parse(byte[] data)
         {
@@ -63,9 +67,8 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
                         return new OutOfRangeReport(data);
                     }
 
-                    bool bit3 = (data[5] & 0x08) != 0;
-                    bool bit4 = (data[5] & 0x10) != 0;
-                    bool anyButton = bit3 || bit4;
+                    var observation = GetObservation(data[5]);
+                    bool anyButton = observation != Observation.None;
 
                     bool reportBarrel = false;
                     bool reportPick = false;
@@ -82,18 +85,27 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
                             break;
 
                         case ButtonState.Classifying:
-                            if (!anyButton)
+                            if (observation == Observation.None)
                             {
-                                ResetClassifier();
+                                if (++_clearFrames >= ReleaseHysteresisFrames)
+                                    ResetClassifier();
                                 break;
                             }
-                            _llr += bit4 ? LlrBit4 : LlrBit3;
-                            if (_llr >= Threshold)
+
+                            _clearFrames = 0;
+
+                            if (observation == Observation.Ambiguous)
+                                break;
+
+                            _decisiveObservations++;
+                            _llr += observation == Observation.Bit4Only ? LlrBit4 : LlrBit3;
+
+                            if (_decisiveObservations >= MinimumDecisiveObservations && _llr >= Threshold)
                             {
                                 _state = ButtonState.LockedBarrel;
                                 reportBarrel = true;
                             }
-                            else if (_llr <= -Threshold)
+                            else if (_decisiveObservations >= MinimumDecisiveObservations && _llr <= -Threshold)
                             {
                                 _state = ButtonState.LockedPick;
                                 reportPick = true;
@@ -101,17 +113,33 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
                             break;
 
                         case ButtonState.LockedBarrel:
-                            if (!anyButton)
-                                ResetClassifier();
+                            if (observation == Observation.None)
+                            {
+                                if (++_clearFrames >= ReleaseHysteresisFrames)
+                                    ResetClassifier();
+                                else
+                                    reportBarrel = true;
+                            }
                             else
+                            {
+                                _clearFrames = 0;
                                 reportBarrel = true;
+                            }
                             break;
 
                         case ButtonState.LockedPick:
-                            if (!anyButton)
-                                ResetClassifier();
+                            if (observation == Observation.None)
+                            {
+                                if (++_clearFrames >= ReleaseHysteresisFrames)
+                                    ResetClassifier();
+                                else
+                                    reportPick = true;
+                            }
                             else
+                            {
+                                _clearFrames = 0;
                                 reportPick = true;
+                            }
                             break;
                     }
 
@@ -137,6 +165,19 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
         {
             _state = ButtonState.Idle;
             _llr = 0;
+            _decisiveObservations = 0;
+            _clearFrames = 0;
+        }
+
+        private static Observation GetObservation(byte flags)
+        {
+            return (flags & 0x18) switch
+            {
+                0x08 => Observation.Bit3Only,
+                0x10 => Observation.Bit4Only,
+                0x18 => Observation.Ambiguous,
+                _ => Observation.None
+            };
         }
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusReportParser.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using OpenTabletDriver.Plugin.Tablet;
 
@@ -6,20 +7,71 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public class WaltopSiriusReportParser : IReportParser<IDeviceReport>
     {
+        private const int ButtonBitsMask = 0x18; // bits 3-4 (barrel button — both map to same)
+        private const long DebounceMs = 30;
+
+        private int _stableButtons;
+        private int _pendingButtons;
+        private long _pendingTimestamp;
+        private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
+
         public IDeviceReport Parse(byte[] data)
         {
-            // Report ID 16 (0x10) = pen digitizer report
-            if (data[0] == 0x10 && data.Length >= 10)
+            switch (data[0])
             {
-                bool inRange = (data[1] & 0x10) != 0;
+                // Pen report (tablet mode, 4000 LPI)
+                case 0x02:
+                {
+                    bool inRange = (data[5] & 0x03) != 0;
 
-                if (!inRange)
-                    return new OutOfRangeReport(data);
+                    if (!inRange)
+                        return new OutOfRangeReport(data);
 
-                return new WaltopSiriusTabletReport(data);
+                    int rawButtons = data[5] & ButtonBitsMask;
+                    int debouncedButtons = Debounce(rawButtons);
+
+                    // Reconstruct flags: keep proximity/tip from raw, use debounced buttons
+                    byte debouncedFlags = (byte)((data[5] & ~ButtonBitsMask) | debouncedButtons);
+
+                    return new WaltopSiriusTabletReport(data, debouncedFlags);
+                }
+
+                // Frame button report
+                case 0x0A when data[1] == 0x0E:
+                    return new WaltopSiriusAuxReport(data);
+
+                default:
+                    return new DeviceReport(data);
+            }
+        }
+
+        private int Debounce(int rawButtons)
+        {
+            if (rawButtons == _stableButtons)
+            {
+                // No change from stable state; reset pending
+                _pendingButtons = rawButtons;
+                return _stableButtons;
             }
 
-            return new DeviceReport(data);
+            long now = _stopwatch.ElapsedMilliseconds;
+
+            if (rawButtons != _pendingButtons)
+            {
+                // New transition — start tracking
+                _pendingButtons = rawButtons;
+                _pendingTimestamp = now;
+                return _stableButtons;
+            }
+
+            // Same pending state — check if stable long enough
+            if (now - _pendingTimestamp >= DebounceMs)
+            {
+                _stableButtons = rawButtons;
+                return _stableButtons;
+            }
+
+            return _stableButtons;
         }
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusReportParser.cs
@@ -1,77 +1,141 @@
-using System.Diagnostics;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Configurations.Parsers.Waltop
 {
+    /// <summary>
+    /// Report parser for Waltop Sirius Battery Free Tablet in tablet mode (4000 LPI).
+    ///
+    /// Problem:
+    /// The pen uses EMR (electromagnetic resonance) where barrel buttons work by switching
+    /// capacitors into the pen's resonant circuit. Button states are physically mutually
+    /// exclusive — only one button can be active at a time. In default mode (Report ID 0x10),
+    /// the firmware correctly encodes this as a 2-bit enumeration (values 2=barrel, 3=pick).
+    ///
+    /// However, in tablet mode (Report ID 0x02, required for 4000 LPI), the firmware encodes
+    /// buttons as individual bits (data[5] bit 3 and bit 4). Because the EMR signal is
+    /// inherently ambiguous between the two button states, the firmware produces a noisy
+    /// alternating pattern on both bits — making it appear as if neither button can be
+    /// reliably identified from a single report.
+    ///
+    /// Solution:
+    /// A Sequential Probability Ratio Test (SPRT) classifier exploits the statistical
+    /// difference between the two buttons. Empirical measurement in default mode (where
+    /// buttons are cleanly identified) showed:
+    ///   - Barrel button (upper physical): produces bit 3 ~99% of the time, bit 4 ~1%
+    ///   - Pick button (lower physical):   produces bit 3 ~8% of the time, bit 4 ~92%
+    ///
+    /// When a button press begins (any button bit set after idle), the classifier accumulates
+    /// a log-likelihood ratio from each report. Once the ratio exceeds a confidence threshold,
+    /// the button identity is locked until release (all button bits clear). This typically
+    /// converges within 2-5 reports (~10-25ms at 200 RPS), well below perceptible latency.
+    /// </summary>
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public class WaltopSiriusReportParser : IReportParser<IDeviceReport>
     {
-        private const int ButtonBitsMask = 0x18; // bits 3-4 (barrel button — both map to same)
-        private const long DebounceMs = 30;
+        private enum ButtonState { Idle, Classifying, LockedBarrel, LockedPick }
 
-        private int _stableButtons;
-        private int _pendingButtons;
-        private long _pendingTimestamp;
-        private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
+        // Log-likelihood ratio increments per observation, derived from empirical
+        // button signal distributions measured in default mode:
+        //   bit3 observation: log(P(bit3|barrel) / P(bit3|pick)) = log(0.99/0.08) = +2.516
+        //   bit4 observation: log(P(bit4|barrel) / P(bit4|pick)) = log(0.01/0.92) = -4.522
+        // Positive LLR = evidence for barrel, negative = evidence for pick.
+        private const double LlrBit3 = 2.516;
+        private const double LlrBit4 = -4.522;
+        private const double Threshold = 4.6; // ln(99) ≈ 4.6, corresponds to ~99% confidence
+
+        private ButtonState _state = ButtonState.Idle;
+        private double _llr;
 
         public IDeviceReport Parse(byte[] data)
         {
             switch (data[0])
             {
-                // Pen report (tablet mode, 4000 LPI)
                 case 0x02:
                 {
                     bool inRange = (data[5] & 0x03) != 0;
 
                     if (!inRange)
+                    {
+                        _state = ButtonState.Idle;
                         return new OutOfRangeReport(data);
+                    }
 
-                    int rawButtons = data[5] & ButtonBitsMask;
-                    int debouncedButtons = Debounce(rawButtons);
+                    bool bit3 = (data[5] & 0x08) != 0;
+                    bool bit4 = (data[5] & 0x10) != 0;
+                    bool anyButton = bit3 || bit4;
 
-                    // Reconstruct flags: keep proximity/tip from raw, use debounced buttons
-                    byte debouncedFlags = (byte)((data[5] & ~ButtonBitsMask) | debouncedButtons);
+                    bool reportBarrel = false;
+                    bool reportPick = false;
 
-                    return new WaltopSiriusTabletReport(data, debouncedFlags);
+                    switch (_state)
+                    {
+                        case ButtonState.Idle:
+                            if (anyButton)
+                            {
+                                _state = ButtonState.Classifying;
+                                _llr = 0;
+                                goto case ButtonState.Classifying;
+                            }
+                            break;
+
+                        case ButtonState.Classifying:
+                            if (!anyButton)
+                            {
+                                _state = ButtonState.Idle;
+                                break;
+                            }
+                            _llr += bit4 ? LlrBit4 : LlrBit3;
+                            if (_llr >= Threshold)
+                            {
+                                _state = ButtonState.LockedBarrel;
+                                reportBarrel = true;
+                            }
+                            else if (_llr <= -Threshold)
+                            {
+                                _state = ButtonState.LockedPick;
+                                reportPick = true;
+                            }
+                            else
+                            {
+                                // Not yet decided — provisionally report the more likely button
+                                reportBarrel = _llr > 0;
+                                reportPick = _llr <= 0;
+                            }
+                            break;
+
+                        case ButtonState.LockedBarrel:
+                            if (!anyButton)
+                                _state = ButtonState.Idle;
+                            else
+                                reportBarrel = true;
+                            break;
+
+                        case ButtonState.LockedPick:
+                            if (!anyButton)
+                                _state = ButtonState.Idle;
+                            else
+                                reportPick = true;
+                            break;
+                    }
+
+                    byte classifiedFlags = (byte)(
+                        (data[5] & 0x07) |           // preserve proximity (bits 0-1) + tip (bit 2)
+                        (reportBarrel ? 0x08 : 0) |  // bit 3 = barrel
+                        (reportPick ? 0x10 : 0)      // bit 4 = pick
+                    );
+
+                    return new WaltopSiriusTabletReport(data, classifiedFlags);
                 }
 
-                // Frame button report
+                // Frame button report (tablet mode only)
                 case 0x0A when data[1] == 0x0E:
                     return new WaltopSiriusAuxReport(data);
 
                 default:
                     return new DeviceReport(data);
             }
-        }
-
-        private int Debounce(int rawButtons)
-        {
-            if (rawButtons == _stableButtons)
-            {
-                // No change from stable state; reset pending
-                _pendingButtons = rawButtons;
-                return _stableButtons;
-            }
-
-            long now = _stopwatch.ElapsedMilliseconds;
-
-            if (rawButtons != _pendingButtons)
-            {
-                // New transition — start tracking
-                _pendingButtons = rawButtons;
-                _pendingTimestamp = now;
-                return _stableButtons;
-            }
-
-            // Same pending state — check if stable long enough
-            if (now - _pendingTimestamp >= DebounceMs)
-            {
-                _stableButtons = rawButtons;
-                return _stableButtons;
-            }
-
-            return _stableButtons;
         }
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusReportParser.cs
@@ -141,6 +141,19 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
                 case 0x0A when data[1] == 0x0E:
                     return new WaltopSiriusAuxReport(data);
 
+                // Dial reports: scroll (0x02), zoom (0x03), volume (0x04)
+                // Same data layout, firmware switches subreport based on mode
+                case 0x0A when data[1] >= 0x02 && data[1] <= 0x04:
+                    return new WaltopSiriusDialReport(data);
+
+                // Keyboard-direction dial report (arrow keys / navigation keys)
+                case 0x0D:
+                    return new WaltopSiriusKeyDialReport(data);
+
+                // Border location report (K1-K10 virtual buttons on top edge)
+                case 0x05:
+                    return new WaltopSiriusBorderReport(data);
+
                 default:
                     return new DeviceReport(data);
             }

--- a/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusReportParser.cs
@@ -24,12 +24,17 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
     ///
     /// A simple majority-vote over the first few decisive frames locks the button
     /// identity until release. This converges within 2-3 frames (~10-15ms at 200 RPS).
+    ///
+    /// The parser also tracks the "subfunction switch" toggle from frame reports (0x0E)
+    /// and routes dial positions to different wheel indices based on subreport ID and
+    /// switch state, allowing users to assign separate wheel bindings per mode.
     /// </summary>
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public class WaltopSiriusReportParser : IReportParser<IDeviceReport>
     {
         private enum ButtonState { Idle, Classifying, LockedBarrel, LockedPick }
 
+        // SPRT button classifier
         private const int VotesNeeded = 3;
         private const int ReleaseFrames = 2;
 
@@ -37,6 +42,8 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
         private int _bit3Count;
         private int _bit4Count;
         private int _clearCount;
+        private bool _subfunctionSwitch;
+        private bool _subfunctionBitPrev;
 
         public IDeviceReport Parse(byte[] data)
         {
@@ -139,12 +146,18 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
 
                 // Frame button report (tablet mode only)
                 case 0x0A when data[1] == 0x0E:
+                {
+                    bool subfunctionBit = (data[3] & 0x20) != 0;
+                    if (subfunctionBit && !_subfunctionBitPrev)
+                        _subfunctionSwitch = !_subfunctionSwitch;
+                    _subfunctionBitPrev = subfunctionBit;
                     return new WaltopSiriusAuxReport(data);
+                }
 
                 // Dial reports: scroll (0x02), zoom (0x03), volume (0x04)
                 // Same data layout, firmware switches subreport based on mode
                 case 0x0A when data[1] >= 0x02 && data[1] <= 0x04:
-                    return new WaltopSiriusDialReport(data);
+                    return new WaltopSiriusDialReport(data, _subfunctionSwitch);
 
                 // Keyboard-direction dial report (arrow keys / navigation keys)
                 case 0x0D:

--- a/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusReportParser.cs
@@ -1,0 +1,25 @@
+using System.Diagnostics.CodeAnalysis;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Waltop
+{
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    public class WaltopSiriusReportParser : IReportParser<IDeviceReport>
+    {
+        public IDeviceReport Parse(byte[] data)
+        {
+            // Report ID 16 (0x10) = pen digitizer report
+            if (data[0] == 0x10 && data.Length >= 10)
+            {
+                bool inRange = (data[1] & 0x10) != 0;
+
+                if (!inRange)
+                    return new OutOfRangeReport(data);
+
+                return new WaltopSiriusTabletReport(data);
+            }
+
+            return new DeviceReport(data);
+        }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusTabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusTabletReport.cs
@@ -4,25 +4,41 @@ using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Configurations.Parsers.Waltop
 {
-    public struct WaltopSiriusTabletReport : ITabletReport, ITiltReport, IEraserReport
+    /// <summary>
+    /// Pen report for Waltop Sirius Battery Free Tablet in tablet mode (Report ID 0x02).
+    /// Tablet mode is activated by sending feature report {0x10, 0x01} on report ID 0x02,
+    /// which enables full 4000 LPI resolution.
+    ///
+    /// Byte layout (from DIGImend reverse engineering):
+    ///   data[0]    = Report ID (0x02)
+    ///   data[1:2]  = X position (uint16 LE, 0-40000)
+    ///   data[3:4]  = Y position (uint16 LE, 0-24000)
+    ///   data[5]    = Flags:
+    ///                  bits 0-1: Proximity (non-zero = in range)
+    ///                  bit 2:    Tip button
+    ///                  bit 3:    Lower side button
+    ///                  bit 4:    Upper side button
+    ///                  bits 5-7: Padding
+    ///   data[6:7]  = Tip pressure (uint16 LE, 0-1023)
+    ///   data[8]    = X tilt
+    ///   data[9]    = Y tilt
+    /// </summary>
+    public struct WaltopSiriusTabletReport : ITabletReport, ITiltReport
     {
-        public WaltopSiriusTabletReport(byte[] report)
+        public WaltopSiriusTabletReport(byte[] report, byte debouncedFlags)
         {
             Raw = report;
 
-            // Lower 2 bits of flags are a 2-bit enumeration:
-            //   0 = no button, 1 = tip, 2 = barrel (button 1), 3 = tablet pick (button 2)
-            int buttonEnum = report[1] & 0x03;
-            bool tipSwitch = buttonEnum == 1;
+            bool tipSwitch = (debouncedFlags & 0x04) != 0;
 
             Position = new Vector2
             {
-                X = Unsafe.ReadUnaligned<ushort>(ref report[2]),
-                Y = Unsafe.ReadUnaligned<ushort>(ref report[4])
+                X = Unsafe.ReadUnaligned<ushort>(ref report[1]),
+                Y = Unsafe.ReadUnaligned<ushort>(ref report[3])
             };
 
-            // Only report pressure when tip is touching; device reports baseline ~5 on hover.
-            // Zero pressure when barrel buttons are pressed (matches Linux hid-waltop.c).
+            // Only report pressure when tip is touching; device reports
+            // a baseline pressure during hover that must be zeroed.
             Pressure = tipSwitch ? Unsafe.ReadUnaligned<ushort>(ref report[6]) : 0u;
 
             Tilt = new Vector2
@@ -31,12 +47,13 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
                 Y = (sbyte)(-report[9])
             };
 
-            Eraser = (report[1] & 0x08) != 0;
-
+            // The pen has two physical side buttons but they share a common
+            // electrical contact — the hardware alternates between bit 3 and
+            // bit 4 for either button. Merge into a single barrel button,
+            // matching the Linux hid-waltop.c approach: (data[1] & 0xF) > 1.
             PenButtons = new bool[]
             {
-                buttonEnum == 2, // barrel switch (side button 1)
-                buttonEnum == 3, // tablet pick (side button 2)
+                (debouncedFlags & 0x18) != 0, // bits 3-4 = barrel button (either side button)
             };
         }
 
@@ -44,7 +61,6 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
         public Vector2 Position { set; get; }
         public uint Pressure { set; get; }
         public Vector2 Tilt { set; get; }
-        public bool Eraser { set; get; }
         public bool[] PenButtons { set; get; }
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusTabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusTabletReport.cs
@@ -9,27 +9,17 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
     /// Tablet mode is activated by sending feature report {0x10, 0x01} on report ID 0x02,
     /// which enables full 4000 LPI resolution.
     ///
-    /// Byte layout (from DIGImend reverse engineering):
-    ///   data[0]    = Report ID (0x02)
-    ///   data[1:2]  = X position (uint16 LE, 0-40000)
-    ///   data[3:4]  = Y position (uint16 LE, 0-24000)
-    ///   data[5]    = Flags:
-    ///                  bits 0-1: Proximity (non-zero = in range)
-    ///                  bit 2:    Tip button
-    ///                  bit 3:    Lower side button
-    ///                  bit 4:    Upper side button
-    ///                  bits 5-7: Padding
-    ///   data[6:7]  = Tip pressure (uint16 LE, 0-1023)
-    ///   data[8]    = X tilt
-    ///   data[9]    = Y tilt
+    /// The pen's EMR barrel buttons are physically mutually exclusive (capacitor switching)
+    /// but tablet mode encodes them as individual bits that produce noisy alternating signals.
+    /// The parser applies SPRT classification to reliably distinguish the two buttons.
     /// </summary>
     public struct WaltopSiriusTabletReport : ITabletReport, ITiltReport
     {
-        public WaltopSiriusTabletReport(byte[] report, byte debouncedFlags)
+        public WaltopSiriusTabletReport(byte[] report, byte classifiedFlags)
         {
             Raw = report;
 
-            bool tipSwitch = (debouncedFlags & 0x04) != 0;
+            bool tipSwitch = (classifiedFlags & 0x04) != 0;
 
             Position = new Vector2
             {
@@ -37,8 +27,6 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
                 Y = Unsafe.ReadUnaligned<ushort>(ref report[3])
             };
 
-            // Only report pressure when tip is touching; device reports
-            // a baseline pressure during hover that must be zeroed.
             Pressure = tipSwitch ? Unsafe.ReadUnaligned<ushort>(ref report[6]) : 0u;
 
             Tilt = new Vector2
@@ -47,13 +35,10 @@ namespace OpenTabletDriver.Configurations.Parsers.Waltop
                 Y = (sbyte)(-report[9])
             };
 
-            // The pen has two physical side buttons but they share a common
-            // electrical contact — the hardware alternates between bit 3 and
-            // bit 4 for either button. Merge into a single barrel button,
-            // matching the Linux hid-waltop.c approach: (data[1] & 0xF) > 1.
             PenButtons = new bool[]
             {
-                (debouncedFlags & 0x18) != 0, // bits 3-4 = barrel button (either side button)
+                (classifiedFlags & 0x08) != 0, // barrel (upper physical button)
+                (classifiedFlags & 0x10) != 0, // pick (lower physical button)
             };
         }
 

--- a/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusTabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Waltop/WaltopSiriusTabletReport.cs
@@ -1,0 +1,50 @@
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Waltop
+{
+    public struct WaltopSiriusTabletReport : ITabletReport, ITiltReport, IEraserReport
+    {
+        public WaltopSiriusTabletReport(byte[] report)
+        {
+            Raw = report;
+
+            // Lower 2 bits of flags are a 2-bit enumeration:
+            //   0 = no button, 1 = tip, 2 = barrel (button 1), 3 = tablet pick (button 2)
+            int buttonEnum = report[1] & 0x03;
+            bool tipSwitch = buttonEnum == 1;
+
+            Position = new Vector2
+            {
+                X = Unsafe.ReadUnaligned<ushort>(ref report[2]),
+                Y = Unsafe.ReadUnaligned<ushort>(ref report[4])
+            };
+
+            // Only report pressure when tip is touching; device reports baseline ~5 on hover.
+            // Zero pressure when barrel buttons are pressed (matches Linux hid-waltop.c).
+            Pressure = tipSwitch ? Unsafe.ReadUnaligned<ushort>(ref report[6]) : 0u;
+
+            Tilt = new Vector2
+            {
+                X = (sbyte)report[8],
+                Y = (sbyte)(-report[9])
+            };
+
+            Eraser = (report[1] & 0x08) != 0;
+
+            PenButtons = new bool[]
+            {
+                buttonEnum == 2, // barrel switch (side button 1)
+                buttonEnum == 3, // tablet pick (side button 2)
+            };
+        }
+
+        public byte[] Raw { set; get; }
+        public Vector2 Position { set; get; }
+        public uint Pressure { set; get; }
+        public Vector2 Tilt { set; get; }
+        public bool Eraser { set; get; }
+        public bool[] PenButtons { set; get; }
+    }
+}

--- a/OpenTabletDriver.Plugin/Tablet/ButtonSpecifications.cs
+++ b/OpenTabletDriver.Plugin/Tablet/ButtonSpecifications.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 namespace OpenTabletDriver.Plugin.Tablet
@@ -10,5 +11,10 @@ namespace OpenTabletDriver.Plugin.Tablet
         /// </summary>
         [Required(ErrorMessage = $"{nameof(ButtonCount)} must be defined")]
         public uint ButtonCount { set; get; }
+
+        /// <summary>
+        /// Optional human-readable names for buttons, indexed by button number.
+        /// </summary>
+        public List<string> ButtonNames { set; get; }
     }
 }

--- a/OpenTabletDriver.Plugin/Tablet/PenSpecifications.cs
+++ b/OpenTabletDriver.Plugin/Tablet/PenSpecifications.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Newtonsoft.Json;
 
@@ -18,6 +19,11 @@ namespace OpenTabletDriver.Plugin.Tablet
         [Required(ErrorMessage = $"{nameof(ButtonCount)} must be defined")]
         public uint ButtonCount { set; get; }
 
+        /// <summary>
+        /// Optional human-readable names for pen buttons, indexed by button number.
+        /// </summary>
+        public List<string> ButtonNames { set; get; }
+
         private bool _legacyButtonsHaveBeenSet;
 
         [Obsolete(Globals.LegacyTabletConfigurationProperty)]
@@ -28,8 +34,9 @@ namespace OpenTabletDriver.Plugin.Tablet
             {
                 _legacyButtonsHaveBeenSet = true;
                 ButtonCount = value.ButtonCount;
+                ButtonNames ??= value.ButtonNames;
             }
-            get => new() { ButtonCount = ButtonCount };
+            get => new() { ButtonCount = ButtonCount, ButtonNames = ButtonNames };
         }
 
         // hack which allows us to deserialize the object for backwards compatibility, but not emit it in serialization

--- a/OpenTabletDriver.Plugin/Tablet/WheelSpecifications.cs
+++ b/OpenTabletDriver.Plugin/Tablet/WheelSpecifications.cs
@@ -62,6 +62,17 @@ namespace OpenTabletDriver.Plugin.Tablet
         public float? AngleOfZeroReading { get; set; }
 
         /// <summary>
+        /// Optional human-readable name for this wheel, displayed in the UI.
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Optional group name for this wheel. Wheels sharing a group are displayed
+        /// together under a single tab in the UI. When unset, each wheel gets its own tab.
+        /// </summary>
+        public string? Group { get; set; }
+
+        /// <summary>
         /// Amount of buttons present on the wheel (usually between 0 and 2, inclusive)
         /// </summary>
         [Required(ErrorMessage = $"{nameof(ButtonCount)} must be defined")]

--- a/OpenTabletDriver.Tests/WheelTabLayoutTests.cs
+++ b/OpenTabletDriver.Tests/WheelTabLayoutTests.cs
@@ -1,0 +1,171 @@
+using OpenTabletDriver.Plugin.Tablet;
+using OpenTabletDriver.UX.Controls;
+using Xunit;
+
+namespace OpenTabletDriver.Tests
+{
+    public class WheelTabLayoutTests
+    {
+        [Fact]
+        public void Create_WithPlainLegacyWheelArray_KeepsStandaloneWheelTabs()
+        {
+            var tabs = WheelTabLayout.Create(
+            [
+                CreateWheel(),
+                CreateWheel()
+            ]);
+
+            Assert.Collection(tabs,
+                first =>
+                {
+                    Assert.False(first.IsGrouped);
+                    Assert.Equal("Wheel 1 Bindings", first.Text);
+                    var wheel = Assert.Single(first.Wheels);
+                    Assert.Equal(0, wheel.WheelIndex);
+                    Assert.Equal("Wheel 1", wheel.Title);
+                },
+                second =>
+                {
+                    Assert.False(second.IsGrouped);
+                    Assert.Equal("Wheel 2 Bindings", second.Text);
+                    var wheel = Assert.Single(second.Wheels);
+                    Assert.Equal(1, wheel.WheelIndex);
+                    Assert.Equal("Wheel 2", wheel.Title);
+                });
+        }
+
+        [Fact]
+        public void Create_WithNamedUngroupedWheels_UsesWheelNamesForStandaloneTabs()
+        {
+            var tabs = WheelTabLayout.Create(
+            [
+                CreateWheel(name: "Scroll"),
+                CreateWheel(name: "Zoom")
+            ]);
+
+            Assert.Collection(tabs,
+                first => Assert.Equal("Scroll Bindings", first.Text),
+                second => Assert.Equal("Zoom Bindings", second.Text));
+        }
+
+        [Fact]
+        public void Create_WithGroupedWheels_CollapsesSharedGroupsByFirstAppearance()
+        {
+            var tabs = WheelTabLayout.Create(
+            [
+                CreateWheel(name: "Scroll", group: "Left Dial"),
+                CreateWheel(name: "Scroll", group: "Right Dial"),
+                CreateWheel(name: "Multimedia", group: "Left Dial"),
+                CreateWheel(group: "Right Dial")
+            ]);
+
+            Assert.Collection(tabs,
+                left =>
+                {
+                    Assert.True(left.IsGrouped);
+                    Assert.Equal("Left Dial", left.Text);
+                    Assert.Collection(left.Wheels,
+                        first =>
+                        {
+                            Assert.Equal(0, first.WheelIndex);
+                            Assert.Equal("Scroll", first.Title);
+                        },
+                        second =>
+                        {
+                            Assert.Equal(2, second.WheelIndex);
+                            Assert.Equal("Multimedia", second.Title);
+                        });
+                },
+                right =>
+                {
+                    Assert.True(right.IsGrouped);
+                    Assert.Equal("Right Dial", right.Text);
+                    Assert.Collection(right.Wheels,
+                        first =>
+                        {
+                            Assert.Equal(1, first.WheelIndex);
+                            Assert.Equal("Scroll", first.Title);
+                        },
+                        second =>
+                        {
+                            Assert.Equal(3, second.WheelIndex);
+                            Assert.Equal("Wheel 4", second.Title);
+                        });
+                });
+        }
+
+        [Fact]
+        public void Create_WithMixedGroupedAndUngroupedWheels_PreservesWheelOrder()
+        {
+            var tabs = WheelTabLayout.Create(
+            [
+                CreateWheel(name: "Wheel A"),
+                CreateWheel(name: "Scroll", group: "Left Dial"),
+                CreateWheel(name: "Multimedia", group: "Left Dial"),
+                CreateWheel(name: "Wheel B"),
+                CreateWheel(name: "Scroll", group: "Right Dial")
+            ]);
+
+            Assert.Collection(tabs,
+                first =>
+                {
+                    Assert.False(first.IsGrouped);
+                    Assert.Equal("Wheel A Bindings", first.Text);
+                    Assert.Equal(0, Assert.Single(first.Wheels).WheelIndex);
+                },
+                second =>
+                {
+                    Assert.True(second.IsGrouped);
+                    Assert.Equal("Left Dial", second.Text);
+                    Assert.Collection(second.Wheels,
+                        firstWheel => Assert.Equal(1, firstWheel.WheelIndex),
+                        secondWheel => Assert.Equal(2, secondWheel.WheelIndex));
+                },
+                third =>
+                {
+                    Assert.False(third.IsGrouped);
+                    Assert.Equal("Wheel B Bindings", third.Text);
+                    Assert.Equal(3, Assert.Single(third.Wheels).WheelIndex);
+                },
+                fourth =>
+                {
+                    Assert.True(fourth.IsGrouped);
+                    Assert.Equal("Right Dial", fourth.Text);
+                    Assert.Equal(4, Assert.Single(fourth.Wheels).WheelIndex);
+                });
+        }
+
+        [Fact]
+        public void Create_WithWhitespaceGroup_TreatsWheelAsUngrouped()
+        {
+            var tabs = WheelTabLayout.Create(
+            [
+                CreateWheel(group: "  "),
+                CreateWheel(name: "Scroll", group: "Left Dial")
+            ]);
+
+            Assert.Collection(tabs,
+                first =>
+                {
+                    Assert.False(first.IsGrouped);
+                    Assert.Equal("Wheel 1 Bindings", first.Text);
+                },
+                second =>
+                {
+                    Assert.True(second.IsGrouped);
+                    Assert.Equal("Left Dial", second.Text);
+                });
+        }
+
+        private static WheelSpecifications CreateWheel(string? name = null, string? group = null)
+        {
+            return new WheelSpecifications
+            {
+                AbsoluteWheelMax = 7,
+                ButtonCount = 0,
+                Name = name,
+                Group = group
+            };
+        }
+    }
+}

--- a/OpenTabletDriver.UX/Controls/Bindings/AuxiliaryBindingEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/AuxiliaryBindingEditor.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Eto.Forms;
 using OpenTabletDriver.Desktop.Reflection;
+using OpenTabletDriver.Plugin.Tablet;
 using OpenTabletDriver.UX.Controls.Generic;
 
 namespace OpenTabletDriver.UX.Controls.Bindings
@@ -31,6 +32,13 @@ namespace OpenTabletDriver.UX.Controls.Bindings
             };
 
             auxButtons.ItemSourceBinding.Bind(SettingsBinding.Child(c => (IList<PluginSettingStore>)c.AuxButtons));
+        }
+
+        public void SetButtonNames(ButtonSpecifications specs)
+        {
+            var names = specs?.ButtonNames;
+            Plugin.Log.Write("AuxEditor", $"SetButtonNames called: {names?.Count ?? 0} names, ItemSource={auxButtons.ItemSource?.Count ?? -1}");
+            auxButtons.ButtonNames = names;
         }
 
         private BindingDisplayList auxButtons;

--- a/OpenTabletDriver.UX/Controls/Bindings/AuxiliaryBindingEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/AuxiliaryBindingEditor.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 using Eto.Forms;
 using OpenTabletDriver.Desktop.Reflection;
+using OpenTabletDriver.Desktop.RPC;
 using OpenTabletDriver.Plugin.Tablet;
 using OpenTabletDriver.UX.Controls.Generic;
 
@@ -36,11 +38,58 @@ namespace OpenTabletDriver.UX.Controls.Bindings
 
         public void SetButtonNames(ButtonSpecifications specs)
         {
-            var names = specs?.ButtonNames;
-            Plugin.Log.Write("AuxEditor", $"SetButtonNames called: {names?.Count ?? 0} names, ItemSource={auxButtons.ItemSource?.Count ?? -1}");
-            auxButtons.ButtonNames = names;
+            auxButtons.ButtonNames = specs?.ButtonNames;
+            _hasAuxButtons = specs != null;
+        }
+
+        public void SetVisible(bool visible)
+        {
+            if (visible && _hasAuxButtons)
+                EnableDebug();
+            else
+                DisableDebug();
+        }
+
+        protected override void OnUnLoad(EventArgs e)
+        {
+            DisableDebug();
+            base.OnUnLoad(e);
+        }
+
+        private void EnableDebug()
+        {
+            if (!_debugActive)
+            {
+                _debugActive = true;
+                App.Driver.DeviceReport += OnDeviceReport;
+                _ = App.Driver.Instance.SetTabletDebug(true);
+            }
+        }
+
+        private void DisableDebug()
+        {
+            if (_debugActive)
+            {
+                _debugActive = false;
+                App.Driver.DeviceReport -= OnDeviceReport;
+                _ = App.Driver.Instance.SetTabletDebug(false);
+            }
+        }
+
+        private void OnDeviceReport(object sender, DebugReportData data)
+        {
+            if (data.ToObject() is IAuxReport auxReport)
+            {
+                for (int i = 0; i < auxReport.AuxButtons.Length; i++)
+                {
+                    if (auxReport.AuxButtons[i])
+                        auxButtons.HighlightItem(i);
+                }
+            }
         }
 
         private BindingDisplayList auxButtons;
+        private bool _hasAuxButtons;
+        private bool _debugActive;
     }
 }

--- a/OpenTabletDriver.UX/Controls/Bindings/BindingDisplayList.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/BindingDisplayList.cs
@@ -99,18 +99,35 @@ namespace OpenTabletDriver.UX.Controls.Bindings
         private void UpdateItemColor(int index)
         {
             var control = layout.Items[index].Control;
+            var bg = SystemColors.ControlBackground;
 
             if (_highlightAlpha[index] > 0.01f)
             {
-                var bg = SystemColors.ControlBackground;
-                control.BackgroundColor = new Color(
-                    1f - bg.R, 1f - bg.G, 1f - bg.B,
-                    _highlightAlpha[index] * 0.5f
+                var a = _highlightAlpha[index] * 0.5f;
+
+                // Pre-blend against background — GTK ignores alpha on BackgroundColor
+                var blended = new Color(
+                    bg.R + (1f - bg.R) * a,
+                    bg.G + (1f - bg.G) * a,
+                    bg.B + (1f - bg.B) * a
                 );
+
+                // Group wraps content in a GroupBox; target that instead of the outer Panel
+                if (control is Panel panel && panel.Content is GroupBox innerBox)
+                    innerBox.BackgroundColor = blended;
+                else if (control is Panel panel2 && panel2.Content is Panel innerPanel)
+                    innerPanel.BackgroundColor = blended;
+                else
+                    control.BackgroundColor = blended;
             }
             else
             {
-                control.BackgroundColor = Colors.Transparent;
+                if (control is Panel panel && panel.Content is GroupBox innerBox)
+                    innerBox.BackgroundColor = bg;
+                else if (control is Panel panel2 && panel2.Content is Panel innerPanel)
+                    innerPanel.BackgroundColor = Colors.Transparent;
+                else
+                    control.BackgroundColor = Colors.Transparent;
             }
         }
 

--- a/OpenTabletDriver.UX/Controls/Bindings/BindingDisplayList.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/BindingDisplayList.cs
@@ -1,8 +1,11 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using Eto.Drawing;
 using Eto.Forms;
 using OpenTabletDriver.Desktop.Reflection;
 using OpenTabletDriver.UX.Controls.Generic;
+using OpenTabletDriver.UX.Tools;
 
 namespace OpenTabletDriver.UX.Controls.Bindings
 {
@@ -43,5 +46,83 @@ namespace OpenTabletDriver.UX.Controls.Bindings
                 Content = display
             };
         }
+
+        #region Highlight Animation
+
+        private const float DecayRate = 0.03f;
+
+        private float[] _highlightAlpha;
+        private bool _animating;
+
+        public void HighlightItem(int index)
+        {
+            if (index < 0 || index >= layout.Items.Count)
+                return;
+
+            if (_highlightAlpha == null || _highlightAlpha.Length != layout.Items.Count)
+                _highlightAlpha = new float[layout.Items.Count];
+
+            _highlightAlpha[index] = 1.0f;
+            UpdateItemColor(index);
+
+            if (!_animating)
+            {
+                _animating = true;
+                CompositionScheduler.Register(OnHighlightTick);
+            }
+        }
+
+        private void OnHighlightTick(object sender, EventArgs e)
+        {
+            if (_highlightAlpha == null)
+            {
+                StopAnimation();
+                return;
+            }
+
+            bool anyActive = false;
+            for (int i = 0; i < _highlightAlpha.Length && i < layout.Items.Count; i++)
+            {
+                if (_highlightAlpha[i] > 0)
+                {
+                    _highlightAlpha[i] = Math.Max(0, _highlightAlpha[i] - DecayRate);
+                    UpdateItemColor(i);
+                    if (_highlightAlpha[i] > 0)
+                        anyActive = true;
+                }
+            }
+
+            if (!anyActive)
+                StopAnimation();
+        }
+
+        private void UpdateItemColor(int index)
+        {
+            var control = layout.Items[index].Control;
+
+            if (_highlightAlpha[index] > 0.01f)
+            {
+                var bg = SystemColors.ControlBackground;
+                control.BackgroundColor = new Color(
+                    1f - bg.R, 1f - bg.G, 1f - bg.B,
+                    _highlightAlpha[index] * 0.5f
+                );
+            }
+            else
+            {
+                control.BackgroundColor = Colors.Transparent;
+            }
+        }
+
+        private void StopAnimation()
+        {
+            if (_animating)
+            {
+                _animating = false;
+                CompositionScheduler.Unregister(OnHighlightTick);
+            }
+        }
+
+        #endregion
     }
 }

--- a/OpenTabletDriver.UX/Controls/Bindings/BindingDisplayList.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/BindingDisplayList.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Collections.Specialized;
 using Eto.Forms;
 using OpenTabletDriver.Desktop.Reflection;
 using OpenTabletDriver.UX.Controls.Generic;
@@ -8,8 +10,23 @@ namespace OpenTabletDriver.UX.Controls.Bindings
     {
         public string Prefix { set; get; }
 
+        private IList<string> _buttonNames;
+        public IList<string> ButtonNames
+        {
+            set
+            {
+                _buttonNames = value;
+                if (ItemSource != null)
+                    HandleCollectionChanged(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+            }
+            get => _buttonNames;
+        }
+
         protected virtual string GetTextForIndex(int index)
         {
+            if (_buttonNames != null && index < _buttonNames.Count
+                && !string.IsNullOrEmpty(_buttonNames[index]))
+                return _buttonNames[index];
             return $"{Prefix} {index + 1}";
         }
 

--- a/OpenTabletDriver.UX/Controls/Bindings/BindingDisplayList.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/BindingDisplayList.cs
@@ -52,6 +52,7 @@ namespace OpenTabletDriver.UX.Controls.Bindings
         private const float DecayRate = 0.03f;
 
         private float[] _highlightAlpha;
+        private Color[] _originalColors;
         private bool _animating;
 
         public void HighlightItem(int index)
@@ -96,38 +97,44 @@ namespace OpenTabletDriver.UX.Controls.Bindings
                 StopAnimation();
         }
 
+        private Control GetColorTarget(Control control)
+        {
+            if (control is Panel panel && panel.Content is GroupBox innerBox)
+                return innerBox;
+            if (control is Panel panel2 && panel2.Content is Panel innerPanel)
+                return innerPanel;
+            return control;
+        }
+
+        private void CaptureOriginalColors()
+        {
+            _originalColors = new Color[layout.Items.Count];
+            for (int i = 0; i < layout.Items.Count; i++)
+                _originalColors[i] = GetColorTarget(layout.Items[i].Control).BackgroundColor;
+        }
+
         private void UpdateItemColor(int index)
         {
-            var control = layout.Items[index].Control;
-            var bg = SystemColors.ControlBackground;
+            if (_originalColors == null || _originalColors.Length != layout.Items.Count)
+                CaptureOriginalColors();
+
+            var target = GetColorTarget(layout.Items[index].Control);
+            var bg = _originalColors[index];
 
             if (_highlightAlpha[index] > 0.01f)
             {
                 var a = _highlightAlpha[index] * 0.5f;
 
                 // Pre-blend against background — GTK ignores alpha on BackgroundColor
-                var blended = new Color(
+                target.BackgroundColor = new Color(
                     bg.R + (1f - bg.R) * a,
                     bg.G + (1f - bg.G) * a,
                     bg.B + (1f - bg.B) * a
                 );
-
-                // Group wraps content in a GroupBox; target that instead of the outer Panel
-                if (control is Panel panel && panel.Content is GroupBox innerBox)
-                    innerBox.BackgroundColor = blended;
-                else if (control is Panel panel2 && panel2.Content is Panel innerPanel)
-                    innerPanel.BackgroundColor = blended;
-                else
-                    control.BackgroundColor = blended;
             }
             else
             {
-                if (control is Panel panel && panel.Content is GroupBox innerBox)
-                    innerBox.BackgroundColor = bg;
-                else if (control is Panel panel2 && panel2.Content is Panel innerPanel)
-                    innerPanel.BackgroundColor = Colors.Transparent;
-                else
-                    control.BackgroundColor = Colors.Transparent;
+                target.BackgroundColor = bg;
             }
         }
 

--- a/OpenTabletDriver.UX/Controls/Bindings/MouseBindingEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/MouseBindingEditor.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Eto.Forms;
 using OpenTabletDriver.Desktop.Reflection;
+using OpenTabletDriver.Plugin.Tablet;
 using OpenTabletDriver.UX.Controls.Generic;
 
 namespace OpenTabletDriver.UX.Controls.Bindings
@@ -60,6 +61,11 @@ namespace OpenTabletDriver.UX.Controls.Bindings
             scrollDown.StoreBinding.Bind(SettingsBinding.Child(c => c.MouseScrollDown));
         }
 
+        public void SetButtonNames(ButtonSpecifications specs)
+        {
+            mouseButtons.ButtonNames = specs?.ButtonNames;
+        }
+
         private MouseBindingDisplayList mouseButtons;
         private BindingDisplay scrollUp, scrollDown;
 
@@ -67,6 +73,10 @@ namespace OpenTabletDriver.UX.Controls.Bindings
         {
             protected override string GetTextForIndex(int index)
             {
+                if (ButtonNames != null && index < ButtonNames.Count
+                    && !string.IsNullOrEmpty(ButtonNames[index]))
+                    return base.GetTextForIndex(index);
+
                 return index switch
                 {
                     0 => "Primary Binding",

--- a/OpenTabletDriver.UX/Controls/Bindings/PenBindingEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/PenBindingEditor.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Eto.Forms;
 using OpenTabletDriver.Desktop.Reflection;
+using OpenTabletDriver.Plugin.Tablet;
 using OpenTabletDriver.UX.Controls.Generic;
 
 namespace OpenTabletDriver.UX.Controls.Bindings
@@ -130,6 +131,11 @@ namespace OpenTabletDriver.UX.Controls.Bindings
             disablePressure.CheckedBinding.Cast<bool>().Bind(SettingsBinding.Child(c => c.DisablePressure));
             disableTilt.CheckedBinding.Cast<bool>().Bind(SettingsBinding.Child(c => c.DisableTilt));
             enableDragBindings.CheckedBinding.Cast<bool>().Bind(SettingsBinding.Child(c => c.EnableDragBindings));
+        }
+
+        public void SetButtonNames(PenSpecifications specs)
+        {
+            penButtons.ButtonNames = specs?.ButtonNames;
         }
 
         private BindingDisplay tipButton, eraserButton;

--- a/OpenTabletDriver.UX/Controls/Bindings/WheelBindingEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/WheelBindingEditor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using Eto.Drawing;
 using Eto.Forms;
 using OpenTabletDriver.Desktop.Profiles;
 using OpenTabletDriver.Plugin.Tablet;
@@ -9,7 +10,7 @@ namespace OpenTabletDriver.UX.Controls.Bindings
 {
     public sealed class WheelBindingEditor : BindingEditor
     {
-        public WheelBindingEditor(int wheelIndex)
+        public WheelBindingEditor(int wheelIndex, bool scrollable = true)
         {
             wheelButtonGroup = new Group
             {
@@ -20,11 +21,8 @@ namespace OpenTabletDriver.UX.Controls.Bindings
                 }
             };
 
-            this.Content = new Scrollable
+            var stackLayout = new StackLayout
             {
-                Border = BorderType.None,
-                Content = new StackLayout
-                {
                     HorizontalContentAlignment = HorizontalAlignment.Stretch,
                     Spacing = 5,
                     Items =
@@ -32,6 +30,8 @@ namespace OpenTabletDriver.UX.Controls.Bindings
                         new Group
                         {
                             Text = "Clockwise Rotation Settings",
+                            TextFont = SystemFonts.Bold(11),
+                            TextColor = SystemColors.ControlText,
                             Content = new StackLayout
                             {
                                 HorizontalContentAlignment = HorizontalAlignment.Stretch,
@@ -63,6 +63,8 @@ namespace OpenTabletDriver.UX.Controls.Bindings
                         new Group
                         {
                             Text = "Counter-Clockwise Rotation Settings",
+                            TextFont = SystemFonts.Bold(11),
+                            TextColor = SystemColors.ControlText,
                             Content = new StackLayout
                             {
                                 HorizontalContentAlignment = HorizontalAlignment.Stretch,
@@ -93,8 +95,11 @@ namespace OpenTabletDriver.UX.Controls.Bindings
                         },
                         wheelButtonGroup
                     }
-                }
-            };
+                };
+
+            this.Content = scrollable
+                ? new Scrollable { Border = BorderType.None, Content = stackLayout }
+                : (Control)stackLayout;
 
             SettingsBinding.DataValueChanged += (sender, args) =>
             {

--- a/OpenTabletDriver.UX/Controls/Bindings/WheelBindingEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/WheelBindingEditor.cs
@@ -10,7 +10,7 @@ namespace OpenTabletDriver.UX.Controls.Bindings
 {
     public sealed class WheelBindingEditor : BindingEditor
     {
-        public WheelBindingEditor(int wheelIndex, bool scrollable = true)
+        public WheelBindingEditor(int wheelIndex)
         {
             wheelButtonGroup = new Group
             {
@@ -97,9 +97,7 @@ namespace OpenTabletDriver.UX.Controls.Bindings
                     }
                 };
 
-            this.Content = scrollable
-                ? new Scrollable { Border = BorderType.None, Content = stackLayout }
-                : (Control)stackLayout;
+            this.Content = stackLayout;
 
             SettingsBinding.DataValueChanged += (sender, args) =>
             {

--- a/OpenTabletDriver.UX/Controls/ControlPanel.cs
+++ b/OpenTabletDriver.UX/Controls/ControlPanel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Eto.Drawing;
 using Eto.Forms;
 using OpenTabletDriver.Desktop.Interop;
 using OpenTabletDriver.Desktop.Profiles;
@@ -8,6 +9,7 @@ using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Output;
 using OpenTabletDriver.Plugin.Tablet;
 using OpenTabletDriver.UX.Controls.Bindings;
+using OpenTabletDriver.UX.Controls.Generic;
 using OpenTabletDriver.UX.Controls.Output;
 
 namespace OpenTabletDriver.UX.Controls
@@ -105,6 +107,7 @@ namespace OpenTabletDriver.UX.Controls
         private AuxiliaryBindingEditor auxBindingEditor;
         private MouseBindingEditor mouseBindingEditor;
         private List<BindingEditor> wheelBindingEditors = [];
+        private List<TabPage> wheelTabPages = [];
         private PluginSettingStoreCollectionEditor<IPositionedPipelineElement<IDeviceReport>> filterEditor;
         private PluginSettingStoreCollectionEditor<ITool> toolEditor;
 
@@ -143,8 +146,8 @@ namespace OpenTabletDriver.UX.Controls
                 SetPageVisibility(penBindingEditor, tablet.Properties.Specifications.Pen != null);
                 SetPageVisibility(auxBindingEditor, tablet.Properties.Specifications.AuxiliaryButtons != null);
 
-                for (int i = 0; i < wheelBindingEditors.Count; i++)
-                    SetPageVisibility(wheelBindingEditors[i], (tablet.Properties.Specifications.Wheels?.Count ?? 0) > i);
+                foreach (var page in wheelTabPages)
+                    SetPageVisibility(page.Content, true);
 
                 SetPageVisibility(mouseBindingEditor, tablet.Properties.Specifications.MouseButtons != null);
                 SetPageVisibility(toolEditor, true);
@@ -163,8 +166,8 @@ namespace OpenTabletDriver.UX.Controls
                 SetPageVisibility(filterEditor, false);
                 SetPageVisibility(penBindingEditor, false);
                 SetPageVisibility(auxBindingEditor, false);
-                foreach (var controlItem in wheelBindingEditors)
-                    SetPageVisibility(controlItem, false);
+                foreach (var page in wheelTabPages)
+                    SetPageVisibility(page.Content, false);
                 SetPageVisibility(mouseBindingEditor, false);
                 SetPageVisibility(toolEditor, false);
 
@@ -185,21 +188,96 @@ namespace OpenTabletDriver.UX.Controls
 
         public void OnTabletChanged(TabletReference tablet)
         {
-            // ensure we have enough wheel binding editors
-            int tabletWheels = tablet?.Properties.Specifications.Wheels?.Count ?? 0;
-            if (tabletWheels > wheelBindingEditors.Count)
+            foreach (var page in wheelTabPages)
+                tabControl.Pages.Remove(page);
+            wheelTabPages.Clear();
+            wheelBindingEditors.Clear();
+
+            var wheels = tablet?.Properties.Specifications.Wheels;
+            if (wheels == null || wheels.Count == 0) return;
+
+            bool hasGroups = wheels.Any(w => w.Group != null);
+
+            for (int i = 0; i < wheels.Count; i++)
             {
-                for (int i = wheelBindingEditors.Count; i < tabletWheels; i++)
+                var editor = new WheelBindingEditor(i, scrollable: !hasGroups);
+                editor.ProfileBinding.Bind(ProfileBinding);
+                wheelBindingEditors.Add(editor);
+            }
+
+            int insertAt = tabControl.Pages.IndexOf(mouseBindingEditor.Parent as TabPage);
+
+            if (hasGroups)
+            {
+                var groupOrder = new List<string>();
+                foreach (var w in wheels)
                 {
-                    var wheelBindingEditor = new WheelBindingEditor(i);
-                    wheelBindingEditor.ProfileBinding.Bind(ProfileBinding);
-                    var pageIndex = tabControl.Pages.IndexOf(mouseBindingEditor.Parent as TabPage);
-                    wheelBindingEditors.Add(wheelBindingEditor);
-                    var wheelPage = new TabPage(wheelBindingEditor) { Text = $"Wheel {i + 1} Bindings" };
-                    if (pageIndex >= 0)
-                        tabControl.Pages.Insert(pageIndex, wheelPage);
+                    if (w.Group != null && !groupOrder.Contains(w.Group))
+                        groupOrder.Add(w.Group);
+                }
+
+                foreach (var groupName in groupOrder)
+                {
+                    var stackLayout = new StackLayout
+                    {
+                        HorizontalContentAlignment = HorizontalAlignment.Stretch,
+                        Spacing = 5
+                    };
+
+                    for (int i = 0; i < wheels.Count; i++)
+                    {
+                        if (wheels[i].Group != groupName) continue;
+                        stackLayout.Items.Add(new StackLayout
+                        {
+                            HorizontalContentAlignment = HorizontalAlignment.Stretch,
+                            Spacing = 5,
+                            Padding = new Padding(0, 8, 0, 0),
+                            Items =
+                            {
+                                new Label
+                                {
+                                    Text = wheels[i].Name ?? $"Wheel {i + 1}",
+                                    Font = SystemFonts.Bold(14),
+                                    TextColor = SystemColors.HighlightText
+                                },
+                                wheelBindingEditors[i]
+                            }
+                        });
+                    }
+
+                    var page = new TabPage
+                    {
+                        Text = groupName,
+                        Content = new Scrollable
+                        {
+                            Border = BorderType.None,
+                            Content = stackLayout
+                        }
+                    };
+
+                    wheelTabPages.Add(page);
+
+                    if (insertAt >= 0)
+                        tabControl.Pages.Insert(insertAt++, page);
                     else
-                        tabControl.Pages.Add(wheelPage);
+                        tabControl.Pages.Add(page);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < wheels.Count; i++)
+                {
+                    var name = wheels[i].Name != null
+                        ? $"{wheels[i].Name} Bindings"
+                        : $"Wheel {i + 1} Bindings";
+                    var page = new TabPage(wheelBindingEditors[i]) { Text = name };
+
+                    wheelTabPages.Add(page);
+
+                    if (insertAt >= 0)
+                        tabControl.Pages.Insert(insertAt++, page);
+                    else
+                        tabControl.Pages.Add(page);
                 }
             }
         }

--- a/OpenTabletDriver.UX/Controls/ControlPanel.cs
+++ b/OpenTabletDriver.UX/Controls/ControlPanel.cs
@@ -85,6 +85,9 @@ namespace OpenTabletDriver.UX.Controls
 
             outputModeEditor.SetDisplaySize(DesktopInterop.VirtualScreen.Displays);
 
+            control.SelectedIndexChanged += (_, __) =>
+                auxBindingEditor.SetVisible(control.SelectedPage?.Content == auxBindingEditor);
+
             Log.Output += (_, message) => Application.Instance.AsyncInvoke(() =>
             {
                 if (message.Level > LogLevel.Info)

--- a/OpenTabletDriver.UX/Controls/ControlPanel.cs
+++ b/OpenTabletDriver.UX/Controls/ControlPanel.cs
@@ -98,7 +98,9 @@ namespace OpenTabletDriver.UX.Controls
         private Placeholder placeholder;
         private LogView logView;
         private OutputModeEditor outputModeEditor;
-        private BindingEditor penBindingEditor, auxBindingEditor, mouseBindingEditor;
+        private PenBindingEditor penBindingEditor;
+        private AuxiliaryBindingEditor auxBindingEditor;
+        private MouseBindingEditor mouseBindingEditor;
         private List<BindingEditor> wheelBindingEditors = [];
         private PluginSettingStoreCollectionEditor<IPositionedPipelineElement<IDeviceReport>> filterEditor;
         private PluginSettingStoreCollectionEditor<ITool> toolEditor;
@@ -144,6 +146,10 @@ namespace OpenTabletDriver.UX.Controls
                 SetPageVisibility(mouseBindingEditor, tablet.Properties.Specifications.MouseButtons != null);
                 SetPageVisibility(toolEditor, true);
 
+                penBindingEditor.SetButtonNames(tablet.Properties.Specifications.Pen);
+                auxBindingEditor.SetButtonNames(tablet.Properties.Specifications.AuxiliaryButtons);
+                mouseBindingEditor.SetButtonNames(tablet.Properties.Specifications.MouseButtons);
+
                 if (switchToOutput)
                     tabControl.SelectedIndex = 0;
             }
@@ -158,6 +164,10 @@ namespace OpenTabletDriver.UX.Controls
                     SetPageVisibility(controlItem, false);
                 SetPageVisibility(mouseBindingEditor, false);
                 SetPageVisibility(toolEditor, false);
+
+                penBindingEditor.SetButtonNames(null);
+                auxBindingEditor.SetButtonNames(null);
+                mouseBindingEditor.SetButtonNames(null);
 
                 if (tabControl.SelectedPage != logView.Parent)
                 {

--- a/OpenTabletDriver.UX/Controls/ControlPanel.cs
+++ b/OpenTabletDriver.UX/Controls/ControlPanel.cs
@@ -9,7 +9,6 @@ using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Output;
 using OpenTabletDriver.Plugin.Tablet;
 using OpenTabletDriver.UX.Controls.Bindings;
-using OpenTabletDriver.UX.Controls.Generic;
 using OpenTabletDriver.UX.Controls.Output;
 
 namespace OpenTabletDriver.UX.Controls
@@ -106,7 +105,7 @@ namespace OpenTabletDriver.UX.Controls
         private PenBindingEditor penBindingEditor;
         private AuxiliaryBindingEditor auxBindingEditor;
         private MouseBindingEditor mouseBindingEditor;
-        private List<BindingEditor> wheelBindingEditors = [];
+        private List<WheelBindingEditor> wheelBindingEditors = [];
         private List<TabPage> wheelTabPages = [];
         private PluginSettingStoreCollectionEditor<IPositionedPipelineElement<IDeviceReport>> filterEditor;
         private PluginSettingStoreCollectionEditor<ITool> toolEditor;
@@ -196,90 +195,86 @@ namespace OpenTabletDriver.UX.Controls
             var wheels = tablet?.Properties.Specifications.Wheels;
             if (wheels == null || wheels.Count == 0) return;
 
-            bool hasGroups = wheels.Any(w => w.Group != null);
-
             for (int i = 0; i < wheels.Count; i++)
             {
-                var editor = new WheelBindingEditor(i, scrollable: !hasGroups);
+                var editor = new WheelBindingEditor(i);
                 editor.ProfileBinding.Bind(ProfileBinding);
                 wheelBindingEditors.Add(editor);
             }
 
             int insertAt = tabControl.Pages.IndexOf(mouseBindingEditor.Parent as TabPage);
 
-            if (hasGroups)
+            foreach (var tabDefinition in WheelTabLayout.Create(wheels))
             {
-                var groupOrder = new List<string>();
-                foreach (var w in wheels)
-                {
-                    if (w.Group != null && !groupOrder.Contains(w.Group))
-                        groupOrder.Add(w.Group);
-                }
+                var page = CreateWheelTabPage(tabDefinition);
+                wheelTabPages.Add(page);
 
-                foreach (var groupName in groupOrder)
-                {
-                    var stackLayout = new StackLayout
-                    {
-                        HorizontalContentAlignment = HorizontalAlignment.Stretch,
-                        Spacing = 5
-                    };
+                if (insertAt >= 0)
+                    tabControl.Pages.Insert(insertAt++, page);
+                else
+                    tabControl.Pages.Add(page);
+            }
+        }
 
-                    for (int i = 0; i < wheels.Count; i++)
+        private TabPage CreateWheelTabPage(WheelTabDefinition tabDefinition)
+        {
+            return tabDefinition.IsGrouped
+                ? CreateGroupedWheelTabPage(tabDefinition)
+                : CreateStandaloneWheelTabPage(tabDefinition);
+        }
+
+        private TabPage CreateGroupedWheelTabPage(WheelTabDefinition tabDefinition)
+        {
+            var stackLayout = new StackLayout
+            {
+                HorizontalContentAlignment = HorizontalAlignment.Stretch,
+                Spacing = 5
+            };
+
+            foreach (var wheel in tabDefinition.Wheels)
+            {
+                stackLayout.Items.Add(new StackLayout
+                {
+                    HorizontalContentAlignment = HorizontalAlignment.Stretch,
+                    Spacing = 5,
+                    Padding = new Padding(0, 8, 0, 0),
+                    Items =
                     {
-                        if (wheels[i].Group != groupName) continue;
-                        stackLayout.Items.Add(new StackLayout
+                        new Label
                         {
-                            HorizontalContentAlignment = HorizontalAlignment.Stretch,
-                            Spacing = 5,
-                            Padding = new Padding(0, 8, 0, 0),
-                            Items =
-                            {
-                                new Label
-                                {
-                                    Text = wheels[i].Name ?? $"Wheel {i + 1}",
-                                    Font = SystemFonts.Bold(14),
-                                    TextColor = SystemColors.HighlightText
-                                },
-                                wheelBindingEditors[i]
-                            }
-                        });
+                            Text = wheel.Title,
+                            Font = SystemFonts.Bold(14),
+                            TextColor = SystemColors.ControlText
+                        },
+                        wheelBindingEditors[wheel.WheelIndex]
                     }
-
-                    var page = new TabPage
-                    {
-                        Text = groupName,
-                        Content = new Scrollable
-                        {
-                            Border = BorderType.None,
-                            Content = stackLayout
-                        }
-                    };
-
-                    wheelTabPages.Add(page);
-
-                    if (insertAt >= 0)
-                        tabControl.Pages.Insert(insertAt++, page);
-                    else
-                        tabControl.Pages.Add(page);
-                }
+                });
             }
-            else
+
+            return new TabPage
             {
-                for (int i = 0; i < wheels.Count; i++)
-                {
-                    var name = wheels[i].Name != null
-                        ? $"{wheels[i].Name} Bindings"
-                        : $"Wheel {i + 1} Bindings";
-                    var page = new TabPage(wheelBindingEditors[i]) { Text = name };
+                Text = tabDefinition.Text,
+                Content = CreateScrollable(stackLayout)
+            };
+        }
 
-                    wheelTabPages.Add(page);
+        private TabPage CreateStandaloneWheelTabPage(WheelTabDefinition tabDefinition)
+        {
+            var wheel = tabDefinition.Wheels.Single();
+            return new TabPage
+            {
+                Text = tabDefinition.Text,
+                Content = CreateScrollable(wheelBindingEditors[wheel.WheelIndex])
+            };
+        }
 
-                    if (insertAt >= 0)
-                        tabControl.Pages.Insert(insertAt++, page);
-                    else
-                        tabControl.Pages.Add(page);
-                }
-            }
+        private static Scrollable CreateScrollable(Control content)
+        {
+            return new Scrollable
+            {
+                Border = BorderType.None,
+                Content = content
+            };
         }
 
         public BindableBinding<ControlPanel, Profile> ProfileBinding

--- a/OpenTabletDriver.UX/Controls/Generic/Group.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/Group.cs
@@ -53,6 +53,8 @@ namespace OpenTabletDriver.UX.Controls.Generic
 
         public Orientation Orientation { set; get; } = DEFAULT_ORIENTATION;
         public bool ExpandContent { set; get; } = true;
+        public Font TextFont { set; get; }
+        public Color? TextColor { set; get; }
         public HorizontalAlignment TitleHorizontalAlignment { set; get; } = HorizontalAlignment.Left;
         public VerticalAlignment TitleVerticalAlignment { set; get; } = VerticalAlignment.Center;
 
@@ -65,12 +67,40 @@ namespace OpenTabletDriver.UX.Controls.Generic
             {
                 case (_, PluginPlatform.MacOS):
                 {
-                    base.Content = new GroupBox
+                    if (TextFont != null || TextColor.HasValue)
                     {
-                        Text = this.Text,
-                        Padding = new Padding(0, 2, 0, 0),
-                        Content = this.Content
-                    };
+                        var label = new Label
+                        {
+                            Text = this.Text,
+                            Font = TextFont ?? SystemFonts.Default(),
+                        };
+                        if (TextColor.HasValue)
+                            label.TextColor = TextColor.Value;
+
+                        base.Content = new StackLayout
+                        {
+                            HorizontalContentAlignment = HorizontalAlignment.Stretch,
+                            Spacing = 2,
+                            Items =
+                            {
+                                label,
+                                new GroupBox
+                                {
+                                    Padding = new Padding(0, 2, 0, 0),
+                                    Content = this.Content
+                                }
+                            }
+                        };
+                    }
+                    else
+                    {
+                        base.Content = new GroupBox
+                        {
+                            Text = this.Text,
+                            Padding = new Padding(0, 2, 0, 0),
+                            Content = this.Content
+                        };
+                    }
                     break;
                 }
                 case (Orientation.Horizontal, _):
@@ -90,10 +120,7 @@ namespace OpenTabletDriver.UX.Controls.Generic
                                 new StackLayoutItem
                                 {
                                     VerticalAlignment = TitleVerticalAlignment,
-                                    Control = new Label
-                                    {
-                                        Text = this.Text
-                                    }
+                                    Control = CreateLabel()
                                 },
                                 new StackLayoutItem(this.Content, ExpandContent)
                             }
@@ -116,11 +143,7 @@ namespace OpenTabletDriver.UX.Controls.Generic
                             new StackLayoutItem
                             {
                                 HorizontalAlignment = TitleHorizontalAlignment,
-                                Control = new Label
-                                {
-                                    Text = this.Text,
-                                    Font = SystemFonts.Bold(9)
-                                }
+                                Control = CreateLabel(SystemFonts.Bold(9))
                             },
                             new StackLayoutItem
                             {
@@ -137,6 +160,18 @@ namespace OpenTabletDriver.UX.Controls.Generic
                     break;
                 }
             }
+        }
+
+        private Label CreateLabel(Font defaultFont = null)
+        {
+            var label = new Label
+            {
+                Text = this.Text,
+                Font = TextFont ?? defaultFont ?? SystemFonts.Default(),
+            };
+            if (TextColor.HasValue)
+                label.TextColor = TextColor.Value;
+            return label;
         }
 
         protected override void OnLoadComplete(EventArgs e)

--- a/OpenTabletDriver.UX/Controls/WheelTabLayout.cs
+++ b/OpenTabletDriver.UX/Controls/WheelTabLayout.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.UX.Controls
+{
+    internal static class WheelTabLayout
+    {
+        public static IReadOnlyList<WheelTabDefinition> Create(IReadOnlyList<WheelSpecifications> wheels)
+        {
+            ArgumentNullException.ThrowIfNull(wheels);
+
+            if (!wheels.Any(HasValidGroup))
+                return CreateStandaloneTabs(wheels);
+
+            var tabs = new List<WheelTabDefinition>();
+            var groupedTabs = new Dictionary<string, WheelTabDefinition>(StringComparer.Ordinal);
+
+            for (int wheelIndex = 0; wheelIndex < wheels.Count; wheelIndex++)
+            {
+                var wheel = wheels[wheelIndex];
+                var wheelTitle = GetWheelTitle(wheel, wheelIndex);
+
+                if (TryGetGroupName(wheel, out var groupName))
+                {
+                    if (!groupedTabs.TryGetValue(groupName, out var tab))
+                    {
+                        tab = WheelTabDefinition.CreateGrouped(groupName);
+                        groupedTabs.Add(groupName, tab);
+                        tabs.Add(tab);
+                    }
+
+                    tab.AddWheel(wheelIndex, wheelTitle);
+                }
+                else
+                {
+                    tabs.Add(WheelTabDefinition.CreateStandalone(wheelIndex, wheelTitle));
+                }
+            }
+
+            return tabs;
+        }
+
+        private static List<WheelTabDefinition> CreateStandaloneTabs(IReadOnlyList<WheelSpecifications> wheels)
+        {
+            var tabs = new List<WheelTabDefinition>(wheels.Count);
+
+            for (int wheelIndex = 0; wheelIndex < wheels.Count; wheelIndex++)
+                tabs.Add(WheelTabDefinition.CreateStandalone(wheelIndex, GetWheelTitle(wheels[wheelIndex], wheelIndex)));
+
+            return tabs;
+        }
+
+        private static bool HasValidGroup(WheelSpecifications wheel) => TryGetGroupName(wheel, out _);
+
+        private static bool TryGetGroupName(WheelSpecifications wheel, out string groupName)
+        {
+            groupName = wheel.Group?.Trim() ?? string.Empty;
+            return groupName.Length > 0;
+        }
+
+        private static string GetWheelTitle(WheelSpecifications wheel, int wheelIndex) =>
+            string.IsNullOrWhiteSpace(wheel.Name) ? $"Wheel {wheelIndex + 1}" : wheel.Name!;
+    }
+
+    internal sealed class WheelTabDefinition
+    {
+        private readonly List<WheelTabItem> _wheels = [];
+
+        private WheelTabDefinition(string text, bool isGrouped)
+        {
+            Text = text;
+            IsGrouped = isGrouped;
+        }
+
+        public string Text { get; }
+        public bool IsGrouped { get; }
+        public IReadOnlyList<WheelTabItem> Wheels => _wheels;
+
+        public static WheelTabDefinition CreateStandalone(int wheelIndex, string wheelTitle)
+        {
+            var tab = new WheelTabDefinition($"{wheelTitle} Bindings", false);
+            tab.AddWheel(wheelIndex, wheelTitle);
+            return tab;
+        }
+
+        public static WheelTabDefinition CreateGrouped(string groupName) => new(groupName, true);
+
+        public void AddWheel(int wheelIndex, string title) => _wheels.Add(new WheelTabItem(wheelIndex, title));
+    }
+
+    internal sealed class WheelTabItem
+    {
+        public WheelTabItem(int wheelIndex, string title)
+        {
+            WheelIndex = wheelIndex;
+            Title = title;
+        }
+
+        public int WheelIndex { get; }
+        public string Title { get; }
+    }
+}

--- a/OpenTabletDriver.UX/OpenTabletDriver.UX.csproj
+++ b/OpenTabletDriver.UX/OpenTabletDriver.UX.csproj
@@ -11,6 +11,10 @@
     <EmbeddedResource Include="..\LICENSE" />
   </ItemGroup>
 
+  <ItemGroup Label="Assembly Attributes">
+    <InternalsVisibleTo Include="OpenTabletDriver.Tests" />
+  </ItemGroup>
+
   <ItemGroup Label="NuGet Packages">
     <PackageReference Include="Eto.Forms" Version="2.5.10" />
     <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -159,7 +159,7 @@
 | Wacom XD-0912-U                    |     Supported     |
 | Wacom XD-1212-U                    |     Supported     |
 | Wacom XD-1218-U                    |     Supported     |
-| Waltop Sirius Battery Free Tablet   |     Supported     |
+| Waltop Sirius Battery Free Tablet   | Missing Features  | Touch dials not supported |
 | Waltop Slim Tablet 5.8"            |     Supported     |
 | XenceLabs Pen Tablet Medium        |     Supported     |
 | XenceLabs Pen Tablet Small         |     Supported     |

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -159,6 +159,7 @@
 | Wacom XD-0912-U                    |     Supported     |
 | Wacom XD-1212-U                    |     Supported     |
 | Wacom XD-1218-U                    |     Supported     |
+| Waltop Sirius Battery Free Tablet   |     Supported     |
 | Waltop Slim Tablet 5.8"            |     Supported     |
 | XenceLabs Pen Tablet Medium        |     Supported     |
 | XenceLabs Pen Tablet Small         |     Supported     |

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -159,7 +159,7 @@
 | Wacom XD-0912-U                    |     Supported     |
 | Wacom XD-1212-U                    |     Supported     |
 | Wacom XD-1218-U                    |     Supported     |
-| Waltop Sirius Battery Free Tablet   | Missing Features  | Touch dials not supported |
+| Waltop Sirius Battery Free Tablet  |     Supported     |
 | Waltop Slim Tablet 5.8"            |     Supported     |
 | XenceLabs Pen Tablet Medium        |     Supported     |
 | XenceLabs Pen Tablet Small         |     Supported     |


### PR DESCRIPTION
> **Depends on #4709** (Waltop Sirius Battery Free Tablet configuration). This PR includes the Waltop Sirius config and parsers as the first configuration to exercise all new features. Please merge #4709 first.

## Summary

This PR adds several quality-of-life improvements to the bindings UI, making it significantly easier to configure tablets with many auxiliary buttons and multiple wheel modes.

<img src="https://raw.githubusercontent.com/Paberu85/OpenTabletDriver/pr-assets-feature-aux-4713/.github/pr-assets/4713/waltop-sirius.jpg" width="400" alt="Waltop Sirius Battery Free Tablet"/>

### Tablet-defined button names

Tablet configurations can now provide human-readable names for auxiliary buttons via a new optional `ButtonNames` array in `AuxiliaryButtons`:

```json
"AuxiliaryButtons": {
    "ButtonCount": 32,
    "ButtonNames": [
        "Left Eraser",
        "Left Shift",
        "Left Tab",
        ...
    ]
}
```

When present, the UI displays these names instead of generic "Auxiliary Binding 1", "Auxiliary Binding 2" labels. **This field is fully optional and backward compatible** — existing configurations without `ButtonNames` continue to display the default numbered labels.

<img src="https://raw.githubusercontent.com/Paberu85/OpenTabletDriver/pr-assets-feature-aux-4713/.github/pr-assets/4713/aux-button-names.png" alt="Auxiliary button names in UI"/>

### Auxiliary button press highlighting

When the auxiliary bindings tab is active, pressing a physical button on the tablet now highlights the corresponding entry in the UI with a brief animated flash. This makes it easy to identify which binding slot corresponds to which physical button, especially on tablets with many buttons.

The highlight uses a smooth fade-out animation driven by `CompositionScheduler`. Colors are pre-blended against the native background to ensure cross-platform compatibility (macOS, GTK, WPF).

### Wheel grouping with Name and Group properties

`WheelSpecifications` gains two new optional fields:

```json
"Wheels": [
    {
        "AbsoluteWheelMax": 7,
        "AngleOfZeroReading": 90.0,
        "Name": "Scroll",
        "Group": "Left Dial",
        "ButtonCount": 0
    },
    {
        "AbsoluteWheelMax": 7,
        "AngleOfZeroReading": 90.0,
        "Name": "Scroll",
        "Group": "Right Dial",
        "ButtonCount": 0
    }
]
```

- **`Name`**: A human-readable label for the wheel mode (e.g. "Scroll", "Multimedia"). Displayed in the UI instead of "Wheel 1", "Wheel 2".
- **`Group`**: Wheels sharing a `Group` value are displayed together under a single tab in the UI, with each wheel's `Name` as a sub-header. This is useful for tablets with multiple physical dials that each have several modes.

**Both fields are fully optional and backward compatible.** Existing configurations without these fields render exactly as before — each wheel gets its own tab with the default numbered label.

<img src="https://raw.githubusercontent.com/Paberu85/OpenTabletDriver/pr-assets-feature-aux-4713/.github/pr-assets/4713/wheel-grouping.png" alt="Wheel grouping in UI"/>

### Configuration JSON changes — backward compatibility

All new JSON fields are optional additions to existing specification types:

| Type | New field | Default behavior when absent |
|------|-----------|------------------------------|
| `ButtonSpecifications` | `ButtonNames` (list) | Generic "Auxiliary Binding N" labels |
| `WheelSpecifications` | `Name` (string) | "Wheel N" label |
| `WheelSpecifications` | `Group` (string) | Each wheel gets its own tab |

No existing fields are modified or removed. Configurations written for older versions of OpenTabletDriver will continue to work unchanged. The new fields are ignored by older versions that do not recognize them.

## Files changed

- **Plugin model**: `ButtonSpecifications.cs`, `WheelSpecifications.cs`, `PenSpecifications.cs` — new optional properties
- **UX layer**: `AuxiliaryBindingEditor.cs`, `BindingDisplayList.cs`, `WheelBindingEditor.cs`, `WheelTabLayout.cs`, `ControlPanel.cs`, `Group.cs` — UI features and cross-platform highlight fix
- **Tests**: `WheelTabLayoutTests.cs` — coverage for wheel grouping/tab layout logic
- **Waltop Sirius config + parsers** — first configuration to use all new features (32 named buttons, 8 grouped wheels)

## Test plan
- [x] Auxiliary button names display from tablet config
- [x] Button press highlighting works on macOS
- [x] Button press highlighting works on GTK/Linux
- [x] Wheel grouping renders correctly in tabs
- [x] Existing configs without new fields render unchanged
- [x] `WheelTabLayoutTests` pass
- [ ] Verify no regression on Windows/WPF

🤖 Generated with [Claude Code](https://claude.com/claude-code)