### PR TITLE
Use `--always` on git describe to fallback when no tags are present

### DIFF
--- a/eng/bash/lib.sh
+++ b/eng/bash/lib.sh
@@ -50,7 +50,7 @@ if [ -z "$VERSION_SUFFIX" ]; then
   hash sed &>/dev/null && \
   git rev-parse --is-inside-work-tree &>/dev/null
   then
-    GIT_DESCRIBE="$(git describe --long --tags --dirty)"
+    GIT_DESCRIBE="$(git describe --long --tags --dirty --always)"
 
     # don't set suffix if this is a tagged commit
     COMMIT_DISTANCE_FROM_TAG="$(sed -E s/"${GIT_TAG_REGEX}"/\\8/ <<< "$GIT_DESCRIBE")"


### PR DESCRIPTION
Currently the build script will fail if run on a git repo with no tags present. This fixes that.

Git describe fallback output looks something like this `ad3e21f1-dirty`, normal output being `v0.6.6.2-879-g3d11d1dc`. This causes the distance from tag check to fail which is expected but doesn't break the build.

Version suffix looks a bit silly but it works: `-ad3e21f1-dirty-dirty`, normal: `+887-gb35caa5b`.

Related: #4741