### PR TITLE
doc: be more precise about the fork

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ ideally want an IDE capable of working with C# and .NET projects, such as:
 Note that OpenTabletDriver being an open source project means a [yearly free license to use
 Rider](https://www.jetbrains.com/community/opensource/#support) can be obtained.
 
-To get started, create a fork of the repository on GitHub. Then, clone the fork you made, and ensure
+To get started, create a full fork (ie: not only the 0.6.x branch) of the repository on GitHub. Then, clone the fork you made, and ensure
 you're capable of building OpenTabletDriver, by running either `build.ps1` (for Windows), or
 `build.sh` (for Linux and MacOS). If successful, these scripts will produce executables in a newly created
 `bin` subdirectory. You can then run OpenTabletDriver by running the executable for the Daemon and


### PR DESCRIPTION
When creating a fork, by default github fork only the 0.6.x branch
<img width="537" height="61" alt="image" src="https://github.com/user-attachments/assets/234cce6a-95a6-4130-904a-946cae5e0639" />

This prevent the forked (then cloned) repository to be build
```bash
jjl@guiautec:/tmp/OpenTabletDriver$ ./build.sh linux
fatal: No names found, cannot describe anything.
jjl@guiautec:/tmp/OpenTabletDriver$ git branch 
* 0.6.x
jjl@guiautec:/tmp/OpenTabletDriver$ git describe --tags 
fatal: No names found, cannot describe anything.
```