### PR TITLE
Console/Daemon/UX: Move string reading logic to daemon and add getstrings CLI command

### DIFF
--- a/OpenTabletDriver.Console/Program.Commands.cs
+++ b/OpenTabletDriver.Console/Program.Commands.cs
@@ -387,6 +387,14 @@ namespace OpenTabletDriver.Console
             await Out.WriteLineAsync(str);
         }
 
+        private static async Task GetStrings(int vid, int pid)
+        {
+            if (!await EnsureDaemonReady()) return;
+            var strings = (await Driver.Instance.RequestDeviceStrings(vid, pid)).ToList();
+            for (int i = 0; i < strings.Count; i++)
+                await Out.WriteLineAsync($"Index {i + 1}: {strings[i]}");
+        }
+
         #endregion
 
         #region List Types

--- a/OpenTabletDriver.Console/Program.Commands.cs
+++ b/OpenTabletDriver.Console/Program.Commands.cs
@@ -383,16 +383,30 @@ namespace OpenTabletDriver.Console
         private static async Task GetString(int vid, int pid, int index)
         {
             if (!await EnsureDaemonReady()) return;
-            var str = await Driver.Instance.RequestDeviceString(vid, pid, index);
-            await Out.WriteLineAsync(str);
+            try
+            {
+                var str = await Driver.Instance.RequestDeviceString(vid, pid, index);
+                await Out.WriteLineAsync(str);
+            }
+            catch (Exception ex)
+            {
+                await Out.WriteLineAsync(ex.Message);
+            }
         }
 
         private static async Task GetStrings(int vid, int pid)
         {
             if (!await EnsureDaemonReady()) return;
-            var strings = (await Driver.Instance.RequestDeviceStrings(vid, pid)).ToList();
-            for (int i = 0; i < strings.Count; i++)
-                await Out.WriteLineAsync($"Index {i + 1}: {strings[i]}");
+            try
+            {
+                var strings = (await Driver.Instance.RequestDeviceStrings(vid, pid)).ToList();
+                for (int i = 0; i < strings.Count; i++)
+                    await Out.WriteLineAsync($"Index {i + 1}: {strings[i]}");
+            }
+            catch (Exception ex)
+            {
+                await Out.WriteLineAsync(ex.Message);
+            }
         }
 
         #endregion

--- a/OpenTabletDriver.Console/Program.cs
+++ b/OpenTabletDriver.Console/Program.cs
@@ -76,6 +76,7 @@ namespace OpenTabletDriver.Console
         private static readonly IEnumerable<Command> DebugCommands =
         [
             CreateCommand<int, int, int>(GetString, "Requests a device string"),
+            CreateCommand<int, int>(GetStrings, "Requests all device strings"),
         ];
 
         private static readonly IEnumerable<Command> ModifyCommands =

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -659,13 +659,31 @@ namespace OpenTabletDriver.Daemon
             return Task.CompletedTask;
         }
 
-        public Task<string> RequestDeviceString(int vid, int pid, int index)
+        public async Task<string> RequestDeviceString(int vid, int pid, int index)
         {
             var tablet = Driver.CompositeDeviceHub.GetDevices().Where(d => d.VendorID == vid && d.ProductID == pid).FirstOrDefault();
             if (tablet == null)
                 throw new IOException("Device not found");
 
-            return Task.FromResult(tablet.GetDeviceString((byte)index));
+            try
+            {
+                var request = Task.Run(() => tablet.GetDeviceString((byte)index));
+                var completed = await Task.WhenAny(request, Task.Delay(TimeSpan.FromSeconds(5)));
+
+                if (completed == request)
+                    return await request;
+                else
+                    return "{ OTD: Operation timed-out }";
+            }
+            catch
+            {
+                var stillPresent = Driver.CompositeDeviceHub.GetDevices()
+                    .Any(d => d.VendorID == vid && d.ProductID == pid);
+
+                return !stillPresent
+                    ? "{ OTD: Device disconnected }"
+                    : "{ OTD: Operation failed }";
+            }
         }
 
         public async Task<IEnumerable<string>> RequestDeviceStrings(int vid, int pid)

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -668,6 +668,35 @@ namespace OpenTabletDriver.Daemon
             return Task.FromResult(tablet.GetDeviceString((byte)index));
         }
 
+        public async Task<IEnumerable<string>> RequestDeviceStrings(int vid, int pid)
+        {
+            var tablet = Driver.CompositeDeviceHub.GetDevices().Where(d => d.VendorID == vid && d.ProductID == pid).FirstOrDefault();
+            if (tablet == null)
+                throw new IOException("Device not found");
+
+            var results = new List<string>();
+
+            for (int i = 1; i < 256; i++)
+            {
+                try
+                {
+                    var request = Task.Run(() => tablet.GetDeviceString((byte)i));
+                    var completed = await Task.WhenAny(request, Task.Delay(TimeSpan.FromSeconds(5)));
+
+                    if (completed == request)
+                        results.Add(await request);
+                    else
+                        results.Add(null);
+                }
+                catch
+                {
+                    results.Add(null);
+                }
+            }
+
+            return results;
+        }
+
         public Task<IEnumerable<LogMessage>> GetCurrentLog()
         {
             return Task.FromResult(_logFile.Read());

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -678,6 +678,17 @@ namespace OpenTabletDriver.Daemon
 
             for (int i = 1; i < 256; i++)
             {
+                // Check if device is still connected
+                var stillConnected = Driver.CompositeDeviceHub.GetDevices()
+                    .Any(d => d.VendorID == vid && d.ProductID == pid);
+
+                if (!stillConnected)
+                {
+                    for (int j = i; j < 256; j++)
+                        results.Add("{ OTD: Device disconnected }");
+                    break;
+                }
+
                 try
                 {
                     var request = Task.Run(() => tablet.GetDeviceString((byte)i));
@@ -686,11 +697,22 @@ namespace OpenTabletDriver.Daemon
                     if (completed == request)
                         results.Add(await request);
                     else
-                        results.Add(null);
+                        results.Add("{ OTD: Operation timed-out }");
                 }
                 catch
                 {
-                    results.Add(null);
+                    var stillPresent = Driver.CompositeDeviceHub.GetDevices()
+                        .Any(d => d.VendorID == vid && d.ProductID == pid);
+
+                    if (!stillPresent)
+                    {
+                        results.Add("{ OTD: Device disconnected }");
+                        for (int j = i + 1; j < 256; j++)
+                            results.Add("{ OTD: Device disconnected }");
+                        break;
+                    }
+
+                    results.Add("{ OTD: Operation failed }");
                 }
             }
 

--- a/OpenTabletDriver.Desktop/Contracts/IDriverDaemon.cs
+++ b/OpenTabletDriver.Desktop/Contracts/IDriverDaemon.cs
@@ -40,6 +40,7 @@ namespace OpenTabletDriver.Desktop.Contracts
 
         Task SetTabletDebug(bool isEnabled);
         Task<string> RequestDeviceString(int vendorID, int productID, int index);
+        Task<IEnumerable<string>> RequestDeviceStrings(int vendorID, int productID);
 
         Task<IEnumerable<LogMessage>> GetCurrentLog();
         Task<DiagnosticInfo> GetDiagnosticInfo();

--- a/OpenTabletDriver.UX/Windows/DeviceStringReader.cs
+++ b/OpenTabletDriver.UX/Windows/DeviceStringReader.cs
@@ -24,11 +24,29 @@ namespace OpenTabletDriver.UX.Windows
                 Text = "Send Request",
             };
 
-            sendRequestButton.Click += async (_, _) => await SendRequestWithTimeout(stringIndexText.Text,
-                (s) => deviceStringText.Text = !string.IsNullOrEmpty(s) ? System.Text.Json.JsonEncodedText.Encode(s).ToString() : "(no value at this index)",
-                (e) => deviceStringText.Text = $"Error: {e.Message}",
-                () => deviceStringText.Text = OperationTimedOut
-            );
+            sendRequestButton.Click += async (_, _) =>
+            {
+                if (!int.TryParse(vendorIdText.Text, out var vid) ||
+                    !int.TryParse(productIdText.Text, out var pid) ||
+                    !int.TryParse(stringIndexText.Text, out var index) ||
+                    index < 1 || index > 255)
+                {
+                    deviceStringText.Text = "Invalid input: enter a VendorID, ProductID, and string index between 1 and 255";
+                    return;
+                }
+
+                try
+                {
+                    var str = await App.Driver.Instance.RequestDeviceString(vid, pid, index);
+                    deviceStringText.Text = !string.IsNullOrEmpty(str)
+                        ? System.Text.Json.JsonEncodedText.Encode(str).ToString()
+                        : "(no value at this index)";
+                }
+                catch (Exception ex)
+                {
+                    deviceStringText.Text = $"Error: {ex.Message}";
+                }
+            };
 
             var sendRequestAllStringsButton = new Button
             {
@@ -124,8 +142,6 @@ namespace OpenTabletDriver.UX.Windows
         private const int NUMERICBOX_WIDTH = 150;
         private const string DecimalStyle = "Decimal Value";
         private const string StringIndex = "Index";
-        private const string OperationTimedOut = "Operation timed-out";
-        private const string OperationFailed = "Operation failed";
 
         private async void SendRequestAllStrings(object sender, EventArgs args)
         {
@@ -165,41 +181,6 @@ namespace OpenTabletDriver.UX.Windows
                         await sw.WriteAsync(stringDump);
                     break;
             }
-        }
-
-        private async Task SendRequestWithTimeout(string strIndex, Action<string> action, Action<Exception> error, Action timeoutAction)
-        {
-            var strVid = vendorIdText.Text;
-            var strPid = productIdText.Text;
-            var request = SendRequest(strIndex, strVid, strPid);
-            var timeout = Task.Delay(TimeSpan.FromSeconds(5));
-            var completed = await Task.WhenAny(request, timeout);
-            if (completed == timeout)
-            {
-                timeoutAction();
-            }
-            else
-            {
-                try
-                {
-                    var str = await request;
-                    action(str);
-                }
-                catch (Exception e)
-                {
-                    error(e);
-                }
-            }
-        }
-
-        private static async Task<string> SendRequest(string strIndex, string strVid, string strPid)
-        {
-            if (int.TryParse(strIndex, out var index) && index < 256 && index > 0)
-            {
-                if (int.TryParse(strVid, out var vid) && int.TryParse(strPid, out var pid))
-                    return await App.Driver.Instance.RequestDeviceString(vid, pid, index);
-            }
-            throw new ArgumentException("Invalid input: enter a VendorID, ProductID, and string index between 1 and 255");
         }
 
         private readonly DropDown<SerializedDeviceEndpoint> deviceDropDown = new();

--- a/OpenTabletDriver.UX/Windows/DeviceStringReader.cs
+++ b/OpenTabletDriver.UX/Windows/DeviceStringReader.cs
@@ -25,9 +25,9 @@ namespace OpenTabletDriver.UX.Windows
             };
 
             sendRequestButton.Click += async (_, _) => await SendRequestWithTimeout(stringIndexText.Text,
-                (s) => deviceStringText.Text = s != null ? System.Text.Json.JsonEncodedText.Encode(s).ToString() : s,
-                (e) => MessageBox.Show($"Error: {e.Message}", MessageBoxType.Error),
-                () => MessageBox.Show(OperationTimedOut)
+                (s) => deviceStringText.Text = !string.IsNullOrEmpty(s) ? System.Text.Json.JsonEncodedText.Encode(s).ToString() : "(no value at this index)",
+                (e) => deviceStringText.Text = $"Error: {e.Message}",
+                () => deviceStringText.Text = OperationTimedOut
             );
 
             var sendRequestAllStringsButton = new Button
@@ -57,13 +57,6 @@ namespace OpenTabletDriver.UX.Windows
                 PlaceholderText = "Device String",
                 ReadOnly = true
             };
-            this.requireReconnect = new CheckBox
-            {
-                Text = "Require reconnect on fail",
-                Checked = false,
-                ToolTip = "Pauses string dump with a pop-up box if any string dump errors occur",
-            };
-
             this.vendorIdCtrl = new Group("VendorID", vendorIdText, Orientation.Horizontal, false);
             this.productIdCtrl = new Group("ProductID", productIdText, Orientation.Horizontal, false);
             this.stringIndexCtrl = new Group("String Index", stringIndexText, Orientation.Horizontal, false);
@@ -79,7 +72,6 @@ namespace OpenTabletDriver.UX.Windows
                     vendorIdCtrl,
                     productIdCtrl,
                     stringIndexCtrl,
-                    requireReconnect,
                     new StackLayoutItem(
                         new StackLayout
                         {
@@ -132,8 +124,6 @@ namespace OpenTabletDriver.UX.Windows
         private const int NUMERICBOX_WIDTH = 150;
         private const string DecimalStyle = "Decimal Value";
         private const string StringIndex = "Index";
-        private const string RequestTabletReplug = "Please replug the tablet, and then press OK to continue";
-        private const string DisconnectionIndex = "Device disconnected";
         private const string OperationTimedOut = "Operation timed-out";
         private const string OperationFailed = "Operation failed";
 
@@ -145,35 +135,15 @@ namespace OpenTabletDriver.UX.Windows
             // ensure requested device exists/is found
             if (!validVid || !validPid || !matchingDeviceFound)
             {
-                MessageBox.Show($"Error: Device not found", MessageBoxType.Error);
+                deviceStringText.Text = "Error: Device not found";
                 return;
             }
 
+            var strings = (await App.Driver.Instance.RequestDeviceStrings(vid, pid)).ToList();
             var stringDump = new StringBuilder();
 
-            for (int i = 1; i < 256; i++)
-            {
-                bool shouldRead = true;
-                await SendRequestWithTimeout($"{i}",
-                    (str) => stringDump.AppendLine($"{StringIndex} {i}: {str}"),
-                    (e) =>
-                    {
-                        if ((bool)requireReconnect.Checked)
-                        {
-                            shouldRead = AskReconnection(stringDump, i);
-                        }
-                        else
-                        {
-                            stringDump.AppendLine($"{StringIndex} {i}: {{ OTD: {OperationFailed} }}");
-                        }
-                    },
-                    () => stringDump.AppendLine($"{StringIndex} {i}: {{ OTD: {OperationTimedOut} }}")
-                );
-
-                // If user pressed "Cancel" return immediately
-                if (!shouldRead)
-                    return;
-            }
+            for (int i = 0; i < strings.Count; i++)
+                stringDump.AppendLine($"{StringIndex} {i + 1}: {strings[i]}");
 
             var fileDialog = Extensions.SaveFileDialog(
                 "Save string dump to...",
@@ -229,20 +199,12 @@ namespace OpenTabletDriver.UX.Windows
                 if (int.TryParse(strVid, out var vid) && int.TryParse(strPid, out var pid))
                     return await App.Driver.Instance.RequestDeviceString(vid, pid, index);
             }
-            throw new ArgumentException("Invalid index");
-        }
-
-        private static bool AskReconnection(StringBuilder stringDump, int i)
-        {
-            stringDump.AppendLine($"{StringIndex} {i}: {{ OTD: {DisconnectionIndex} }}");
-            var result = MessageBox.Show(RequestTabletReplug, MessageBoxButtons.OKCancel);
-            return result == DialogResult.Ok;
+            throw new ArgumentException("Invalid input: enter a VendorID, ProductID, and string index between 1 and 255");
         }
 
         private readonly DropDown<SerializedDeviceEndpoint> deviceDropDown = new();
         private readonly NumericMaskedTextBox<ushort> vendorIdText, productIdText, stringIndexText;
         private readonly TextBox deviceStringText;
         private readonly Group vendorIdCtrl, productIdCtrl, stringIndexCtrl;
-        private readonly CheckBox requireReconnect;
     }
 }


### PR DESCRIPTION
Fixes #4156

## Summary
- Add `getstrings` CLI command to dump all 255 device string descriptors
- Add `getstring` CLI command to request a single device string descriptor
- Move all string reading logic (timeout, error handling, disconnection detection) from the GUI into the daemon so CLI, GUI, and 3rd party interfaces share the same behavior
- Refactor GUI "Dump All" to use the daemon's `RequestDeviceStrings` RPC method instead of looping client-side
- Refactor GUI "Send Request" to use the daemon's `RequestDeviceString` directly instead of a client-side timeout wrapper
- Remove the "Require reconnect on fail" checkbox, disconnection is now detected by the daemon
- Replace GUI error popups with inline text box messages for a less intrusive experience; pop up were intrusive and displayed on the wrong monitor.
- Add error handling to CLI commands (e.g., `getstrings 0 0` now prints "Device not found" instead of crashing)

## Daemon's error handling
`RequestDeviceString` and `RequestDeviceStrings` now return error strings to distinguish error states:
- `{ OTD: Operation timed-out }` 5-second timeout per index
- `{ OTD: Operation failed }` exception during read
- `{ OTD: Device disconnected }` device disappeared mid-iteration

Timeout was not runtime-tested but uses the same `Task.WhenAny` pattern that was already proven in the previous GUI implementation. Disconnection was tested by unplugging the tablet mid dump.

## Test plan
- [x] CLI `getstrings <vid> <pid>` outputs all 255 indices with correct format
- [x] CLI `getstring <vid> <pid> <index>` returns a single string
- [x] CLI handles invalid VID/PID gracefully
- [x] GUI "Dump All" output matches CLI output and previous GUI behavior
- [x] GUI "Send Request" works for valid and invalid inputs
- [x] Device disconnection mid-dump produces correct error strings
- [x] Errors display in text box instead of popups. My own design choice. People will naturally be looking at the textbox for results, not at another monitor for a pop up. And the CLI returns the same error string so it's consistent.