### PR TITLE
Use `--no-self-contained` in powershell build script

### DIFF
--- a/eng/windows/package.ps1
+++ b/eng/windows/package.ps1
@@ -5,8 +5,7 @@ param (
     $netRuntime = "win-x64",
     $isRelease = $true,
     $isPackage = $true,
-    $isPortable = $false,
-    $selfContained = $false
+    $isPortable = $false
 )
 
 $ErrorActionPreference = "Stop";
@@ -25,7 +24,7 @@ $UIProjects = @(
 $Options = @(
     "--configuration", "$config",
     "--runtime", "$netRuntime",
-    "--self-contained", "$selfContained",
+    "--no-self-contained",
     "--output", "$output",
     "/p:PublishSingleFile=true",
     "/p:PublishTrimmed=false",


### PR DESCRIPTION
This technically is a breaking change since I'm removing the `$selfContained` arg but since using this script for packaging is deprecated it shouldnt matter. It's only used for convenience when testing.

Same deal as #4623