### PR TITLE
Bump actions versions to node 24 supported versions

### DIFF
--- a/.github/actions/build-bash/action.yml
+++ b/.github/actions/build-bash/action.yml
@@ -21,7 +21,7 @@ runs:
       run: sudo dnf install -y rpm-build systemd-rpm-macros libicu openssl-libs zlib krb5-libs dotnet-sdk-8.0 tree jq
 
     # re-checkout repository prior to build to ensure git root is initialized (causes OpenTabletDriver#3774 if not done)
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0 # we need tags _and_ history for correct VERSION_SUFFIX'ing
 

--- a/.github/actions/handle-artifact/action.yml
+++ b/.github/actions/handle-artifact/action.yml
@@ -16,7 +16,7 @@ runs:
 
     - name: Artifact upload
       if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.file-display-name }}
         path: ${{ inputs.files }}
@@ -51,7 +51,7 @@ runs:
         echo "zipfile ready: ${FILENAME}.zip"
 
     - name: Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       if: ${{ startsWith(github.ref, 'refs/tags/') }}
       with:
         name: ${{ inputs.publish-name }} ${{ github.ref_name }}

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/build-wrapper
         with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,12 +17,12 @@ jobs:
     name: Generate udev Rules
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - run: ./generate-rules.sh > 70-opentabletdriver.rules
 
       - name: Upload udev Rules
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: udev Rules
           path: 70-opentabletdriver.rules
@@ -32,7 +32,7 @@ jobs:
     name: Lint Code
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Full git history is needed to get a proper list of changed files
           fetch-depth: 0
@@ -48,7 +48,7 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-dotnet
 
       - name: Run tests
@@ -58,7 +58,7 @@ jobs:
     name: Validate Solution Filters
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-dotnet
 
       - name: Windows

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -11,7 +11,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: github/issue-labeler@v3.3
+    - uses: github/issue-labeler@v3.4
       with:
         repo-token: "${{ github.token }}"
         configuration-path: .github/issue-labeler.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     if: ${{ github.event_name != 'workflow_dispatch' }}
     name: NuGet Deploy Release (Ubuntu Host)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Publish NuGet package
         env:

--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -10,7 +10,7 @@ jobs:
     name: Test for presence of all GitHub Labeler paths
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Test paths
         run: |
@@ -21,7 +21,7 @@ jobs:
     name: Test for presence of added/changed configuration files in TABLETS.md
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Full git history is needed to get a proper list of changed files
           fetch-depth: 0


### PR DESCRIPTION
"Node.js 20 will be removed from the runner on September 16th, 2026."

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/