### PR TITLE
Fix eto sending back input text as null sometimes but empty string if the user touched it

### DIFF
--- a/OpenTabletDriver.UX/Dialogs/RepositoryDialog.cs
+++ b/OpenTabletDriver.UX/Dialogs/RepositoryDialog.cs
@@ -116,7 +116,7 @@ namespace OpenTabletDriver.UX.Dialogs
             public string InputText
             {
                 protected set => this.inputText = value;
-                get => this.inputText ?? DefaultInputText;
+                get => this.inputText == null || this.inputText?.Length == 0 ? DefaultInputText : this.inputText;
             }
 
             public string DefaultInputText { set; get; }


### PR DESCRIPTION
eto moment

This is the `Use alternate source...` thing in the plugin manager.