### PR TITLE
Ensure name and manufacturer are not null

### DIFF
--- a/OpenTabletDriver.UX/Windows/DeviceStringReader.cs
+++ b/OpenTabletDriver.UX/Windows/DeviceStringReader.cs
@@ -118,8 +118,9 @@ namespace OpenTabletDriver.UX.Windows
             this.deviceDropDown.ItemTextBinding = Binding.Delegate<SerializedDeviceEndpoint, string>(x =>
             {
                 // don't include manufacturer if it's already in the product name (e.g. Razer)
-                string name = x.ProductName ?? x.FriendlyName;
-                string title = name.Contains(x.Manufacturer) ? name : $"{x.Manufacturer} {name}";
+                string name = x.ProductName ?? x.FriendlyName ?? "null";
+                string manufacturer = x.Manufacturer ?? "null";
+                string title = name.Contains(manufacturer) ? name : $"{manufacturer} {name}";
 
                 if (title.Length >= 32) // truncate if too long, used in GUI
                     title = title[..29] + "...";


### PR DESCRIPTION
Untested fix based on this trace (truncated):
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at OpenTabletDriver.UX.Windows.DeviceStringReader.<>c.<.ctor>b__0_8(SerializedDeviceEndpoint x) in D:\a\OpenTabletDriver\OpenTabletDriver\OpenTabletDriver.UX\Windows\DeviceStringReader.cs:line 122
   at Eto.Wpf.Forms.Controls.WpfTextBindingBlock.Convert(Object value, Type targetType, Object parameter, CultureInfo culture)
```
[message-13.txt](https://github.com/user-attachments/files/26736380/message-13.txt)

Noticed that `x.Manufacturer` likely can be null as well which would cause this to throw too.

```csharp
string name = null;
string manufacturer = null;
name.Contains(""); // obviously throws, the error we see in the above trace
"".Contains(manufacturer); // also throws, should be possible to hit too
```

Could also go for something like this, just kept it as close to the original pattern instead:
```csharp
string name = x.ProductName ?? x.FriendlyName ?? "null";
string title = name;
if (x.Manufacturer != null && !name.Contains(x.Manufacturer))
{
    title = $"{x.Manufacturer} {name}";
}
```