### PR TITLE
Use base variant of heavy checkmark instead of emoji variant in debugger

### DIFF
--- a/OpenTabletDriver.Desktop/ViewModels/Utility/Statistics.cs
+++ b/OpenTabletDriver.Desktop/ViewModels/Utility/Statistics.cs
@@ -245,7 +245,7 @@ namespace OpenTabletDriver.Desktop.ViewModels.Utility
             string SelectEmojisFromButtonBool(KeyValuePair<int, bool?> button) =>
                 button.Value switch
                 { // add 1 to key number to display human-friendly number
-                    null => $"{button.Key + 1}✔️",
+                    null => $"{button.Key + 1}✔",
                     false => $"{button.Key + 1}↓️️",
                     true => $"{button.Key + 1}↑",
                 };


### PR DESCRIPTION
<img width="508" height="58" alt="image" src="https://github.com/user-attachments/assets/1ddd4ba5-7a8a-4268-bd77-e1bc802393cb" />

https://www.unicode.org/emoji/charts/emoji-variants.html

Comparison in OTD:
<img width="285" height="102" alt="image" src="https://github.com/user-attachments/assets/e0c79b53-15e3-423b-b950-2c0298300df9" />
