### PR TITLE
Add another Deco 01 V2 variant

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01 V2 (Variant 2).json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco 01 V2 (Variant 2).json
@@ -43,6 +43,20 @@
         "4": "UG902_BPG1002",
         "5": "^202\\d-\\d{2}-\\d{2}"
       }
+    },
+    {
+      "VendorID": 10429,
+      "ProductID": 2306,
+      "InputReportLength": 12,
+      "OutputReportLength": 14,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
+      "OutputInitReport": [
+        "ArAE"
+      ],
+      "DeviceStrings": {
+        "4": "UG903_BPN1002",
+        "5": "^202\\d-\\d{2}-\\d{2}"
+      }
     }
   ],
   "Attributes": {


### PR DESCRIPTION
It's time to add another variant to our favorite tablet, the Deco 01 V2. Full on new variant this time. No funny business.

Diag: [diag.json](https://github.com/user-attachments/files/27383282/diag.json)

Strings:
Index 4: UG903_BPN1002L-F
Index 5: 2025-07-17_Release1

Verification (not being strict here since it just needs to match specs close enough): https://discord.com/channels/615607687467761684/615611007951306863/1501047435856711904 https://discord.com/channels/615607687467761684/615611007951306863/1501049666400157806