### PR TITLE
Experimental mouse scrolling for all output modes

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -500,9 +500,17 @@ namespace OpenTabletDriver.Daemon
 
             if (pointer is IMouseButtonHandler mouseButtonHandler)
                 bindingServiceProvider.AddService(() => mouseButtonHandler);
+            // experimental mouse button handler was tried, it behaves very weird
 
             if (pointer is IMouseScrollHandler mouseScrollHandler)
                 bindingServiceProvider.AddService(() => mouseScrollHandler);
+            else if (DesktopInterop.RelativePointer is IMouseScrollHandler detachedMouseScrollHandler)
+            {
+                Log.Write(nameof(CreateBindingHandler),
+                    "Using experimental mouse scroll handler for output mode not implementing mouse scrolling",
+                    LogLevel.Debug);
+                bindingServiceProvider.AddService(() => detachedMouseScrollHandler);
+            }
 
             if (pointer is IPenActionHandler penActionHandler)
                 bindingServiceProvider.AddService(() => penActionHandler);


### PR DESCRIPTION
Some output modes (Linux Artist Mode, Windows Ink, maybe more?) do not support any mouse events.

This uses a relative mouse handler as the mouse scrolling handler for those output modes, enabling mouse scroll bindings to work on some setups.
    
Tested working on Sway WM 1.12

Untested on Windows and macOS