### PR TITLE
Add support for MTE-450 wheel

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/MTE-450.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/MTE-450.json
@@ -13,14 +13,21 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 4
-    }
+    },
+    "Wheels": [
+      {
+        "AbsoluteWheelMax": 71,
+        "AngleOfZeroReading": 0.0,
+        "ButtonCount": 0
+      }
+    ]
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 1386,
       "ProductID": 101,
       "InputReportLength": 5,
-      "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
       "FeatureInitReport": [
         "AgI="
       ]

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Bamboo/BambooAuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Bamboo/BambooAuxReport.cs
@@ -1,8 +1,9 @@
 using OpenTabletDriver.Plugin.Tablet;
+using OpenTabletDriver.Plugin.Tablet.Wheel;
 
 namespace OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo
 {
-    public struct BambooAuxReport : IAuxReport
+    public struct BambooAuxReport : IAuxReport, IAbsoluteWheelReport
     {
         public BambooAuxReport(byte[] report)
         {
@@ -17,10 +18,11 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo
                 auxByte.IsBitSet(6),
             ];
 
-            // wheel = report[8] & 0x7f
+            AnalogPositions = [report[8].IsBitSet(7) ? (uint)(report[8] & 0x7f) : null];
         }
 
         public byte[] Raw { set; get; }
         public bool[] AuxButtons { set; get; }
+        public uint?[] AnalogPositions { set; get; }
     }
 }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Bamboo/BambooTabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Bamboo/BambooTabletReport.cs
@@ -1,10 +1,11 @@
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using OpenTabletDriver.Plugin.Tablet;
+using OpenTabletDriver.Plugin.Tablet.Wheel;
 
 namespace OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo
 {
-    public struct BambooTabletReport : ITabletReport, IAuxReport, IEraserReport, IProximityReport
+    public struct BambooTabletReport : ITabletReport, IAuxReport, IEraserReport, IProximityReport, IAbsoluteWheelReport
     {
         public BambooTabletReport(byte[] report)
         {
@@ -35,6 +36,8 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo
 
             HoverDistance = 0;
             NearProximity = report[1].IsBitSet(7);
+
+            AnalogPositions = [report[8].IsBitSet(7) ? (uint)(report[8] & 0x7f) : null];
         }
 
         public byte[] Raw { set; get; }
@@ -45,5 +48,6 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo
         public bool Eraser { set; get; }
         public uint HoverDistance { set; get; }
         public bool NearProximity { set; get; }
+        public uint?[] AnalogPositions { set; get; }
     }
 }

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -138,6 +138,7 @@
 | Wacom GD-1212-U                    |     Supported     |
 | Wacom GD-1218-U                    |     Supported     |
 | Wacom Cintiq 18SX (PL-800-U)       |     Supported     |
+| Wacom MTE-450                      |     Supported     |
 | Wacom PTH-450                      |     Supported     |
 | Wacom PTH-451                      |     Supported     |
 | Wacom PTH-650                      |     Supported     |
@@ -319,7 +320,6 @@
 | Wacom Cintiq 21UX (DTZ-2100)       |  Missing Features | Touch bars are not yet supported.
 | Wacom Cintiq 22HD (DTK-2200)       |  Missing Features | Touch Strips are not yet supported.
 | Wacom Cintiq 12WX (DTZ-1200W)      |  Missing Features | Touch bars and top side buttons are not yet supported.
-| Wacom MTE-450                      |  Missing Features | Wheel is not yet supported.
 | Wacom PTZ-1230                     |  Missing Features | Touch bars are not yet supported.
 | Wacom PTZ-1231W                    |  Missing Features | Touch bars are not yet supported.
 | Wacom PTZ-431W                     |  Missing Features | Touch bars are not yet supported.


### PR DESCRIPTION
I own one of these.

Only aux: [tablet-data_1776709746.txt](https://github.com/user-attachments/files/26907255/tablet-data_1776709746.txt)
Aux and pen: [tablet-data_1776709892.txt](https://github.com/user-attachments/files/26907266/tablet-data_1776709892.txt)

This tablet is kindof annoying since it doesn't separate out aux and position/pressure reports if the pen is on the tablet so they need to be parsed in both parser paths.