### PR TITLE
CTE-640: Use correct parser

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-640.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTE-640.json
@@ -23,7 +23,7 @@
       "VendorID": 1386,
       "ProductID": 22,
       "InputReportLength": 8,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Bamboo.BambooReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Graphire.GraphireReportParser",
       "FeatureInitReport": [
         "AgI="
       ]


### PR DESCRIPTION
The other tablets were fixed in #4058 but this specific model was apparently missed

Fixes #4749