### PR TITLE
Add wheel bindings to console GetBindings

### DIFF
--- a/OpenTabletDriver.Console/Extensions.cs
+++ b/OpenTabletDriver.Console/Extensions.cs
@@ -66,7 +66,11 @@ namespace OpenTabletDriver.Console
             var wheelIndex = 0;
             foreach (var wheelBinding in wheelBindings)
             {
-                yield return $"Wheel {wheelIndex + 1} Button Bindings: [{string.Join(", ", wheelBinding.WheelButtons.Format())}]\nWheel {wheelIndex + 1} Clockwise Rotation: [{wheelBinding.ClockwiseRotation.Format()}]@{wheelBinding.ClockwiseActivationThreshold}°\nWheel {wheelIndex + 1} Counter-Clockwise Rotation: [{wheelBinding.CounterClockwiseRotation.Format()}]@{wheelBinding.CounterClockwiseActivationThreshold}°";
+                yield return $"""
+                            Wheel {wheelIndex + 1} Button Bindings: [{string.Join(", ", wheelBinding.WheelButtons.Format())}]
+                            Wheel {wheelIndex + 1} Clockwise Rotation: [{wheelBinding.ClockwiseRotation.Format()}]@{wheelBinding.ClockwiseActivationThreshold}°
+                            Wheel {wheelIndex + 1} Counter-Clockwise Rotation: [{wheelBinding.CounterClockwiseRotation.Format()}]@{wheelBinding.CounterClockwiseActivationThreshold}°
+                            """;
                 wheelIndex++;
             }
         }

--- a/OpenTabletDriver.Console/Extensions.cs
+++ b/OpenTabletDriver.Console/Extensions.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.CommandLine;
 using System.Linq;
+using OpenTabletDriver.Desktop.Profiles;
 using OpenTabletDriver.Desktop.Reflection;
 
 namespace OpenTabletDriver.Console
@@ -56,6 +57,17 @@ namespace OpenTabletDriver.Console
             else
             {
                 yield return "None";
+            }
+        }
+
+        public static IEnumerable<string> Format(this IEnumerable<WheelBindingSettings> wheelBindings)
+        {
+            if (!wheelBindings.Any()) { yield return "None"; }
+            var wheelIndex = 0;
+            foreach (var wheelBinding in wheelBindings)
+            {
+                yield return $"Wheel {wheelIndex + 1} Button Bindings: [{string.Join(", ", wheelBinding.WheelButtons.Format())}]\nWheel {wheelIndex + 1} Clockwise Rotation: [{wheelBinding.ClockwiseRotation.Format()}]@{wheelBinding.ClockwiseActivationThreshold}°\nWheel {wheelIndex + 1} Counter-Clockwise Rotation: [{wheelBinding.CounterClockwiseRotation.Format()}]@{wheelBinding.CounterClockwiseActivationThreshold}°";
+                wheelIndex++;
             }
         }
     }

--- a/OpenTabletDriver.Console/Program.Commands.cs
+++ b/OpenTabletDriver.Console/Program.Commands.cs
@@ -322,6 +322,7 @@ namespace OpenTabletDriver.Console
             await Out.WriteLineAsync($"Tip Binding: {profile.BindingSettings.TipButton.Format() ?? "None"}@{profile.BindingSettings.TipActivationThreshold}%");
             await Out.WriteLineAsync($"Pen Bindings: {string.Join(", ", profile.BindingSettings.PenButtons.Format())}");
             await Out.WriteLineAsync($"Express Key Bindings: {string.Join(", ", profile.BindingSettings.AuxButtons.Format())}");
+            await Out.WriteLineAsync($"Wheel Bindings:\n{string.Join("\n", profile.BindingSettings.WheelBindings.Format())}");
         }
 
         private static async Task GetMiscSettings(string tablet)


### PR DESCRIPTION
Ends up looking like this:
```
Wheel Bindings:
Wheel 1 Button Bindings: [None]
Wheel 1 Clockwise Rotation: []@15°
Wheel 1 Counter-Clockwise Rotation: []@15°
```
```
Wheel Bindings:
Wheel 1 Button Bindings: ['Key Binding: { Key: C }']
Wheel 1 Clockwise Rotation: ['Key Binding: { Key: A }']@5°
Wheel 1 Counter-Clockwise Rotation: ['Key Binding: { Key: B }']@5°
```
```
Wheel Bindings:
Wheel 1 Button Bindings: ['Key Binding: { Key: C }']
Wheel 1 Clockwise Rotation: ['Key Binding: { Key: A }']@5°
Wheel 1 Counter-Clockwise Rotation: ['Key Binding: { Key: B }']@5°
Wheel 2 Button Bindings: ['Key Binding: { Key: F }']
Wheel 2 Clockwise Rotation: ['Key Binding: { Key: D }']@5°
Wheel 2 Counter-Clockwise Rotation: ['Key Binding: { Key: E }']@5°

```
```
Wheel Bindings: None
```

Not sure if this is the best way to display this.