### PR TITLE
Parblo Ninos N4 add back identifier with set outputreportlength and set interfaces per identifier

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N4.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N4.json
@@ -20,11 +20,26 @@
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
       "OutputInitReport": [
         "ArAE"
-      ]
+      ],
+      "Attributes": {
+        "Interface": "1"
+      }
+    },
+    {
+      "VendorID": 1155,
+      "ProductID": 40985,
+      "InputReportLength": 10,
+      "OutputReportLength": 8,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
+      "OutputInitReport": [
+        "ArAE"
+      ],
+      "Attributes": {
+        "Interface": "2"
+      }
     }
   ],
   "Attributes": {
-    "libinputoverride": "1",
-    "Interface": "1"
+    "libinputoverride": "1"
   }
 }


### PR DESCRIPTION
Turns out #4282 was breaking

Verification-ish: https://discord.com/channels/615607687467761684/615611007951306863/1499164207273218268
Would like better verification.

Diag (undetected): [Diagnostics-067.json](https://github.com/user-attachments/files/27219134/Diagnostics-067.json)

Another verification and diag:
https://discord.com/channels/615607687467761684/615611007951306863/1505671290856669356
[Diagnostics-067 Parblo Ninos N4.json](https://github.com/user-attachments/files/27937489/Diagnostics-067.Parblo.Ninos.N4.json)
