### PR TITLE
Bindings: Error-log if necessary injected properties/fields aren't present.

### DIFF
--- a/OpenTabletDriver.Desktop/Binding/AdaptiveBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/AdaptiveBinding.cs
@@ -18,6 +18,15 @@ namespace OpenTabletDriver.Desktop.Binding
 
         [Resolved] public IMouseButtonHandler MouseButtonHandler { set; get; }
 
+        [OnDependencyLoad]
+        public void VerifyInitialization()
+        {
+            if (PenActionHandler == null && MouseButtonHandler == null)
+                Log.Write(PluginName,
+                    $"Neither {nameof(IPenActionHandler)} nor {nameof(IMouseButtonHandler)} is available. Your selected output mode is incompatible",
+                    LogLevel.Error);
+        }
+
         // ReSharper disable once UnusedMember.Global
         public AdaptiveBinding()
         {

--- a/OpenTabletDriver.Desktop/Binding/AdaptiveBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/AdaptiveBinding.cs
@@ -7,6 +7,8 @@ using OpenTabletDriver.Plugin.DependencyInjection;
 using OpenTabletDriver.Plugin.Platform.Pointer;
 using OpenTabletDriver.Plugin.Tablet;
 
+#nullable enable
+
 namespace OpenTabletDriver.Desktop.Binding
 {
     [PluginName(PluginName)]
@@ -14,9 +16,9 @@ namespace OpenTabletDriver.Desktop.Binding
     {
         private const string PluginName = "Adaptive Binding";
 
-        [Resolved] public IPenActionHandler PenActionHandler { set; get; }
+        [Resolved] public IPenActionHandler? PenActionHandler { set; get; }
 
-        [Resolved] public IMouseButtonHandler MouseButtonHandler { set; get; }
+        [Resolved] public IMouseButtonHandler? MouseButtonHandler { set; get; }
 
         [OnDependencyLoad]
         public void VerifyInitialization()
@@ -108,6 +110,6 @@ namespace OpenTabletDriver.Desktop.Binding
         private static string ActionToString(PenAction button) =>
             ValidButtons.Where(x => x.Value == button)
                 .Select(x => x.Key)
-                .FirstOrDefault();
+                .First();
     }
 }

--- a/OpenTabletDriver.Desktop/Binding/KeyBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/KeyBinding.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
-using OpenTabletDriver.Desktop.Interop;
 using OpenTabletDriver.Desktop.Interop.Input.Keyboard;
 using OpenTabletDriver.Interop;
 using OpenTabletDriver.Plugin;
@@ -8,6 +6,8 @@ using OpenTabletDriver.Plugin.Attributes;
 using OpenTabletDriver.Plugin.DependencyInjection;
 using OpenTabletDriver.Plugin.Platform.Keyboard;
 using OpenTabletDriver.Plugin.Tablet;
+
+#nullable enable
 
 namespace OpenTabletDriver.Desktop.Binding
 {
@@ -17,10 +17,10 @@ namespace OpenTabletDriver.Desktop.Binding
         private const string PLUGIN_NAME = "Key Binding";
 
         [Resolved]
-        public IVirtualKeyboard Keyboard { set; get; }
+        public IVirtualKeyboard? Keyboard { set; get; }
 
         [Property("Key"), PropertyValidated(nameof(ValidKeys))]
-        public string Key { set; get; }
+        public string? Key { set; get; }
 
         [OnDependencyLoad]
         public void VerifyInitialization()
@@ -33,17 +33,17 @@ namespace OpenTabletDriver.Desktop.Binding
         public void Press(TabletReference tablet, IDeviceReport report)
         {
             if (!string.IsNullOrWhiteSpace(Key))
-                Keyboard.Press(Key);
+                Keyboard?.Press(Key);
         }
 
         public void Release(TabletReference tablet, IDeviceReport report)
         {
             if (!string.IsNullOrWhiteSpace(Key))
-                Keyboard.Release(Key);
+                Keyboard?.Release(Key);
         }
 
-        private static IEnumerable<string> validKeys;
-        public static IEnumerable<string> ValidKeys
+        private static IEnumerable<string>? validKeys;
+        public static IEnumerable<string>? ValidKeys
         {
             get => validKeys ??= SystemInterop.CurrentPlatform switch
             {

--- a/OpenTabletDriver.Desktop/Binding/KeyBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/KeyBinding.cs
@@ -22,6 +22,14 @@ namespace OpenTabletDriver.Desktop.Binding
         [Property("Key"), PropertyValidated(nameof(ValidKeys))]
         public string Key { set; get; }
 
+        [OnDependencyLoad]
+        public void VerifyInitialization()
+        {
+            if (Keyboard == null)
+                Log.Write(nameof(KeyBinding),
+                    $"{nameof(IVirtualKeyboard)} unavailable. {PLUGIN_NAME} will not work", LogLevel.Error);
+        }
+
         public void Press(TabletReference tablet, IDeviceReport report)
         {
             if (!string.IsNullOrWhiteSpace(Key))

--- a/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModeButtonBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModeButtonBinding.cs
@@ -14,7 +14,7 @@ namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
     public class LinuxArtistModeButtonBinding : IStateBinding
     {
         private readonly EvdevVirtualTablet virtualTablet = (EvdevVirtualTablet)DesktopInterop.VirtualTablet;
-        private const string _PLUGIN_NAME  = "Linux Artist Mode Button Binding";
+        private const string _PLUGIN_NAME = "Linux Artist Mode Button Binding";
 
         public static Dictionary<string, EventCode> SupportedButtons { get; } = new() {
             { "Pen Button 1", EventCode.BTN_STYLUS },

--- a/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModeButtonBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModeButtonBinding.cs
@@ -1,20 +1,35 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenTabletDriver.Desktop.Interop;
 using OpenTabletDriver.Desktop.Interop.Input.Absolute;
 using OpenTabletDriver.Native.Linux.Evdev;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Attributes;
+using OpenTabletDriver.Plugin.DependencyInjection;
+using OpenTabletDriver.Plugin.Platform.Pointer;
 using OpenTabletDriver.Plugin.Tablet;
+
+#nullable enable
 
 namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
 {
     [PluginName(_PLUGIN_NAME), SupportedPlatform(PluginPlatform.Linux)]
     public class LinuxArtistModeButtonBinding : IStateBinding
     {
-        private readonly EvdevVirtualTablet virtualTablet = (EvdevVirtualTablet)DesktopInterop.VirtualTablet;
         private const string _PLUGIN_NAME = "Linux Artist Mode Button Binding";
+
+        [Resolved] public IPressureHandler? PressureHandler;
+
+        private EvdevVirtualTablet? _virtualTablet;
+        private EvdevVirtualTablet? VirtualTablet => _virtualTablet ??= PressureHandler as EvdevVirtualTablet;
+
+        [OnDependencyLoad]
+        public void VerifyInitialization()
+        {
+            if (VirtualTablet == null)
+                Log.Write(_PLUGIN_NAME,
+                    $"{nameof(EvdevVirtualTablet)} unavailable", LogLevel.Error);
+        }
 
         public static Dictionary<string, EventCode> SupportedButtons { get; } = new() {
             { "Pen Button 1", EventCode.BTN_STYLUS },
@@ -25,7 +40,7 @@ namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
         public static string[] ValidButtons => SupportedButtons.Keys.ToArray();
 
         [Property("Button"), PropertyValidated(nameof(ValidButtons))]
-        public string Button { get; set; }
+        public string? Button { get; set; }
 
         public void Press(TabletReference tablet, IDeviceReport report)
         {
@@ -39,10 +54,10 @@ namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
 
         private void SetState(bool state)
         {
-            if (!SupportedButtons.TryGetValue(Button, out var eventCode))
+            if (Button == null || !SupportedButtons.TryGetValue(Button, out var eventCode))
                 throw new InvalidOperationException($"Invalid Button '{Button}'");
 
-            virtualTablet.SetKeyState(eventCode, state);
+            VirtualTablet?.SetKeyState(eventCode, state);
         }
 
         public override string ToString() => $"{nameof(LinuxArtistModeButtonBinding)}: {Button}";

--- a/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModeButtonBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModeButtonBinding.cs
@@ -10,10 +10,11 @@ using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
 {
-    [PluginName("Linux Artist Mode"), SupportedPlatform(PluginPlatform.Linux)]
+    [PluginName(_PLUGIN_NAME), SupportedPlatform(PluginPlatform.Linux)]
     public class LinuxArtistModeButtonBinding : IStateBinding
     {
         private readonly EvdevVirtualTablet virtualTablet = (EvdevVirtualTablet)DesktopInterop.VirtualTablet;
+        private const string _PLUGIN_NAME  = "Linux Artist Mode Button Binding";
 
         public static Dictionary<string, EventCode> SupportedButtons { get; } = new() {
             { "Pen Button 1", EventCode.BTN_STYLUS },

--- a/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModePadBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModePadBinding.cs
@@ -7,6 +7,8 @@ using OpenTabletDriver.Plugin.DependencyInjection;
 using OpenTabletDriver.Plugin.Platform.Keyboard;
 using OpenTabletDriver.Plugin.Tablet;
 
+#nullable enable
+
 namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
 {
     [PluginName(_PLUGIN_NAME), SupportedPlatform(PluginPlatform.Linux)]
@@ -15,7 +17,7 @@ namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
         private const string _PLUGIN_NAME = "Linux Artist Mode Pad Binding";
 
         [Resolved]
-        public IVirtualPad VirtualPad;
+        public IVirtualPad? VirtualPad;
 
         [OnDependencyLoad]
         public void VerifyInitialization()
@@ -43,17 +45,20 @@ namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
         public static string[] ValidKeys => s_ValidButtons.Keys.ToArray();
 
         [Property("Button"), PropertyValidated(nameof(ValidKeys))]
-        public string Button
+        public string? Button
         {
             get => _button;
             set
             {
                 _button = value;
-                _buttonPadEvent = s_ValidButtons.First(x => x.Key == value).Value;
+                if (value != null)
+                    _buttonPadEvent = s_ValidButtons.First(x => x.Key == value).Value;
+                else
+                    _buttonPadEvent = null;
             }
         }
 
-        private string _button;
+        private string? _button;
         private TabletPadEvent? _buttonPadEvent;
 
         public void Press(TabletReference tablet, IDeviceReport report)
@@ -70,7 +75,7 @@ namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
         {
             if (_buttonPadEvent == null) throw new InvalidOperationException("Cannot send null event");
 
-            VirtualPad.KeyEvent(_buttonPadEvent.Value, isPress);
+            VirtualPad?.KeyEvent(_buttonPadEvent.Value, isPress);
         }
 
         public override string ToString() => $"{nameof(LinuxArtistModePadBinding)}: {Button ?? "<button not set>"}";

--- a/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModePadBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModePadBinding.cs
@@ -17,6 +17,14 @@ namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
         [Resolved]
         public IVirtualPad VirtualPad;
 
+        [OnDependencyLoad]
+        public void VerifyInitialization()
+        {
+            if (VirtualPad == null)
+                Log.Write(_PLUGIN_NAME,
+                    $"{nameof(IVirtualPad)} unavailable", LogLevel.Error);
+        }
+
         private static readonly Dictionary<string, TabletPadEvent> s_ValidButtons = new()
         {
             { "Pad Button 1", TabletPadEvent.BUTTON_1 },

--- a/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModePadBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModePadBinding.cs
@@ -9,9 +9,11 @@ using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
 {
-    [PluginName("Linux Artist Mode Pad Bindings"), SupportedPlatform(PluginPlatform.Linux)]
+    [PluginName(_PLUGIN_NAME), SupportedPlatform(PluginPlatform.Linux)]
     public class LinuxArtistModePadBinding : IStateBinding
     {
+        private const string _PLUGIN_NAME = "Linux Artist Mode Pad Binding";
+
         [Resolved]
         public IVirtualPad VirtualPad;
 

--- a/OpenTabletDriver.Desktop/Binding/MouseBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/MouseBinding.cs
@@ -18,6 +18,15 @@ namespace OpenTabletDriver.Desktop.Binding
         [Resolved]
         public IMouseButtonHandler Pointer { set; get; }
 
+        [OnDependencyLoad]
+        public void VerifyInitialization()
+        {
+            if (Pointer == null)
+                Log.Write(PLUGIN_NAME,
+                    $"{nameof(IMouseButtonHandler)} unavailable. Your selected output mode is incompatible",
+                    LogLevel.Error);
+        }
+
         [Property("Button"), PropertyValidated(nameof(ValidButtons))]
         public string Button { set; get; }
 

--- a/OpenTabletDriver.Desktop/Binding/MouseBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/MouseBinding.cs
@@ -4,9 +4,10 @@ using System.Linq;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Attributes;
 using OpenTabletDriver.Plugin.DependencyInjection;
-using OpenTabletDriver.Plugin.Output;
 using OpenTabletDriver.Plugin.Platform.Pointer;
 using OpenTabletDriver.Plugin.Tablet;
+
+#nullable enable
 
 namespace OpenTabletDriver.Desktop.Binding
 {
@@ -16,7 +17,7 @@ namespace OpenTabletDriver.Desktop.Binding
         private const string PLUGIN_NAME = "Mouse Button Binding";
 
         [Resolved]
-        public IMouseButtonHandler Pointer { set; get; }
+        public IMouseButtonHandler? Pointer { set; get; }
 
         [OnDependencyLoad]
         public void VerifyInitialization()
@@ -28,7 +29,7 @@ namespace OpenTabletDriver.Desktop.Binding
         }
 
         [Property("Button"), PropertyValidated(nameof(ValidButtons))]
-        public string Button { set; get; }
+        public string? Button { set; get; }
 
         public void Press(TabletReference tablet, IDeviceReport report)
         {
@@ -42,11 +43,9 @@ namespace OpenTabletDriver.Desktop.Binding
                 Pointer?.MouseUp(mouseButton);
         }
 
-        private static IEnumerable<string> validButtons;
-        public static IEnumerable<string> ValidButtons
-        {
-            get => validButtons ??= Enum.GetValues<MouseButton>().Select(Enum.GetName);
-        }
+        private static IEnumerable<string>? validButtons;
+        public static IEnumerable<string> ValidButtons =>
+            validButtons ??= Enum.GetValues<MouseButton>().Select(Enum.GetName)!;
 
         public override string ToString() => $"{PLUGIN_NAME}: {Button}";
     }

--- a/OpenTabletDriver.Desktop/Binding/MouseScrollBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/MouseScrollBinding.cs
@@ -41,6 +41,15 @@ namespace OpenTabletDriver.Desktop.Binding
             }
         }
 
+        [OnDependencyLoad]
+        public void VerifyInitialization()
+        {
+            if (Pointer == null)
+                Log.Write(PLUGIN_NAME,
+                    $"{nameof(IMouseScrollHandler)} unavailable. Your selected output mode is incompatible",
+                    LogLevel.Error);
+        }
+
         [Property("Direction"), DefaultPropertyValue("Vertical"), PropertyValidated(nameof(ValidDirections))]
         public string Direction
         {

--- a/OpenTabletDriver.Desktop/Binding/MouseScrollBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/MouseScrollBinding.cs
@@ -63,12 +63,18 @@ namespace OpenTabletDriver.Desktop.Binding
             }
         }
 
+        private int _amount = 120;
+
         [Property("Amount"),
          DefaultPropertyValue(120),
          ToolTip("The amount to scroll. A negative value will scroll up or left " +
                  "and a positive value will scroll down or right.\n\n" +
                  "Note: A tick equals to 120 on Windows & Linux.")]
-        public int Amount { get; set; } = 120;
+        public int Amount
+        {
+            get => _amount;
+            set => _amount = value != 0 ? value : 1;
+        }
 
         [Property("Interval"),
          DefaultPropertyValue(300),
@@ -98,9 +104,6 @@ namespace OpenTabletDriver.Desktop.Binding
 
         public void Scroll()
         {
-            if (Amount == 0)
-                throw new InvalidOperationException($"{nameof(Amount)} must be greater than zero");
-
             if (_direction == ScrollDirection.Vertical)
                 Pointer.ScrollVertically(-Amount);
             else

--- a/OpenTabletDriver.Desktop/Binding/MouseScrollBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/MouseScrollBinding.cs
@@ -8,6 +8,8 @@ using OpenTabletDriver.Plugin.Platform.Pointer;
 using OpenTabletDriver.Plugin.Tablet;
 using OpenTabletDriver.Plugin.Timers;
 
+#nullable enable
+
 namespace OpenTabletDriver.Desktop.Binding
 {
     [PluginName(PLUGIN_NAME)]
@@ -15,15 +17,15 @@ namespace OpenTabletDriver.Desktop.Binding
     {
         private const string PLUGIN_NAME = "Mouse Scroll Binding";
 
-        private ITimer _timer;
+        private ITimer? _timer;
         private ScrollDirection _direction;
         private int _interval = 1;
 
         [Resolved]
-        public IMouseScrollHandler Pointer { set; get; }
+        public IMouseScrollHandler? Pointer { set; get; }
 
         [Resolved]
-        public ITimer Timer
+        public ITimer? Timer
         {
             get => _timer;
             set
@@ -93,9 +95,6 @@ namespace OpenTabletDriver.Desktop.Binding
 
         public void Press(TabletReference tablet, IDeviceReport report)
         {
-            if (Timer == null)
-                Log.Write(nameof(MouseScrollBinding), $"{nameof(Timer)} not found, key repeat will not work", LogLevel.Warning);
-
             Scroll();
             Timer?.Start();
         }
@@ -105,17 +104,17 @@ namespace OpenTabletDriver.Desktop.Binding
         public void Scroll()
         {
             if (_direction == ScrollDirection.Vertical)
-                Pointer.ScrollVertically(-Amount);
+                Pointer?.ScrollVertically(-Amount);
             else
-                Pointer.ScrollHorizontally(-Amount);
+                Pointer?.ScrollHorizontally(-Amount);
 
             if (Pointer is ISynchronousPointer synchronousPointer)
                 synchronousPointer.Flush();
         }
 
-        private static IEnumerable<string> validDirections;
+        private static IEnumerable<string>? validDirections;
         public static IEnumerable<string> ValidDirections =>
-            validDirections ??= Enum.GetValues<ScrollDirection>().Select(Enum.GetName);
+            validDirections ??= Enum.GetValues<ScrollDirection>().Select(Enum.GetName)!;
 
         public override string ToString() => $"{PLUGIN_NAME}: Direction: {Direction}, Amount: {Amount}, Interval: {Interval}";
     }

--- a/OpenTabletDriver.Desktop/Binding/MouseScrollBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/MouseScrollBinding.cs
@@ -101,9 +101,6 @@ namespace OpenTabletDriver.Desktop.Binding
             if (Amount == 0)
                 throw new InvalidOperationException($"{nameof(Amount)} must be greater than zero");
 
-            if (Pointer == null)
-                throw new InvalidOperationException($"{nameof(Pointer)} was not injected by daemon");
-
             if (_direction == ScrollDirection.Vertical)
                 Pointer.ScrollVertically(-Amount);
             else

--- a/OpenTabletDriver.Desktop/Binding/MouseScrollBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/MouseScrollBinding.cs
@@ -68,7 +68,7 @@ namespace OpenTabletDriver.Desktop.Binding
          ToolTip("The amount to scroll. A negative value will scroll up or left " +
                  "and a positive value will scroll down or right.\n\n" +
                  "Note: A tick equals to 120 on Windows & Linux.")]
-        public int Amount { get; set; }
+        public int Amount { get; set; } = 120;
 
         [Property("Interval"),
          DefaultPropertyValue(300),

--- a/OpenTabletDriver.Desktop/Binding/MultiKeyBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/MultiKeyBinding.cs
@@ -1,11 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Attributes;
 using OpenTabletDriver.Plugin.DependencyInjection;
 using OpenTabletDriver.Plugin.Platform.Keyboard;
 using OpenTabletDriver.Plugin.Tablet;
+
+#nullable enable
 
 namespace OpenTabletDriver.Desktop.Binding
 {
@@ -15,11 +16,11 @@ namespace OpenTabletDriver.Desktop.Binding
         private const string PLUGIN_NAME = "Multi-Key Binding";
         private const char KEYS_SPLITTER = '+';
 
-        private string[] keys;
-        private string keysString;
+        private string[] keys = [];
+        private string? keysString;
 
         [Resolved]
-        public IVirtualKeyboard Keyboard { set; get; }
+        public IVirtualKeyboard? Keyboard { set; get; }
 
         [OnDependencyLoad]
         public void VerifyInitialization()
@@ -30,7 +31,7 @@ namespace OpenTabletDriver.Desktop.Binding
         }
 
         [Property("Keys")]
-        public string Keys
+        public string? Keys
         {
             set
             {
@@ -43,19 +44,20 @@ namespace OpenTabletDriver.Desktop.Binding
         public void Press(TabletReference tablet, IDeviceReport report)
         {
             if (keys.Length > 0)
-                Keyboard.Press(this.keys);
+                Keyboard?.Press(this.keys);
         }
 
         public void Release(TabletReference tablet, IDeviceReport report)
         {
             if (keys.Length > 0)
-                Keyboard.Release(this.keys);
+                Keyboard?.Release(this.keys);
         }
 
-        private string[] ParseKeys(string str)
+        private string[] ParseKeys(string? str)
         {
+            if (str == null || Keyboard == null) return [];
             var newKeys = str.Split(KEYS_SPLITTER, StringSplitOptions.TrimEntries);
-            return newKeys.All(k => Keyboard.SupportedKeys.Contains(k)) ? newKeys : Array.Empty<string>();
+            return newKeys.All(k => Keyboard.SupportedKeys.Contains(k)) ? newKeys : [];
         }
 
         public override string ToString() => $"{PLUGIN_NAME}: {Keys}";

--- a/OpenTabletDriver.Desktop/Binding/MultiKeyBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/MultiKeyBinding.cs
@@ -21,6 +21,14 @@ namespace OpenTabletDriver.Desktop.Binding
         [Resolved]
         public IVirtualKeyboard Keyboard { set; get; }
 
+        [OnDependencyLoad]
+        public void VerifyInitialization()
+        {
+            if (Keyboard == null)
+                Log.Write(nameof(MultiKeyBinding),
+                    $"{nameof(IVirtualKeyboard)} unavailable. Keyboard buttons will not work", LogLevel.Error);
+        }
+
         [Property("Keys")]
         public string Keys
         {

--- a/OpenTabletDriver.Plugin/DependencyInjection/OnDependencyLoadAttribute.cs
+++ b/OpenTabletDriver.Plugin/DependencyInjection/OnDependencyLoadAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using JetBrains.Annotations;
 
 namespace OpenTabletDriver.Plugin.DependencyInjection
 {
@@ -6,6 +7,7 @@ namespace OpenTabletDriver.Plugin.DependencyInjection
     /// Marks a method to fire when all dependencies have been injected successfully.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    [MeansImplicitUse(ImplicitUseKindFlags.Access, ImplicitUseTargetFlags.Itself)]
     public class OnDependencyLoadAttribute : Attribute
     {
     }


### PR DESCRIPTION
Minor refactor of bindings - also contains a change that stops pipeline from dying when mouse scroll bindings are used on incompatible output modes.

Needed for v0.6.7 as this was discovered in v0.6.7-rc1 that the existing code isn't sufficient.

Skipped adding checks of `LinuxArtistModeButtonBinding` as it isn't an injected property, but will likely be PR'd later (so that it's also an injected property).

2 plugin names have changed but I am 99% sure this isn't a problem, as plugins are looked up via `$namespace`.`$class` paths.