### PR TITLE
Add Creators field for plugin metadata

### DIFF
--- a/OpenTabletDriver.Desktop/Reflection/Metadata/PluginMetadata.cs
+++ b/OpenTabletDriver.Desktop/Reflection/Metadata/PluginMetadata.cs
@@ -25,6 +25,11 @@ namespace OpenTabletDriver.Desktop.Reflection.Metadata
         public string? Owner { set; get; }
 
         /// <summary>
+        /// The original creator of the plugin if it differs from the Owner.
+        /// </summary>
+        public string? Creator { set; get; }
+
+        /// <summary>
         /// The plugin's long description.
         /// <para/>
         /// GUI currently expects this property to be filled with something useful in some manner

--- a/OpenTabletDriver.UX/Windows/Plugins/MetadataViewer.cs
+++ b/OpenTabletDriver.UX/Windows/Plugins/MetadataViewer.cs
@@ -91,6 +91,11 @@ namespace OpenTabletDriver.UX.Windows.Plugins
                         },
                         new AlignedGroup
                         {
+                            Text = "Creator",
+                            Content = creator = new Label()
+                        },
+                        new AlignedGroup
+                        {
                             Text = "Description",
                             Content = description = new Label
                             {
@@ -143,6 +148,7 @@ namespace OpenTabletDriver.UX.Windows.Plugins
 
             name.TextBinding.Bind(MetadataBinding.Child(c => c!.Name));
             owner.TextBinding.Bind(MetadataBinding.Child(c => c!.Owner));
+            creator.TextBinding.Bind(MetadataBinding.Child(c => c!.Creator ?? c.Owner));
             description.TextBinding.Bind(MetadataBinding.Child(c => c!.Description));
             driverVersion.TextBinding.Bind(MetadataBinding.Child(c => c!.SupportedDriverVersion).Convert(v => v?.ToString()));
             maxDriverVersion.TextBinding.Bind(MetadataBinding.Child(c => c!.MaxSupportedDriverVersion).Convert(v => v?.ToString() ?? "N/A"));
@@ -165,7 +171,7 @@ namespace OpenTabletDriver.UX.Windows.Plugins
             Text = "No plugin selected.",
         };
 
-        private Label name, owner, description, driverVersion, maxDriverVersion, pluginVersion, license;
+        private Label name, owner, creator, description, driverVersion, maxDriverVersion, pluginVersion, license;
         private Button sourceCode, wiki;
 
         private Button uninstallButton, installButton;


### PR DESCRIPTION
I don't really like that when I take over maintaining a plugin it essentially strips all credit from the creator unless they have their name in the plugin's name. Or something is added to the description (clunky).
