### PR TITLE
Add support for Artisul D16

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Artisul/D16.json
+++ b/OpenTabletDriver.Configurations/Configurations/Artisul/D16.json
@@ -1,0 +1,43 @@
+{
+  "Name": "Artisul D16",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 345.46,
+      "Height": 194.86,
+      "MaxX": 34546,
+      "MaxY": 19486
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 8
+    },
+    "Wheels": [
+      {
+        "RelativeWheelSteps": 24,
+        "ButtonCount": 0
+      }
+    ]
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 21827,
+      "ProductID": 71,
+      "InputReportLength": 10,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicV1ReportParser",
+      "DeviceStrings": {
+        "6": "^ARTISUL D16$"
+      },
+      "InitializationStrings": [
+        100,
+        200
+      ]
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1",
+    "Interface": "0"
+  }
+}

--- a/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicV1ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicV1ReportParser.cs
@@ -8,8 +8,10 @@ namespace OpenTabletDriver.Configurations.Parsers.UCLogic
     {
         public IDeviceReport Parse(byte[] data)
         {
-            if (data[1] == 0xE0)
+            if (data[1] == 0xE0 && data[3] == 0x01)
                 return new UCLogicAuxReport(data);
+            else if (data[1] == 0xE0 && data[3] == 0x10)
+                return new UCLogicV1WheelReport(data);
             else if (data[1].IsBitSet(6))
                 return new TabletReport(data);
             else

--- a/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicV1WheelReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicV1WheelReport.cs
@@ -1,0 +1,19 @@
+using OpenTabletDriver.Plugin.Tablet;
+using OpenTabletDriver.Plugin.Tablet.Wheel;
+
+namespace OpenTabletDriver.Configurations.Parsers.UCLogic
+{
+    public struct UCLogicV1WheelReport : IRelativeWheelReport
+    {
+        public UCLogicV1WheelReport(byte[] report)
+        {
+            Raw = report;
+            AnalogDeltas = [
+                (sbyte)report[4],
+            ];
+        }
+
+        public byte[] Raw { set; get; }
+        public int[] AnalogDeltas { get; set; }
+    }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -216,6 +216,7 @@
 | XP-Pen Star G960S                  |     Supported     |
 | XP-Pen Star G960S Plus             |     Supported     |
 | XP-Pen Deco 03                     |     Supported     |
+| Artisul D16                        |    Has Quirks     | Wheel button reports as 8th aux button.
 | Bosto BT-12HD                      |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0.
 | FlooGoo FMA100                     |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 1. Might also need to change the configuration depending on the tablet used.
 | Gaomon S56K                        |    Has Quirks     | Windows: Might need Zadig's WinUSB to be installed on interface 0 or 1


### PR DESCRIPTION
Fixes #2914

The is super close to a conflict with the `XP-Pen Artist 22HD`. But theyre both locked to the same interface and with different inputreportlength.  Put a string check on it anyways.

The only other tablet using this parser is the XP-Pen Artist 10S. From the videos sent by the contributor that added it, nothing should break from this change. https://youtu.be/STd6U_dqs84?si=Q6MSKTyKG5HzZA0C&t=31
<img width="1855" height="644" alt="Screenshot_2026-04-03_16-14-54" src="https://github.com/user-attachments/assets/b7dae219-b852-412a-a10e-e0124d72d763" />
When he presses the buttons, the 4th byte is `01`, same as on the Artisul D16.

Verification:
https://discord.com/channels/615607687467761684/1157439268550103170/1489713788319039568

Verification on wheel recording data:
[tablet-data_1775251156.txt](https://github.com/user-attachments/files/26472232/tablet-data_1775251156.txt)

Diag (detected):
[diag8.json](https://github.com/user-attachments/files/26472230/diag8.json)

Strings:
[string.dump.txt](https://github.com/user-attachments/files/26471363/string.dump.txt)

Throwing in `Has Quirks` since the wheel button is out of order from the aux buttons.

There is a pcap in the linked issue:
[initialization.pcapng.zip](https://github.com/user-attachments/files/26471436/initialization.pcapng.zip)

It shows these strings but only `100` appears to change the data in any meaningful way:
```
122
123
100
101
110
```