### PR TITLE
Use regular checkmark instead of heavy checkmark

### DIFF
--- a/OpenTabletDriver.Desktop/ViewModels/Utility/Statistics.cs
+++ b/OpenTabletDriver.Desktop/ViewModels/Utility/Statistics.cs
@@ -245,7 +245,7 @@ namespace OpenTabletDriver.Desktop.ViewModels.Utility
             string SelectEmojisFromButtonBool(KeyValuePair<int, bool?> button) =>
                 button.Value switch
                 { // add 1 to key number to display human-friendly number
-                    null => $"{button.Key + 1}✔",
+                    null => $"{button.Key + 1}✓",
                     false => $"{button.Key + 1}↓",
                     true => $"{button.Key + 1}↑",
                 };

--- a/OpenTabletDriver.UX/Windows/Plugins/PluginMetadataList.cs
+++ b/OpenTabletDriver.UX/Windows/Plugins/PluginMetadataList.cs
@@ -16,7 +16,7 @@ namespace OpenTabletDriver.UX.Windows.Plugins
     {
         public PluginMetadataList()
         {
-            ItemTextBinding = Binding.Property<PluginMetadata, string>(m => m.Installed ? $"✔ {m.Name}" : m.Name);
+            ItemTextBinding = Binding.Property<PluginMetadata, string>(m => m.Installed ? $"✓ {m.Name}" : m.Name);
 
             Refresh();
             AppInfo.PluginManager.AssembliesChanged += (sender, e) => Refresh();


### PR DESCRIPTION
Linux:
<img width="331" height="511" alt="image" src="https://github.com/user-attachments/assets/1527c8e1-444f-4ed8-b3d6-83f06f7ee5e4" />
<img width="164" height="130" alt="image" src="https://github.com/user-attachments/assets/8c172290-4217-4456-b8d5-a15d8d84c383" />

Windows:
<img width="186" height="173" alt="image" src="https://github.com/user-attachments/assets/2d71adda-482d-4de8-b72f-8b86126cfca8" />
<img width="191" height="89" alt="image" src="https://github.com/user-attachments/assets/ab4f3961-f259-4bd7-bc48-ca5cf673b732" />

Heavy checkmark (before this PR) looked fine on Linux but terrible on Windows:
<img width="181" height="164" alt="image" src="https://github.com/user-attachments/assets/5a1e19c0-6f39-4f42-8d4a-04fc1055e3f7" />
<img width="309" height="388" alt="image" src="https://github.com/user-attachments/assets/593c31ec-a0ab-465e-9613-ed53297f1486" />
