### PR TITLE
Display units on pen and wheel thresholds

### DIFF
--- a/OpenTabletDriver.UX/Controls/Bindings/PenBindingEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/PenBindingEditor.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using Eto.Forms;
 using OpenTabletDriver.Desktop.Reflection;
 using OpenTabletDriver.UX.Controls.Generic;
+using OpenTabletDriver.UX.Controls.Output.Area;
 
 namespace OpenTabletDriver.UX.Controls.Bindings
 {
@@ -41,12 +42,13 @@ namespace OpenTabletDriver.UX.Controls.Bindings
                                                         ExpandContent = false,
                                                         Content = tipButton = new BindingDisplay()
                                                     },
-                                                    new Group
+                                                    new UnitGroup
                                                     {
                                                         Text = "Tip Threshold",
                                                         ToolTip = "The minimum threshold in order for the assigned binding to activate.",
                                                         Orientation = Orientation.Horizontal,
-                                                        Content = tipThreshold = new FloatSlider()
+                                                        Content = tipThreshold = new FloatSlider(),
+                                                        Unit = "%"
                                                     }
                                                 }
                                             }
@@ -67,12 +69,13 @@ namespace OpenTabletDriver.UX.Controls.Bindings
                                                         Orientation = Orientation.Horizontal,
                                                         Content = eraserButton = new BindingDisplay()
                                                     },
-                                                    new Group
+                                                    new UnitGroup
                                                     {
                                                         Text = "Eraser Threshold",
                                                         ToolTip = "The minimum threshold in order for the assigned binding to activate.",
                                                         Orientation = Orientation.Horizontal,
-                                                        Content = eraserThreshold = new FloatSlider()
+                                                        Content = eraserThreshold = new FloatSlider(),
+                                                        Unit = "%"
                                                     }
                                                 }
                                             }

--- a/OpenTabletDriver.UX/Controls/Bindings/PenBindingEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/PenBindingEditor.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using Eto.Forms;
 using OpenTabletDriver.Desktop.Reflection;
 using OpenTabletDriver.UX.Controls.Generic;
-using OpenTabletDriver.UX.Controls.Output.Area;
 
 namespace OpenTabletDriver.UX.Controls.Bindings
 {

--- a/OpenTabletDriver.UX/Controls/Bindings/WheelBindingEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/WheelBindingEditor.cs
@@ -4,6 +4,7 @@ using Eto.Forms;
 using OpenTabletDriver.Desktop.Profiles;
 using OpenTabletDriver.Plugin.Tablet;
 using OpenTabletDriver.UX.Controls.Generic;
+using OpenTabletDriver.UX.Controls.Output.Area;
 
 namespace OpenTabletDriver.UX.Controls.Bindings
 {
@@ -45,7 +46,7 @@ namespace OpenTabletDriver.UX.Controls.Bindings
                                         ExpandContent = false,
                                         Content = clockwiseButton = new BindingDisplay()
                                     },
-                                    new Group
+                                    new UnitGroup
                                     {
                                         Text = "Clockwise Rotation Threshold",
                                         ToolTip = "The minimum threshold in degrees in order for the assigned binding to activate.",
@@ -55,7 +56,8 @@ namespace OpenTabletDriver.UX.Controls.Bindings
                                             Minimum = 1,
                                             Maximum = 360,
                                             SnapToTick = true,
-                                        }
+                                        },
+                                        Unit = "°"
                                     }
                                 }
                             }
@@ -76,7 +78,7 @@ namespace OpenTabletDriver.UX.Controls.Bindings
                                         Orientation = Orientation.Horizontal,
                                         Content = counterClockwiseButton = new BindingDisplay()
                                     },
-                                    new Group
+                                    new UnitGroup
                                     {
                                         Text = "Counter-Clockwise Rotation Threshold",
                                         ToolTip = "The minimum threshold in degrees in order for the assigned binding to activate.",
@@ -86,7 +88,8 @@ namespace OpenTabletDriver.UX.Controls.Bindings
                                             Minimum = 1,
                                             Maximum = 360,
                                             SnapToTick = true,
-                                        }
+                                        },
+                                        Unit = "°"
                                     }
                                 }
                             }

--- a/OpenTabletDriver.UX/Controls/Bindings/WheelBindingEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/WheelBindingEditor.cs
@@ -4,7 +4,6 @@ using Eto.Forms;
 using OpenTabletDriver.Desktop.Profiles;
 using OpenTabletDriver.Plugin.Tablet;
 using OpenTabletDriver.UX.Controls.Generic;
-using OpenTabletDriver.UX.Controls.Output.Area;
 
 namespace OpenTabletDriver.UX.Controls.Bindings
 {

--- a/OpenTabletDriver.UX/Controls/Generic/UnitGroup.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/UnitGroup.cs
@@ -1,8 +1,7 @@
 using System;
 using Eto.Forms;
-using OpenTabletDriver.UX.Controls.Generic;
 
-namespace OpenTabletDriver.UX.Controls.Output.Area
+namespace OpenTabletDriver.UX.Controls.Generic
 {
     public class UnitGroup : Group
     {

--- a/OpenTabletDriver.UX/Controls/Output/Area/AreaEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/Area/AreaEditor.cs
@@ -6,6 +6,7 @@ using Eto.Drawing;
 using Eto.Forms;
 using OpenTabletDriver.Desktop.Profiles;
 using OpenTabletDriver.Native.Linux.Evdev.Structs;
+using OpenTabletDriver.UX.Controls.Generic;
 using OpenTabletDriver.UX.Controls.Generic.Text;
 using OpenTabletDriver.UX.Controls.Utilities;
 

--- a/OpenTabletDriver.UX/Controls/Output/Area/RotationAreaEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/Area/RotationAreaEditor.cs
@@ -1,4 +1,5 @@
 using Eto.Forms;
+using OpenTabletDriver.UX.Controls.Generic;
 using OpenTabletDriver.UX.Controls.Generic.Text;
 using OpenTabletDriver.UX.Controls.Utilities;
 

--- a/OpenTabletDriver.UX/Controls/Output/RelativeModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/RelativeModeEditor.cs
@@ -3,7 +3,6 @@ using Eto.Forms;
 using OpenTabletDriver.Desktop.Profiles;
 using OpenTabletDriver.UX.Controls.Generic;
 using OpenTabletDriver.UX.Controls.Generic.Text;
-using OpenTabletDriver.UX.Controls.Output.Area;
 
 namespace OpenTabletDriver.UX.Controls.Output
 {


### PR DESCRIPTION
`UnitGroup` is in a bit of a weird location in the codebase since it was only intended to be used in the area editor. Moved it to `Generic` (same area `Group` is in) since I think it makes more sense there.

Tested and working on windows and linux.