### PR TITLE
Styling: Disallow unnecessary `using` directives (`IDE0005`)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -38,6 +38,8 @@ dotnet_diagnostic.CA1822.severity = warning
 dotnet_diagnostic.SYSLIB1045.severity = warning
 # use concrete types when possible for improved performance
 dotnet_diagnostic.CA1859.severity = warning
+# disallow unnecessary using directives
+dotnet_diagnostic.IDE0005.severity = warning
 
 # IDE-only inspections (Rider, etc.)
 resharper_can_simplify_dictionary_lookup_with_try_get_value_highlighting=warning

--- a/OpenTabletDriver.Configurations/Parsers/10moon/10moonAuxParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/10moon/10moonAuxParser.cs
@@ -1,5 +1,3 @@
-using System;
-using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Configurations.Parsers.TenMoon

--- a/OpenTabletDriver.Configurations/Parsers/10moon/10moonReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/10moon/10moonReportParser.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Configurations.Parsers.TenMoon

--- a/OpenTabletDriver.Configurations/Parsers/10moon/10moonTabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/10moon/10moonTabletReport.cs
@@ -1,8 +1,5 @@
 using System;
-using System.Linq;
 using System.Numerics;
-using System.Runtime.CompilerServices;
-using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Configurations.Parsers.TenMoon

--- a/OpenTabletDriver.Configurations/Parsers/Huion/InspiroyRelWheelReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Huion/InspiroyRelWheelReport.cs
@@ -1,4 +1,3 @@
-using System;
 using OpenTabletDriver.Plugin.Tablet.Wheel;
 
 namespace OpenTabletDriver.Configurations.Parsers.Huion

--- a/OpenTabletDriver.Configurations/Parsers/Huion/KamvasRelWheelReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Huion/KamvasRelWheelReport.cs
@@ -1,4 +1,3 @@
-using System;
 using OpenTabletDriver.Plugin.Tablet.Wheel;
 
 namespace OpenTabletDriver.Configurations.Parsers.Huion;

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/BambooPad/BambooPadAuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/BambooPad/BambooPadAuxReport.cs
@@ -1,5 +1,3 @@
-using System.Numerics;
-using System.Runtime.CompilerServices;
 using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Configurations.Parsers.Wacom.BambooPad

--- a/OpenTabletDriver.Configurations/Parsers/Wacom/WacomTouchReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Wacom/WacomTouchReport.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Numerics;
 using OpenTabletDriver.Plugin.Tablet;
 using OpenTabletDriver.Plugin.Tablet.Touch;

--- a/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenDeco03WheelReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenDeco03WheelReport.cs
@@ -1,4 +1,3 @@
-using OpenTabletDriver.Plugin.Tablet;
 using OpenTabletDriver.Plugin.Tablet.Wheel;
 
 namespace OpenTabletDriver.Configurations.Parsers.XP_Pen

--- a/OpenTabletDriver.Console/Program.Commands.cs
+++ b/OpenTabletDriver.Console/Program.Commands.cs
@@ -6,7 +6,6 @@ using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using OpenTabletDriver.Desktop;
-using OpenTabletDriver.Desktop.Diagnostics;
 using OpenTabletDriver.Desktop.Interop;
 using OpenTabletDriver.Desktop.Reflection;
 using OpenTabletDriver.Plugin;

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using OpenTabletDriver.Desktop;
 using OpenTabletDriver.Desktop.Binding;

--- a/OpenTabletDriver.Daemon/Program.cs
+++ b/OpenTabletDriver.Daemon/Program.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.CommandLine;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -11,9 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTabletDriver.Desktop;
-using OpenTabletDriver.Desktop.Interop;
 using OpenTabletDriver.Desktop.RPC;
-using OpenTabletDriver.Desktop.Updater;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Components;
 

--- a/OpenTabletDriver.Desktop/AppInfo.cs
+++ b/OpenTabletDriver.Desktop/AppInfo.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
 using OpenTabletDriver.Desktop.Reflection;
 using OpenTabletDriver.Interop;
 using OpenTabletDriver.Plugin;

--- a/OpenTabletDriver.Desktop/Binding/PresetBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/PresetBinding.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenTabletDriver.Desktop.Contracts;

--- a/OpenTabletDriver.Desktop/DesktopReportParserProvider.cs
+++ b/OpenTabletDriver.Desktop/DesktopReportParserProvider.cs
@@ -1,4 +1,3 @@
-using OpenTabletDriver.Desktop.Reflection;
 using OpenTabletDriver.Plugin.Components;
 using OpenTabletDriver.Plugin.Tablet;
 

--- a/OpenTabletDriver.Desktop/Interop/Input/Keyboard/MacOSVirtualKeyboard.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Keyboard/MacOSVirtualKeyboard.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using OpenTabletDriver.Native.OSX;
-using OpenTabletDriver.Native.OSX.Generic;
 using OpenTabletDriver.Native.OSX.Input;
 using OpenTabletDriver.Plugin.Platform.Keyboard;
 

--- a/OpenTabletDriver.Desktop/Interop/Input/Keyboard/WindowsVirtualKeyboard.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Keyboard/WindowsVirtualKeyboard.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using OpenTabletDriver.Native.Windows;
 using OpenTabletDriver.Native.Windows.Input;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Platform.Keyboard;

--- a/OpenTabletDriver.Desktop/Interop/Input/Relative/MacOSRelativePointer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Relative/MacOSRelativePointer.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Numerics;
 using OpenTabletDriver.Native.OSX;
 using OpenTabletDriver.Native.OSX.Input;

--- a/OpenTabletDriver.Desktop/Interop/Timer/FallbackTimer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Timer/FallbackTimer.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using System.Threading;
-using OpenTabletDriver.Plugin.Timers;
 
 using ITimer = OpenTabletDriver.Plugin.Timers.ITimer;
 

--- a/OpenTabletDriver.Desktop/Interop/Timer/WindowsTimer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Timer/WindowsTimer.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.InteropServices;
-using OpenTabletDriver.Native.Windows;
 using OpenTabletDriver.Native.Windows.Timers;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Timers;

--- a/OpenTabletDriver.Desktop/Profiles/Profile.cs
+++ b/OpenTabletDriver.Desktop/Profiles/Profile.cs
@@ -1,6 +1,5 @@
 using System;
 using Newtonsoft.Json;
-using OpenTabletDriver.Desktop.Interop;
 using OpenTabletDriver.Desktop.Output;
 using OpenTabletDriver.Desktop.Reflection;
 using OpenTabletDriver.Interop;

--- a/OpenTabletDriver.Desktop/Profiles/ProfileCollection.cs
+++ b/OpenTabletDriver.Desktop/Profiles/ProfileCollection.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;

--- a/OpenTabletDriver.Desktop/RPC/RpcClient.cs
+++ b/OpenTabletDriver.Desktop/RPC/RpcClient.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.IO.Pipes;
 using System.Threading.Tasks;
 using StreamJsonRpc;

--- a/OpenTabletDriver.Desktop/RPC/RpcHost.cs
+++ b/OpenTabletDriver.Desktop/RPC/RpcHost.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.IO.Pipes;
 using System.Threading;
 using System.Threading.Tasks;

--- a/OpenTabletDriver.Desktop/Reflection/DesktopPluginContext.cs
+++ b/OpenTabletDriver.Desktop/Reflection/DesktopPluginContext.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using OpenTabletDriver.Desktop.Interop;
 using OpenTabletDriver.Desktop.Reflection.Metadata;
 using OpenTabletDriver.Interop;
 using OpenTabletDriver.Plugin;

--- a/OpenTabletDriver.Desktop/Reflection/Metadata/PluginMetadata.cs
+++ b/OpenTabletDriver.Desktop/Reflection/Metadata/PluginMetadata.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
-using System.Text;
 using System.Threading.Tasks;
 using OpenTabletDriver.Desktop.Compression;
 

--- a/OpenTabletDriver.Desktop/Reflection/PluginSettingStoreCollection.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginSettingStoreCollection.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;

--- a/OpenTabletDriver.Desktop/Reflection/ServiceManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/ServiceManager.cs
@@ -1,8 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using OpenTabletDriver.Plugin.DependencyInjection;
 
 namespace OpenTabletDriver.Desktop.Reflection
 {

--- a/OpenTabletDriver.Desktop/Updater/MacOSUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/MacOSUpdater.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;

--- a/OpenTabletDriver.Desktop/Updater/WindowsUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/WindowsUpdater.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;

--- a/OpenTabletDriver.Native/Linux/Evdev/EvdevDevice.cs
+++ b/OpenTabletDriver.Native/Linux/Evdev/EvdevDevice.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 
 namespace OpenTabletDriver.Native.Linux.Evdev
 {

--- a/OpenTabletDriver.Native/Linux/Xorg/XLib.cs
+++ b/OpenTabletDriver.Native/Linux/Xorg/XLib.cs
@@ -5,7 +5,6 @@ namespace OpenTabletDriver.Native.Linux.Xorg
 {
     using Display = IntPtr;
     using IntPtr = IntPtr;
-    using KeySym = IntPtr;
     using Window = IntPtr;
 
     public class XLib

--- a/OpenTabletDriver.Native/OSX/CoreFoundation.cs
+++ b/OpenTabletDriver.Native/OSX/CoreFoundation.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
 
 namespace OpenTabletDriver.Native.OSX

--- a/OpenTabletDriver.Native/OSX/Generic/CGPoint.cs
+++ b/OpenTabletDriver.Native/OSX/Generic/CGPoint.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace OpenTabletDriver.Native.OSX

--- a/OpenTabletDriver.Native/OSX/IOkit/IOHIDAccessType.cs
+++ b/OpenTabletDriver.Native/OSX/IOkit/IOHIDAccessType.cs
@@ -1,4 +1,3 @@
-using System;
 namespace OpenTabletDriver.Native.OSX.IOkit
 {
     public enum IOHIDAccessType

--- a/OpenTabletDriver.Native/OSX/IOkit/IOHIDRequestType.cs
+++ b/OpenTabletDriver.Native/OSX/IOkit/IOHIDRequestType.cs
@@ -1,4 +1,3 @@
-using System;
 namespace OpenTabletDriver.Native.OSX.IOkit
 {
     public enum IOHIDRequestType : uint

--- a/OpenTabletDriver.Native/OSX/IOkit/IOKit.cs
+++ b/OpenTabletDriver.Native/OSX/IOkit/IOKit.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Runtime.InteropServices;
 
 namespace OpenTabletDriver.Native.OSX.IOkit

--- a/OpenTabletDriver.Native/OSX/LibQuarantine.cs
+++ b/OpenTabletDriver.Native/OSX/LibQuarantine.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Runtime.InteropServices;
 
 namespace OpenTabletDriver.Native.OSX

--- a/OpenTabletDriver.Native/Windows/Input/KEYBDINPUT.cs
+++ b/OpenTabletDriver.Native/Windows/Input/KEYBDINPUT.cs
@@ -3,9 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace OpenTabletDriver.Native.Windows.Input
 {
-    using Int16 = Int16;
     using ScanCodeShort = Int16;
-    using UInt32 = UInt32;
     using VirtualKeyShort = Int16;
 
     [StructLayout(LayoutKind.Sequential)]

--- a/OpenTabletDriver.Native/Windows/WinUSB.cs
+++ b/OpenTabletDriver.Native/Windows/WinUSB.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;
-using Microsoft.Win32.SafeHandles;
 using OpenTabletDriver.Native.Windows.USB;
 
 namespace OpenTabletDriver.Native.Windows

--- a/OpenTabletDriver.Native/Windows/Windows.cs
+++ b/OpenTabletDriver.Native/Windows/Windows.cs
@@ -2,7 +2,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.InteropServices;
-using Microsoft.Win32.SafeHandles;
 using OpenTabletDriver.Native.Windows.Input;
 using OpenTabletDriver.Native.Windows.Timers;
 

--- a/OpenTabletDriver.Plugin/Attributes/ToolTipAttribute.cs
+++ b/OpenTabletDriver.Plugin/Attributes/ToolTipAttribute.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace OpenTabletDriver.Plugin.Attributes
 {
     /// <summary>

--- a/OpenTabletDriver.Plugin/Devices/IDeviceEndpoint.cs
+++ b/OpenTabletDriver.Plugin/Devices/IDeviceEndpoint.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.IO;
 
 namespace OpenTabletDriver.Plugin.Devices
 {

--- a/OpenTabletDriver.Plugin/IBinding.cs
+++ b/OpenTabletDriver.Plugin/IBinding.cs
@@ -1,5 +1,3 @@
-using OpenTabletDriver.Plugin.Tablet;
-
 namespace OpenTabletDriver.Plugin
 {
     public interface IBinding

--- a/OpenTabletDriver.Plugin/Logging/LogMessage.cs
+++ b/OpenTabletDriver.Plugin/Logging/LogMessage.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Text;
 
 namespace OpenTabletDriver.Plugin.Logging
 {

--- a/OpenTabletDriver.Plugin/Platform/Keyboard/IVirtualPad.cs
+++ b/OpenTabletDriver.Plugin/Platform/Keyboard/IVirtualPad.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Plugin.Platform.Keyboard

--- a/OpenTabletDriver.Plugin/Tablet/DigitizerSpecifications.cs
+++ b/OpenTabletDriver.Plugin/Tablet/DigitizerSpecifications.cs
@@ -1,5 +1,4 @@
 using System;
-using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;

--- a/OpenTabletDriver.Plugin/Tablet/IAuxReport.cs
+++ b/OpenTabletDriver.Plugin/Tablet/IAuxReport.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace OpenTabletDriver.Plugin.Tablet
 {
     public interface IAuxReport : IDeviceReport

--- a/OpenTabletDriver.Plugin/Tablet/ITabletReport.cs
+++ b/OpenTabletDriver.Plugin/Tablet/ITabletReport.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Numerics;
-
 namespace OpenTabletDriver.Plugin.Tablet
 {
     public interface ITabletReport : IAbsolutePositionReport

--- a/OpenTabletDriver.Plugin/Tablet/OutOfRangeReport.cs
+++ b/OpenTabletDriver.Plugin/Tablet/OutOfRangeReport.cs
@@ -1,5 +1,3 @@
-using OpenTabletDriver.Plugin.Tablet;
-
 namespace OpenTabletDriver.Plugin.Tablet
 {
     public struct OutOfRangeReport : IDeviceReport

--- a/OpenTabletDriver.Tests/Fakes/FakeUpdater.cs
+++ b/OpenTabletDriver.Tests/Fakes/FakeUpdater.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
 using System.Threading.Tasks;
 using OpenTabletDriver.Desktop.Updater;

--- a/OpenTabletDriver.UX.Gtk/Program.cs
+++ b/OpenTabletDriver.UX.Gtk/Program.cs
@@ -1,6 +1,4 @@
 using System;
-using Eto.Forms;
-using GLib;
 
 namespace OpenTabletDriver.UX.Gtk
 {

--- a/OpenTabletDriver.UX.MacOS/Program.cs
+++ b/OpenTabletDriver.UX.MacOS/Program.cs
@@ -1,5 +1,4 @@
 using System;
-using Eto.Forms;
 
 namespace OpenTabletDriver.UX.MacOS
 {

--- a/OpenTabletDriver.UX/App.cs
+++ b/OpenTabletDriver.UX/App.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Eto.Drawing;
 using Eto.Forms;
 using OpenTabletDriver.Desktop;
-using OpenTabletDriver.Desktop.Interop;
 using OpenTabletDriver.Interop;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.UX.RPC;

--- a/OpenTabletDriver.UX/Controls/Bindings/BindingEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/BindingEditor.cs
@@ -1,7 +1,6 @@
 using System;
 using Eto.Forms;
 using OpenTabletDriver.Desktop.Profiles;
-using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.UX.Controls.Bindings
 {

--- a/OpenTabletDriver.UX/Controls/Bindings/WheelBindingEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/WheelBindingEditor.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Diagnostics;
 using Eto.Forms;
 using OpenTabletDriver.Desktop.Profiles;
-using OpenTabletDriver.Plugin.Tablet;
 using OpenTabletDriver.UX.Controls.Generic;
 
 namespace OpenTabletDriver.UX.Controls.Bindings

--- a/OpenTabletDriver.UX/Controls/ControlPanel.cs
+++ b/OpenTabletDriver.UX/Controls/ControlPanel.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Eto.Forms;
 using OpenTabletDriver.Desktop.Interop;
 using OpenTabletDriver.Desktop.Profiles;

--- a/OpenTabletDriver.UX/Controls/Generic/FloatSlider.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/FloatSlider.cs
@@ -1,5 +1,4 @@
 using System;
-using System.ComponentModel;
 using Eto.Forms;
 using OpenTabletDriver.UX.Controls.Generic;
 using OpenTabletDriver.UX.Controls.Generic.Text;

--- a/OpenTabletDriver.UX/Controls/Generic/Group.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/Group.cs
@@ -1,7 +1,6 @@
 using System;
 using Eto.Drawing;
 using Eto.Forms;
-using OpenTabletDriver.Desktop.Interop;
 using OpenTabletDriver.Interop;
 using OpenTabletDriver.Plugin;
 

--- a/OpenTabletDriver.UX/Controls/Generic/UnitLabel.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/UnitLabel.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Numerics;
 using Eto.Drawing;
 using Eto.Forms;
 using JetBrains.Annotations;

--- a/OpenTabletDriver.UX/Controls/Output/Area/AreaDisplay.cs
+++ b/OpenTabletDriver.UX/Controls/Output/Area/AreaDisplay.cs
@@ -1,12 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.Numerics;
 using Eto.Drawing;
 using Eto.Forms;
 using OpenTabletDriver.Desktop.Profiles;
 using OpenTabletDriver.Interop;
 using OpenTabletDriver.Plugin;
-using OpenTabletDriver.UX.Controls.Generic;
 
 namespace OpenTabletDriver.UX.Controls.Output.Area
 {

--- a/OpenTabletDriver.UX/Controls/Output/Area/AreaEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/Area/AreaEditor.cs
@@ -5,7 +5,6 @@ using System.Numerics;
 using Eto.Drawing;
 using Eto.Forms;
 using OpenTabletDriver.Desktop.Profiles;
-using OpenTabletDriver.Native.Linux.Evdev.Structs;
 using OpenTabletDriver.UX.Controls.Generic;
 using OpenTabletDriver.UX.Controls.Generic.Text;
 using OpenTabletDriver.UX.Controls.Utilities;

--- a/OpenTabletDriver.UX/Controls/Output/OutputModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/OutputModeEditor.cs
@@ -9,7 +9,6 @@ using OpenTabletDriver.Desktop.Reflection;
 using OpenTabletDriver.Plugin.Output;
 using OpenTabletDriver.Plugin.Platform.Display;
 using OpenTabletDriver.Plugin.Tablet;
-using OpenTabletDriver.UX.Controls.Generic;
 using OpenTabletDriver.UX.Controls.Generic.Reflection;
 
 namespace OpenTabletDriver.UX.Controls.Output

--- a/OpenTabletDriver.UX/Controls/TabletSwitcherPanel.cs
+++ b/OpenTabletDriver.UX/Controls/TabletSwitcherPanel.cs
@@ -1,13 +1,11 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Eto.Drawing;
 using Eto.Forms;
 using OpenTabletDriver.Desktop.Profiles;
-using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.UX.Controls

--- a/OpenTabletDriver.UX/Controls/Utilities/BooleanCommand.cs
+++ b/OpenTabletDriver.UX/Controls/Utilities/BooleanCommand.cs
@@ -1,4 +1,3 @@
-using System;
 using Eto.Forms;
 
 namespace OpenTabletDriver.UX.Controls.Utilities

--- a/OpenTabletDriver.UX/DaemonWatchdog.cs
+++ b/OpenTabletDriver.UX/DaemonWatchdog.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using OpenTabletDriver.Desktop.Interop;
 using OpenTabletDriver.Interop;
 using OpenTabletDriver.Plugin;
 

--- a/OpenTabletDriver.UX/DesktopForm.cs
+++ b/OpenTabletDriver.UX/DesktopForm.cs
@@ -1,6 +1,5 @@
 using Eto.Drawing;
 using Eto.Forms;
-using OpenTabletDriver.Desktop.Interop;
 using OpenTabletDriver.Interop;
 using OpenTabletDriver.Plugin;
 

--- a/OpenTabletDriver.UX/RPC/DaemonRpcClient.cs
+++ b/OpenTabletDriver.UX/RPC/DaemonRpcClient.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using Eto.Forms;
 using OpenTabletDriver.Desktop.Contracts;
 using OpenTabletDriver.Desktop.RPC;
-using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Logging;
 using OpenTabletDriver.Plugin.Tablet;
 

--- a/OpenTabletDriver.UX/Windows/AreaConverterDialog.cs
+++ b/OpenTabletDriver.UX/Windows/AreaConverterDialog.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using Eto.Forms;
 using OpenTabletDriver.Desktop.Profiles;

--- a/OpenTabletDriver.UX/Windows/Greeter/Pages/AreaEditorPage.cs
+++ b/OpenTabletDriver.UX/Windows/Greeter/Pages/AreaEditorPage.cs
@@ -1,4 +1,3 @@
-using System;
 using Eto.Drawing;
 using Eto.Forms;
 using OpenTabletDriver.Desktop.Profiles;

--- a/OpenTabletDriver.UX/Windows/Plugins/PluginMetadataList.cs
+++ b/OpenTabletDriver.UX/Windows/Plugins/PluginMetadataList.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Reflection;
-using System.Threading;
 using System.Threading.Tasks;
 using Eto.Forms;
 using OpenTabletDriver.Desktop;

--- a/OpenTabletDriver.UX/Windows/Updater/UpdaterWindow.cs
+++ b/OpenTabletDriver.UX/Windows/Updater/UpdaterWindow.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using Eto.Drawing;
 using Eto.Forms;
-using OpenTabletDriver.Desktop;
 using OpenTabletDriver.Desktop.Interop;
 using OpenTabletDriver.UX.Controls;
 using OpenTabletDriver.UX.Controls.Generic;

--- a/OpenTabletDriver/Devices/HidSharpBackend/Extensions.cs
+++ b/OpenTabletDriver/Devices/HidSharpBackend/Extensions.cs
@@ -2,9 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using HidSharp.Reports;
-using OpenTabletDriver.Interop;
 
 namespace OpenTabletDriver.Devices.HidSharpBackend
 {

--- a/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpoint.cs
+++ b/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpoint.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 using HidSharp;
 using HidSharp.Reports;

--- a/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpointStream.cs
+++ b/OpenTabletDriver/Devices/HidSharpBackend/HidSharpEndpointStream.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using HidSharp;
 using OpenTabletDriver.Plugin.Devices;
 

--- a/OpenTabletDriver/Devices/WinUSB/WinUSBInterface.cs
+++ b/OpenTabletDriver/Devices/WinUSB/WinUSBInterface.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using HidSharp.Reports;
-using OpenTabletDriver.Devices.HidSharpBackend;
 using OpenTabletDriver.Native.Windows;
 using OpenTabletDriver.Native.Windows.USB;
 using OpenTabletDriver.Plugin.Devices;

--- a/OpenTabletDriver/Devices/WinUSB/WinUSBInterfaceStream.cs
+++ b/OpenTabletDriver/Devices/WinUSB/WinUSBInterfaceStream.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
 using System.Runtime.CompilerServices;
 using OpenTabletDriver.Native.Windows.USB;
 using OpenTabletDriver.Plugin.Devices;

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
-using System.Threading;
 using OpenTabletDriver.Devices.HidSharpBackend;
 using OpenTabletDriver.Interop;
 using OpenTabletDriver.Plugin;

--- a/OpenTabletDriver/SystemDrivers/InfoProviders/WacomDriverInfoProvider.cs
+++ b/OpenTabletDriver/SystemDrivers/InfoProviders/WacomDriverInfoProvider.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace OpenTabletDriver.SystemDrivers.InfoProviders
 {
     internal class WacomDriverInfoProvider : ProcessModuleQueryableDriverInfoProvider


### PR DESCRIPTION
Kinda seen in #4562 but it was not implemented as a requirement there

Actually implemented in #4680