### PR TITLE
Dont use subtraction in wacom wheel parsing

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos4/Intuos4AuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/Intuos4/Intuos4AuxReport.cs
@@ -27,7 +27,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.Intuos4
             var wheelByte = report[1];
 
             // Wheel Start at Position zero (0x80) and Provides a value between 0x80 & 0xC7 on PTK 440, 640 & 840
-            AnalogPositions = [wheelByte.IsBitSet(7) ? (uint)wheelByte - 0x80 : null];
+            AnalogPositions = [wheelByte.IsBitSet(7) ? (uint)(wheelByte & 0x7f) : null];
 
             WheelButtons = [[touchWheelButtonByte.IsBitSet(0)]];
         }

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosPro/IntuosProAuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/IntuosPro/IntuosProAuxReport.cs
@@ -27,7 +27,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Wacom.IntuosPro
             var wheelByte = report[2];
 
             // Wheel Start at Position zero (0x80) and Provides a value between 0x80 & 0xC7 on PTH-x50 & PTH-x51
-            AnalogPositions = [wheelByte.IsBitSet(7) ? (uint)wheelByte - 0x80 : null];
+            AnalogPositions = [wheelByte.IsBitSet(7) ? (uint)(wheelByte & 0x7f) : null];
 
             WheelButtons = [[touchWheelButtonByte.IsBitSet(0)]];
         }


### PR DESCRIPTION
Chasing out the devil from these parsers.
<img width="570" height="476" alt="image" src="https://github.com/user-attachments/assets/fc09e92c-2809-47e2-a3c7-9c1e63a93464" />

Exact same handling for the exact same reported values in the PTH-x60 in `IntuosV2AuxReport` (`0x80 -> 0xC7`).