### PR TITLE
Configurations: Fix Huion HS610 wheel support and orientation

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/Huion/HuionWheelReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Huion/HuionWheelReport.cs
@@ -9,7 +9,7 @@ public struct HuionWheelReport : IAbsoluteWheelReport
         Raw = data;
         var wheelData = data[5];
 
-        AnalogPositions = [wheelData != 0 ? wheelData - 1u : null];
+        AnalogPositions = [wheelData != 0 ? (4u - wheelData + 12u) % 12u : null];
     }
 
     public byte[] Raw { get; set; }

--- a/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicTiltReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicTiltReportParser.cs
@@ -8,10 +8,12 @@ namespace OpenTabletDriver.Configurations.Parsers.UCLogic
     {
         public IDeviceReport Parse(byte[] data)
         {
-            if (data[1].IsBitSet(6))
-                return new UCLogicAuxReport(data);
-            else
-                return new TiltTabletReport(data, false, true);
+            return data[1] switch
+            {
+                0xe0 => new UCLogicAuxReport(data),
+                0xf0 => new DeviceReport(data),
+                _ => new TiltTabletReport(data, false, true)
+            };
         }
     }
 }


### PR DESCRIPTION
### Fix Huion HS610 wheel support and orientation

This PR fixes two main issues with the Huion HS610 touch ring:

1. **Greedy Parser Fix**: Modified `UCLogicTiltReportParser` to specifically check for `0xE0` button reports. Previously, it used a bit-check that incorrectly hijacked `0xF0` wheel reports and treated them as auxiliary buttons, causing the wheel to be non-functional in the UI.
2. **Wheel Orientation & Direction**: 
   - Inverted the `HuionWheelReport` calculation to fix CCW-increasing raw data, ensuring Clockwise rotation appropriately triggers "Scroll Down" actions.
   - Aligned the wheel mapping so that the physical 12 o'clock position (`0x04`) reports as `0`, following a standard clock-face logic.
   - Updated `HS610.json` with the correct `AngleOfZeroReading` (90.0) to match the new mapping.

Verified on physical hardware: absolute positions now report correctly (0-11) starting at 12 o'clock and increasing CW.
