### PR TITLE
Fix windows tablet debugger additional statistics from failing due to STAThread error

### DIFF
--- a/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
+++ b/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
@@ -398,7 +398,7 @@ namespace OpenTabletDriver.UX.Windows.Tablet
             // don't do anything if there isn't anything to do anyway
             if (viewmodel.AdditionalStatistics.Children.Count == 0) return;
 
-            await Task.Run(async () =>
+            await Application.Instance.InvokeAsync(async () =>
             {
                 var outerContainer = new StackLayout
                 {


### PR DESCRIPTION
The error:
<img width="957" height="418" alt="image" src="https://github.com/user-attachments/assets/677a9d8a-0189-42b5-8f8e-51459cbed292" />

"STAThread refers to 'Single-Threaded Apartments' which refers to the threading model used by the current (main) thread."
"The single-threaded application model requires that no single object 'live in' more than one STA thread at a time"