### PR TITLE
Fix macOS Gatekeeper "app is damaged" error

### DIFF
--- a/.github/actions/build-wrapper/action.yml
+++ b/.github/actions/build-wrapper/action.yml
@@ -26,6 +26,11 @@ runs:
         hash git &>/dev/null && \
           git config --system --add safe.directory /__w/OpenTabletDriver/OpenTabletDriver
 
+    - name: "Install rcodesign (macOS builds)"
+      if: inputs.package-name == 'macos'
+      shell: bash
+      run: cargo install apple-codesign
+
     - name: "BASH Build Artifact"
       uses: ./.github/actions/build-bash
       with:

--- a/eng/bash/macos/package.sh
+++ b/eng/bash/macos/package.sh
@@ -18,7 +18,13 @@ cp "${pkg_script_root}/Icon.icns" "${pkg_root}/Contents/Resources/"
 cp "${pkg_script_root}/Info.plist" "${pkg_root}/Contents/"
 
 echo "Signing app bundle..."
-rcodesign sign "${pkg_root}"
+if hash rcodesign 2>/dev/null; then
+  rcodesign sign "${pkg_root}"
+elif hash codesign 2>/dev/null; then
+  codesign --deep --force --sign - "${pkg_root}"
+else
+  echo "Warning: neither rcodesign nor codesign found, skipping signing"
+fi
 
 echo "Creating tarball..."
 create_binary_tarball "${pkg_root}" "${OUTPUT}/${PKG_FILE}"

--- a/eng/bash/macos/package.sh
+++ b/eng/bash/macos/package.sh
@@ -17,6 +17,9 @@ mkdir -p "${pkg_root}/Contents/Resources"
 cp "${pkg_script_root}/Icon.icns" "${pkg_root}/Contents/Resources/"
 cp "${pkg_script_root}/Info.plist" "${pkg_root}/Contents/"
 
+echo "Signing app bundle..."
+rcodesign sign "${pkg_root}"
+
 echo "Creating tarball..."
 create_binary_tarball "${pkg_root}" "${OUTPUT}/${PKG_FILE}"
 


### PR DESCRIPTION
Newer .NET SDK adhoc signs individual Mach-O executables during publish, creating a partially signed bundle that macOS treats as tampered ("damaged") rather than unsigned.

This signs the .app bundle with `rcodesign` during packaging, restoring the "unidentified developer" behavior from 0.6.6.x.

Uses `rcodesign` so the build stays on a Linux runner.