### PR TITLE
Remove variation selector 16 from down arrow

### DIFF
--- a/OpenTabletDriver.Desktop/ViewModels/Utility/Statistics.cs
+++ b/OpenTabletDriver.Desktop/ViewModels/Utility/Statistics.cs
@@ -246,7 +246,7 @@ namespace OpenTabletDriver.Desktop.ViewModels.Utility
                 button.Value switch
                 { // add 1 to key number to display human-friendly number
                     null => $"{button.Key + 1}✔",
-                    false => $"{button.Key + 1}↓️️",
+                    false => $"{button.Key + 1}↓",
                     true => $"{button.Key + 1}↑",
                 };
         }


### PR DESCRIPTION
Windows doesn't have the fonts to render it or wpf is doing something weird... it renders as a box. And we arent even using it.

<img width="139" height="78" alt="image" src="https://github.com/user-attachments/assets/7e2113a3-f8bf-493a-b583-1159c0a5789b" />
