### PR TITLE
Set `SINGLE_FILE` to true for macos for signed builds, disable signing by default

### DIFF
--- a/.github/actions/build-wrapper/action.yml
+++ b/.github/actions/build-wrapper/action.yml
@@ -27,7 +27,7 @@ runs:
           git config --system --add safe.directory /__w/OpenTabletDriver/OpenTabletDriver
 
     - name: "Install rcodesign (macOS builds)"
-      if: inputs.package-name == 'macos'
+      if: inputs.package-name == 'macos-signed'
       shell: bash
       run: cargo install apple-codesign
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,12 @@ You can also run `./build.sh linux` to generate files into `bin/`, but this does
 A newer version of Bash and Coreutils is required to build OpenTabletDriver. You can install them using Homebrew.
 Run `PATH="$(brew --prefix coreutils)/libexec/gnubin:$PATH" $(brew --prefix)/bin/bash ./eng/bash/package.sh -r osx-x64`.
 
-Packaging MacOS builds on Linux or Windows requires `rcodesign`.
+| Package Format | Command |
+| --- | --- |
+| Unsigned Package | `./eng/bash/package.sh --runtime osx-x64 --package macos` |
+| Signed Package | `./eng/bash/package.sh --signed true --runtime osx-x64 --package macos` |
+
+Packaging signed MacOS builds on Linux or Windows requires `rcodesign`.
 
 # Features
 

--- a/build.sh
+++ b/build.sh
@@ -31,6 +31,9 @@ while [ $# -gt 0 ]; do
     macos)
       options+=("--runtime" "osx-x64")
       ;;
+    macos-signed)
+      options+=("--runtime" "osx-x64" "--signed" "true")
+      ;;
     linux)
       options+=("--runtime" "linux-x64")
       ;;

--- a/eng/bash/lib.sh
+++ b/eng/bash/lib.sh
@@ -105,6 +105,7 @@ declare -g DOG_FOOD="true"
 declare -g BUILD="true"
 declare -g PORTABLE="false"
 declare -g SINGLE_FILE="true"
+declare -g SIGNED="false"
 declare -g SELF_CONTAINED="false"
 
 ### Global Descriptors
@@ -232,6 +233,13 @@ parse_build_args() {
         SELF_CONTAINED="${args[1]}"
         shift_arr "args"
         ;;
+      --signed=*)
+        SIGNED="${args[0]#*=}"
+        ;;
+      --signed)
+        SIGNED="${args[1]}"
+        shift_arr "args"
+        ;;
       *)
         remaining_options+=("${args[0]}")
         ;;
@@ -251,6 +259,7 @@ print_common_arg_help() {
   echo "  --portable <bool>             Whether to build portable binaries (default: ${PORTABLE})"
   echo "  --single-file <bool>          Whether to build single-file binaries (default: ${SINGLE_FILE})"
   echo "  --self-contained <bool>       Whether to build self-contained binaries (default: ${SELF_CONTAINED})"
+  echo "  --signed <bool>               Whether to sign MacOS binaries (default: ${SIGNED})"
   echo "  -h, --help                    Print this help message"
 }
 
@@ -306,6 +315,9 @@ build() {
   fi
   if [ "${SINGLE_FILE}" == "true" ]; then
     options+=( -p:PublishSingleFile=true )
+  fi
+  if [ "${SIGNED}" == "false" ] && [[ "${NET_RUNTIME}" =~ ^osx-.*$ ]]; then
+    options+=( /p:_EnableMacOSCodeSign=false )
   fi
   if [ "${SELF_CONTAINED}" == "true" ]; then
     options+=( --self-contained "${SELF_CONTAINED}" )

--- a/eng/bash/macos/package.sh
+++ b/eng/bash/macos/package.sh
@@ -17,13 +17,15 @@ mkdir -p "${pkg_root}/Contents/Resources"
 cp "${pkg_script_root}/Icon.icns" "${pkg_root}/Contents/Resources/"
 cp "${pkg_script_root}/Info.plist" "${pkg_root}/Contents/"
 
-echo "Signing app bundle..."
-if hash rcodesign 2>/dev/null; then
-  rcodesign sign "${pkg_root}"
-elif hash codesign 2>/dev/null; then
-  codesign --deep --force --sign - "${pkg_root}"
-else
-  echo "Warning: neither rcodesign nor codesign found, skipping signing"
+if [ "${SIGNED}" == "true" ]; then
+  echo "Signing app bundle..."
+  if hash rcodesign 2>/dev/null; then
+    rcodesign sign "${pkg_root}"
+  elif hash codesign 2>/dev/null; then
+    codesign --deep --force --sign - "${pkg_root}"
+  else
+    echo "Warning: neither rcodesign nor codesign found, skipping signing"
+  fi
 fi
 
 echo "Creating tarball..."

--- a/eng/bash/package.sh
+++ b/eng/bash/package.sh
@@ -78,8 +78,7 @@ if [[ "${NET_RUNTIME}" =~ ^win-.*$ ]]; then
 fi
 
 if [[ "${NET_RUNTIME}" =~ ^osx-.*$ ]]; then
-  # the following vars are imported from old packaging script
-  SINGLE_FILE="false"
+  SINGLE_FILE="true"
   SELF_CONTAINED="true"
 
   PACKAGE_GEN=${PACKAGE_GEN:-"macos"}

--- a/eng/bash/package.sh
+++ b/eng/bash/package.sh
@@ -78,7 +78,8 @@ if [[ "${NET_RUNTIME}" =~ ^win-.*$ ]]; then
 fi
 
 if [[ "${NET_RUNTIME}" =~ ^osx-.*$ ]]; then
-  SINGLE_FILE="true"
+  # signed builds must be single file, otherwise reduce package size by not using single file
+  SINGLE_FILE="${SIGNED}"
   SELF_CONTAINED="true"
 
   PACKAGE_GEN=${PACKAGE_GEN:-"macos"}


### PR DESCRIPTION
Adds an option for signing on macos but run `/p:_EnableMacOSCodeSign=false` by default. Also avoid installing rcodesign by default by defining `macos-signed` as a build target that is required for installing rcodesign.

`SINGLE_FILE` is true by default in the build system but since macos appears to require this for signing and breaks without it, I'd rather have it explicitly. Note that this is not a perfect solution since it increases the macos bundle size by 3x due to packing all dependencies in each executable separately rather than letting them share since macos needs to be self contained.

Confirmed signing and single file makes installation fail in the same way it did previously.
https://discord.com/channels/615607687467761684/628651971267788800/1491195026284347402

Confirmed unsigned also works with these changes.
https://discord.com/channels/615607687467761684/628651971267788800/1491457514712207470