### PR TITLE
Show installed plugins with checkmark to differentiate

### DIFF
--- a/OpenTabletDriver.Desktop/Reflection/DesktopPluginContext.cs
+++ b/OpenTabletDriver.Desktop/Reflection/DesktopPluginContext.cs
@@ -36,13 +36,16 @@ namespace OpenTabletDriver.Desktop.Reflection
             Directory.Refresh();
             if (Directory.Exists && Directory.EnumerateFiles().FirstOrDefault(f => f.Name == "metadata.json") is FileInfo file)
             {
-                return Serialization.Deserialize<PluginMetadata>(file);
+                var metadata = Serialization.Deserialize<PluginMetadata>(file);
+                metadata.Installed = true;
+                return metadata;
             }
             else
             {
                 return new PluginMetadata
                 {
                     Name = FriendlyName,
+                    Installed = true,
                 };
             }
         }

--- a/OpenTabletDriver.Desktop/Reflection/Metadata/PluginMetadata.cs
+++ b/OpenTabletDriver.Desktop/Reflection/Metadata/PluginMetadata.cs
@@ -73,6 +73,11 @@ namespace OpenTabletDriver.Desktop.Reflection.Metadata
         public string WikiUrl { set; get; }
 
         /// <summary>
+        /// Whether the plugin is installed.
+        /// </summary>
+        public bool Installed { set; get; }
+
+        /// <summary>
         /// The SPDX license identifier expression.
         /// </summary>
         public string LicenseIdentifier { set; get; }

--- a/OpenTabletDriver.UX/Windows/Plugins/PluginMetadataList.cs
+++ b/OpenTabletDriver.UX/Windows/Plugins/PluginMetadataList.cs
@@ -17,7 +17,7 @@ namespace OpenTabletDriver.UX.Windows.Plugins
     {
         public PluginMetadataList()
         {
-            ItemTextBinding = Binding.Property<PluginMetadata, string>(m => m.Name);
+            ItemTextBinding = Binding.Property<PluginMetadata, string>(m => m.Installed ? $"(Installed) {m.Name}" : m.Name);
 
             Refresh();
             AppInfo.PluginManager.AssembliesChanged += (sender, e) => Refresh();

--- a/OpenTabletDriver.UX/Windows/Plugins/PluginMetadataList.cs
+++ b/OpenTabletDriver.UX/Windows/Plugins/PluginMetadataList.cs
@@ -17,7 +17,7 @@ namespace OpenTabletDriver.UX.Windows.Plugins
     {
         public PluginMetadataList()
         {
-            ItemTextBinding = Binding.Property<PluginMetadata, string>(m => m.Installed ? $"(Installed) {m.Name}" : m.Name);
+            ItemTextBinding = Binding.Property<PluginMetadata, string>(m => m.Installed ? $"✔ {m.Name}" : m.Name);
 
             Refresh();
             AppInfo.PluginManager.AssembliesChanged += (sender, e) => Refresh();


### PR DESCRIPTION
Only tested on Linux. Shouldn't have any potential of breaking anything since it's just editing a string but worth checking that it looks good elsewhere.

Example of how this looks:

<img width="995" height="782" alt="image" src="https://github.com/user-attachments/assets/92562279-6731-4117-8711-6664405a5a6a" />
