### PR TITLE
Use symbols from the Miscellaneous Symbols and Arrows block instead of the Arrows and Dingbats blocks

### DIFF
--- a/OpenTabletDriver.Desktop/ViewModels/Utility/Statistics.cs
+++ b/OpenTabletDriver.Desktop/ViewModels/Utility/Statistics.cs
@@ -245,9 +245,9 @@ namespace OpenTabletDriver.Desktop.ViewModels.Utility
             string SelectEmojisFromButtonBool(KeyValuePair<int, bool?> button) =>
                 button.Value switch
                 { // add 1 to key number to display human-friendly number
-                    null => $"{button.Key + 1}✔",
-                    false => $"{button.Key + 1}↓️️",
-                    true => $"{button.Key + 1}↑",
+                    null => $"{button.Key + 1}⮃",
+                    false => $"{button.Key + 1}⭣",
+                    true => $"{button.Key + 1}⭡",
                 };
         }
 


### PR DESCRIPTION
It looks alright on Linux as-is but on Windows it does not (ignore the boxes, those would be fixed with #4791).
<img width="139" height="78" alt="image" src="https://github.com/user-attachments/assets/2a936f1e-7d5e-42c0-a9d7-992745f2ebb6" />


Windows:
<img width="181" height="150" alt="image" src="https://github.com/user-attachments/assets/b2ad67f3-4dbd-45e7-a6a5-aee6ac8c8725" />

Linux:
<img width="160" height="138" alt="image" src="https://github.com/user-attachments/assets/2749640b-85f7-401f-bcf7-e337620df126" />
