### PR TITLE
Reset Connected HIDs selection when user changes vid or pid in string reader

### DIFF
--- a/OpenTabletDriver.UX/Windows/DeviceStringReader.cs
+++ b/OpenTabletDriver.UX/Windows/DeviceStringReader.cs
@@ -102,13 +102,23 @@ namespace OpenTabletDriver.UX.Windows
                     this.Close();
             };
 
-            deviceDropDown.SelectedItemBinding
-                .Convert(x => x?.VendorID.ToString())
-                .Bind(vendorIdText.TextBinding);
+            deviceDropDown.SelectedValueChanged += (_, _) =>
+            {
+                if (deviceDropDown.SelectedItem != null)
+                {
+                    productIdText.Text = deviceDropDown.SelectedItem?.ProductID.ToString();
+                    vendorIdText.Text = deviceDropDown.SelectedItem?.VendorID.ToString();
+                }
+            };
 
-            deviceDropDown.SelectedItemBinding
-                .Convert(x => x?.ProductID.ToString())
-                .Bind(productIdText.TextBinding);
+            this.vendorIdText.KeyDown += (_, _) =>
+            {
+                deviceDropDown.SelectedItem = null;
+            };
+            this.productIdText.KeyDown += (_, _) =>
+            {
+                deviceDropDown.SelectedItem = null;
+            };
 
             this.deviceDropDown.DataStore =
                 App.Driver.Instance.GetDevices().Result


### PR DESCRIPTION
It's a bit weird that you can select a device in the dropdown, change the pid or vid, then request strings and it still shows as having selected that device. And if you want to go back and autofill that device's strings again you have to select another device and reselect the one you had selected before.

Had to remove the nice and pretty `SelectedItemBinding`s here. Need this to fall through when it's reset back to `null`.

Can't use `TextInput` or `TextChanged` events for checking if the user has edited the pid and vid boxes because eto moment. (`TextInput` only fires when the string increases in length, `TextChanged` fires on all changes not just from user input)

Technically this a bit jank since pressing shift or ctrl with the box in focus for example will clear it. But it should be fine.

Tested and working on Windows and Linux.