### PR TITLE
Use radio button for hex/binary select in tablet debugger

### DIFF
--- a/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
+++ b/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
@@ -265,14 +265,17 @@ namespace OpenTabletDriver.UX.Windows.Tablet
                 Text = "Raw Data Mode",
             };
 
+            RadioMenuItem? rootRadioButton = null;
             foreach (var decodingMode in Enum.GetValues<DecodingMode>())
             {
                 string modeName = decodingMode.ToString();
 
-                var item = new CheckMenuItem();
+                var item = new RadioMenuItem(rootRadioButton);
                 item.Text = modeName;
                 item.BindDataContext(x => x.Checked,
                     Binding.Property((TDVM vm) => vm.DecodingMode).ToBool(decodingMode));
+
+                rootRadioButton ??= item;
 
                 decodingSwitchMenuItem.Items.Add(item);
             }


### PR DESCRIPTION
Noticed that it's possible to uncheck both hex and binary. This fixes that.

Eto radio buttons are designed in the most obtuse way I've ever seen radio buttons designed. Theres a root button and all other buttons piggyback off that root button instead of simply all the buttons go into the same collection. There's also no docs stating this is why the constructors are made to take a radiobuttonitem, despite this way of doing things being totally different from how anything else does it.

~~Havent tested on windows yet.~~