### PR TITLE
Add support for aux keys of Artisul M0610 Pro Tablet

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Artisul/M0610 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Artisul/M0610 Pro.json
@@ -32,7 +32,7 @@
       "VendorID": 9580,
       "ProductID": 111,
       "InputReportLength": 12,
-      "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicV2ReportParser",
       "DeviceStrings": {
         "201": "OEM16_T205_\\d{6}$"
       },
@@ -44,7 +44,7 @@
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicV2ReportParser",
       "DeviceStrings": {
         "201": "OEM16_T205_\\d{6}$"
       },

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -255,7 +255,7 @@
 | Artisul A1201                      |  Missing Features | Touch bar is not yet supported.
 | Artisul AP604 (Pencil Small)       |  Missing Features | Aux buttons and eraser detection are not yet supported. Windows: Requires Zadig's WinUSB to be installed on interface 1.
 | Artisul D16 Pro                    |  Missing Features | Wheel is not yet supported.
-| Artisul M0610 Pro                  |  Missing Features | Tablet buttons, tilt, and wheel are not yet supported.
+| Artisul M0610 Pro                  |  Missing Features | Wheel is not yet supported.
 | Gaomon M10K                        |  Missing Features | Wheel is not yet supported.
 | Gaomon M10K Pro                    |  Missing Features | Wheel is not yet supported.
 | Gaomon M1220                       |  Missing Features | Wheel is not yet supported.


### PR DESCRIPTION
Hi, this pull request tries to add support for 7 auxilary keys present on the Artisul M0610 Pro tablet.

Points I would like to state before the PR gets merged:
- The 8th aux key, the wheel itself, and the key inside the wheel, don't send any event, which I verified on TabletDebugger and by reading from device /dev file.
- I didn't try to add support of tilt.
- I verified the 7 aux keys are getting binded correctly and actually working. But, whenever I was on TabletDebugger screen, and pressed any aux key, I would get the following error, whose root cause I couldn't figure out:
  ```
  System.IndexOutOfRangeException: Index was outside the bounds of the array.
    at OpenTabletDriver.Desktop.ViewModels.Utility.Statistic.SaveButtons(Boolean[] buttons, Int32 expectedButtons) in /home/yoimiya/git/OpenTabletDriver/OpenTabletDriver.Desktop/ViewModels/Utility/Statistics.cs:line 201
    at OpenTabletDriver.Desktop.ViewModels.TabletDebuggerViewModel.set_ReportData(DebugReportData value) in /home/yoimiya/git/OpenTabletDriver/OpenTabletDriver.Desktop/ViewModels/TabletDebuggerViewModel.cs:line 125
    at GLib.Timeout.TimeoutProxy.Handler()
  ```
