### PR TITLE
Add support for another way of wheel reporting from Huion Kamvas 13 (Gen 3)

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/Huion/GianoReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Huion/GianoReportParser.cs
@@ -11,6 +11,8 @@ namespace OpenTabletDriver.Configurations.Parsers.Huion
         {
             if (data[1] == 0xF1)
                 return new KamvasRelWheelReport(data);
+            if (data[1] == 0xF0)
+                return new UCLogicAuxRelWheelReport(data);
             if (data[1].IsBitSet(5) && data[1].IsBitSet(6))
                 return new UCLogicAuxReport(data);
             else

--- a/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicAuxRelWheelReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicAuxRelWheelReport.cs
@@ -1,0 +1,35 @@
+using OpenTabletDriver.Plugin.Tablet;
+using OpenTabletDriver.Plugin.Tablet.Wheel;
+
+namespace OpenTabletDriver.Configurations.Parsers.UCLogic
+{
+    public struct UCLogicAuxRelWheelReport : IAuxReport, IRelativeWheelReport
+    {
+        public UCLogicAuxRelWheelReport(byte[] report)
+        {
+            Raw = report;
+
+            AuxButtons =
+            [
+                report[4].IsBitSet(0),
+                report[4].IsBitSet(1),
+                report[4].IsBitSet(2),
+                report[4].IsBitSet(3),
+                report[4].IsBitSet(4),
+                report[4].IsBitSet(5),
+                report[4].IsBitSet(6),
+                report[4].IsBitSet(7),
+            ];
+
+            AnalogDeltas =
+            [
+                (sbyte)report[5],
+                (sbyte)report[6],
+            ];
+        }
+
+        public bool[] AuxButtons { set; get; }
+        public byte[] Raw { set; get; }
+        public int[] AnalogDeltas { get; set; }
+    }
+}


### PR DESCRIPTION
Yes, we already have wheel support for this tablet. Yes, this is detected as the exact same tablet we already have support for. Yes, it reports the wheel differently while not even having any difference in identifiers.

...

Wheel data alone: [tablet-data_1777616712.txt](https://github.com/user-attachments/files/27283082/tablet-data_1777616712.txt)
Moving the pen around: [tablet-data_1777617525.txt](https://github.com/user-attachments/files/27283087/tablet-data_1777617525.txt)
First wheel moving while pressing aux buttons (note that wheel and aux are seen in the same reports): [tablet-data_1777617562.txt](https://github.com/user-attachments/files/27283092/tablet-data_1777617562.txt)
Same as above but the second wheel: [tablet-data_1777617618.txt](https://github.com/user-attachments/files/27283099/tablet-data_1777617618.txt)

Verification: https://discord.com/channels/615607687467761684/723399565780189234/1500386953202372699