### PR TITLE
Skip opening google devices stream

### DIFF
--- a/OpenTabletDriver/Devices/WinUSB/WinUSBInterface.cs
+++ b/OpenTabletDriver/Devices/WinUSB/WinUSBInterface.cs
@@ -37,6 +37,11 @@ namespace OpenTabletDriver.Devices.WinUSB
                     throw new IOException(
                         "skipping device with idVendor 0x2833 (Meta/Facebook/Oculus) due to known issues with Quest headsets");
                 }
+                else if (deviceDescriptor.idVendor == 0x18D1)
+                {
+                    throw new IOException(
+                        "skipping device with idVendor 0x18D1 (Google) due to known issues with android bootloaders in fastboot mode");
+                }
 
                 var interfaceDescriptor = new InterfaceDescriptor();
                 if (!WinUsb_QueryInterfaceSettings(winUsbHandle, 0, &interfaceDescriptor))

--- a/OpenTabletDriver/Devices/WinUSB/WinUSBRootHub.cs
+++ b/OpenTabletDriver/Devices/WinUSB/WinUSBRootHub.cs
@@ -109,9 +109,10 @@ namespace OpenTabletDriver.Devices.WinUSB
                 var winUsbInterface = new WinUSBInterface(devicePath);
                 list.Add(winUsbInterface);
             }
-            catch
+            catch (Exception ex)
             {
                 Log.Write("WinUSB", $"Cannot create device for '{devicePath}'");
+                Log.Exception(ex);
             }
         }
 


### PR DESCRIPTION
Due to a bug in android bootloaders, attempting to open those devices may break them in unusual ways.
(especially when in fastboot mode)

Fixes #4722