### PR TITLE
`find-tablet-support.sh` assorted bugfixes

### DIFF
--- a/scripts/find-tablet-support.sh
+++ b/scripts/find-tablet-support.sh
@@ -117,7 +117,7 @@ echo "Tablet config: ${tablet_config}"
 
 tablet_config="${root_dir}"/"${configs_path}"/"${tablet_config}"
 
-commit_added="$(git log --follow --pretty=format:%H --diff-filter=AC -1 -- "${tablet_config}")"
+commit_added="$(git log --follow --pretty=format:%H --diff-filter=ARC -1 -- "${tablet_config}")"
 
 echo -e "\nAdded in:"
 git_prettyprint_ref "${commit_added}"

--- a/scripts/find-tablet-support.sh
+++ b/scripts/find-tablet-support.sh
@@ -31,6 +31,9 @@ git_prettyprint_ref() {
   fi
   local text="$(git log --format="%h {{DESCRIBEHERE}} - %aN - %as: %s" -1 "$1")"
   local describe="$(git describe --contains "${1}" 2>/dev/null)"
+  if [ "${describe}" == "" ]; then
+    describe="<untagged>"
+  fi
   sed "s/{{DESCRIBEHERE}}/${describe}/" <<< $text
 }
 

--- a/scripts/find-tablet-support.sh
+++ b/scripts/find-tablet-support.sh
@@ -25,6 +25,10 @@ configs_path="OpenTabletDriver.Configurations/Configurations/"
 ### funcs
 
 git_prettyprint_ref() {
+  if [ "$1" == "" ]; then
+    echo "ERR: Cannot look up empty ref"
+    return
+  fi
   local text="$(git log --format="%h {{DESCRIBEHERE}} - %aN - %as: %s" -1 "$1")"
   local describe="$(git describe --contains "${1}")"
   sed "s/{{DESCRIBEHERE}}/${describe}/" <<< $text

--- a/scripts/find-tablet-support.sh
+++ b/scripts/find-tablet-support.sh
@@ -30,7 +30,7 @@ git_prettyprint_ref() {
     return
   fi
   local text="$(git log --format="%h {{DESCRIBEHERE}} - %aN - %as: %s" -1 "$1")"
-  local describe="$(git describe --contains "${1}")"
+  local describe="$(git describe --contains "${1}" 2>/dev/null)"
   sed "s/{{DESCRIBEHERE}}/${describe}/" <<< $text
 }
 


### PR DESCRIPTION
Properly labels unknown additions now (commits that aren't in a tag yet would otherwise throw an error)

Still has a bug where it doesn't properly follow renames. I think `git log --follow` seems bugged but looking at alternatives I wasn't able to get better history than this. Especially noticeable with the Huion 420.