### PR TITLE
Fix deco LW config and parsing

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco LW (Variant 2).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco LW (Variant 2).json
@@ -1,5 +1,5 @@
 {
-  "Name": "XP-Pen Deco LW",
+  "Name": "XP-Pen Deco LW (Variant 2)",
   "Specifications": {
     "Digitizer": {
       "Width": 254,
@@ -8,7 +8,7 @@
       "MaxY": 30480
     },
     "Pen": {
-      "MaxPressure": 8191,
+      "MaxPressure": 16383,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {
@@ -19,8 +19,9 @@
     {
       "VendorID": 10429,
       "ProductID": 2357,
-      "InputReportLength": 12,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenOffsetPressureReportParser",
+      "InputReportLength": 14,
+      "OutputReportLength": 33,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenGen2ReportParser",
       "OutputInitReport": [
         "ArAE"
       ]

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco LW.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco LW.json
@@ -20,7 +20,7 @@
       "VendorID": 10429,
       "ProductID": 2357,
       "InputReportLength": 12,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenOffsetPressureReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenGen2ReportParser",
       "OutputInitReport": [
         "ArAE"
       ]

--- a/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenTabletGen2Report.cs
+++ b/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenTabletGen2Report.cs
@@ -15,7 +15,7 @@ namespace OpenTabletDriver.Configurations.Parsers.XP_Pen
                 X = Unsafe.ReadUnaligned<ushort>(ref report[2]) | report[10] << 16,
                 Y = Unsafe.ReadUnaligned<ushort>(ref report[4]) | report[11] << 16
             };
-            Pressure = (uint)((Unsafe.ReadUnaligned<ushort>(ref report[6]) & 0xBFFF) | (report[13] & 0x01) << 13);
+            Pressure = (uint)((Unsafe.ReadUnaligned<ushort>(ref report[6]) & 0x1FFF) | (report[13] & 0x01) << 13);
             Eraser = report[1].IsBitSet(3);
 
             PenButtons =

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -195,6 +195,7 @@
 | XP-Pen Deco MW                     |     Supported     |
 | XP-Pen Deco L                      |     Supported     |
 | XP-Pen Deco LW                     |     Supported     |
+| XP-Pen Deco LW (Variant 2)         |     Supported     |
 | XP-Pen Deco mini4                  |     Supported     |
 | XP-Pen Deco mini7                  |     Supported     |
 | XP-Pen Deco mini7 V2               |     Supported     |


### PR DESCRIPTION
0xBFFF vs 0x1FFF mask makes no difference here to existing tablets using this parser.

`1011111111111111` (0xBFFF) vs `0001111111111111` (0x1FFF) but the last 3 bits arent used. All 13 bits needed used on for pressure on these bytes are untouched. 2^13 = 8192 -> 2^14 = 16384. The 14th bit is at the end not in line with the others.

Deco LW sends `0010000000000000` (0x2000) over the pressure when the pen is hovering. (read backwards in the data because readunaligned `00 20`, mask comes after read unaligned aligns them).

[tablet-data_1776120664.txt](https://github.com/user-attachments/files/26721758/tablet-data_1776120664.txt)

Annoyingly, there's no data included with #4385

Identifier from https://github.com/OpenTabletDriver/OpenTabletDriver/issues/2912#issuecomment-2309897753

Diag (detected): [Diagnostics-067+903-g541f8393 XP-Pen Deco LW.json](https://github.com/user-attachments/files/26726422/Diagnostics-067%2B903-g541f8393.XP-Pen.Deco.LW.json)

Data (with parser change): [tablet-data_1776195674.txt](https://github.com/user-attachments/files/26726508/tablet-data_1776195674.txt)
Data (max pos verification): [tablet-data_1776196403.txt](https://github.com/user-attachments/files/26726607/tablet-data_1776196403.txt)

Verification: https://discord.com/channels/615607687467761684/789348845372178482/1493696961369346209