### PR TITLE
Gaomon M6: Add wheel support

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M6.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M6.json
@@ -13,14 +13,20 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 13
-    }
+    },
+    "Wheels": [
+      {
+        "AbsoluteWheelMax": 11,
+        "ButtonCount": 0
+      }
+    ]
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 100,
       "InputReportLength": 12,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicV2ReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicV2WheelReportParser",
       "DeviceStrings": {
         "201": "(OEM02_T183|GM001_T223)_\\d{6}$"
       },
@@ -32,7 +38,7 @@
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicV2ReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicV2WheelReportParser",
       "DeviceStrings": {
         "201": "OEM02_T183_\\d{6}$"
       },

--- a/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicV2WheelReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicV2WheelReportParser.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics.CodeAnalysis;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.UCLogic
+{
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    public class UCLogicV2WheelReportParser : IReportParser<IDeviceReport>
+    {
+        public IDeviceReport Parse(byte[] data)
+        {
+            return data[1] switch
+            {
+                0xe0 => new UCLogicAuxReport(data),
+                0xf0 => new UCLogicWheelReport(data),
+                _ => new TiltTabletReport(data)
+            };
+        }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicWheelReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicWheelReport.cs
@@ -1,0 +1,25 @@
+using OpenTabletDriver.Plugin.Tablet.Wheel;
+
+namespace OpenTabletDriver.Configurations.Parsers.UCLogic
+{
+    public struct UCLogicWheelReport : IAbsoluteWheelReport
+    {
+        private const byte RawMinPosition = 1;
+        private const byte RawMaxPosition = 12;
+
+        public UCLogicWheelReport(byte[] report)
+        {
+            Raw = report;
+
+            var wheelData = report[5];
+
+            uint? position = wheelData is >= RawMinPosition and <= RawMaxPosition
+                ? (uint)(RawMaxPosition - wheelData)
+                : null;
+            AnalogPositions = [position];
+        }
+
+        public uint?[] AnalogPositions { set; get; }
+        public byte[] Raw { set; get; }
+    }
+}

--- a/OpenTabletDriver.Tests/Binding/GaomonM6WheelBindingTests.cs
+++ b/OpenTabletDriver.Tests/Binding/GaomonM6WheelBindingTests.cs
@@ -1,0 +1,105 @@
+using System.Linq;
+using OpenTabletDriver.Configurations.Parsers.UCLogic;
+using OpenTabletDriver.Desktop.Binding;
+using OpenTabletDriver.Plugin;
+using OpenTabletDriver.Plugin.Tablet;
+using OpenTabletDriver.Tests.ConfigurationTest;
+using Xunit;
+
+namespace OpenTabletDriver.Tests.Binding
+{
+    public class GaomonM6WheelBindingTests
+    {
+        [Fact]
+        public void GaomonM6_Configures_One_Twelve_Step_Absolute_Wheel()
+        {
+            var configuration = GetGaomonM6Configuration();
+            var wheel = configuration.Specifications.Wheels!.Single();
+
+            Assert.Equal(11u, wheel.AbsoluteWheelMax!.Value);
+            Assert.Null(wheel.RelativeWheelSteps);
+            Assert.Equal(12u, wheel.StepCount!.Value);
+            Assert.Equal(0u, wheel.ButtonCount);
+        }
+
+        [Fact]
+        public void GaomonM6_Uses_Wheel_Parser_For_All_Digitizer_Identifiers()
+        {
+            var configuration = GetGaomonM6Configuration();
+
+            Assert.All(configuration.DigitizerIdentifiers, identifier =>
+                Assert.Equal(typeof(UCLogicV2WheelReportParser).FullName, identifier.ReportParser));
+        }
+
+        [Fact]
+        public void GaomonM6_RawWheelReports_Invoke_Clockwise_Binding()
+        {
+            var parser = new UCLogicV2WheelReportParser();
+            var bindingHandler = CreateGaomonM6BindingHandler();
+            var binding = new CountingBinding();
+            bindingHandler.Wheels[0].ClockwiseRotation = new DeltaThresholdBindingState
+            {
+                Binding = binding,
+                ActivationThreshold = 30,
+                IsNegativeThreshold = false
+            };
+
+            bindingHandler.HandleBinding(parser.Parse(CreateGaomonM6WheelReport(0x0C)));
+            bindingHandler.HandleBinding(parser.Parse(CreateGaomonM6WheelReport(0x0B)));
+
+            Assert.Equal(1, binding.Presses);
+        }
+
+        [Fact]
+        public void GaomonM6_RawWheelReports_Invoke_CounterClockwise_Binding()
+        {
+            var parser = new UCLogicV2WheelReportParser();
+            var bindingHandler = CreateGaomonM6BindingHandler();
+            var binding = new CountingBinding();
+            bindingHandler.Wheels[0].CounterClockwiseRotation = new DeltaThresholdBindingState
+            {
+                Binding = binding,
+                ActivationThreshold = 30,
+                IsNegativeThreshold = true
+            };
+
+            bindingHandler.HandleBinding(parser.Parse(CreateGaomonM6WheelReport(0x0B)));
+            bindingHandler.HandleBinding(parser.Parse(CreateGaomonM6WheelReport(0x0C)));
+
+            Assert.Equal(1, binding.Presses);
+        }
+
+        private static TabletConfiguration GetGaomonM6Configuration()
+        {
+            return TestData.DeviceConfigurationProvider.TabletConfigurations
+                .Single(config => config.Name == "Gaomon M6");
+        }
+
+        private static BindingHandler CreateGaomonM6BindingHandler()
+        {
+            var configuration = GetGaomonM6Configuration();
+
+            return new BindingHandler(new TabletReference(configuration, configuration.DigitizerIdentifiers));
+        }
+
+        private static byte[] CreateGaomonM6WheelReport(byte rawPosition) =>
+        [
+            0x08, 0xF0, 0x01, 0x01, 0x00, rawPosition,
+            0x00, 0x00, 0x00, 0x00, 0x13, 0xF2
+        ];
+
+        private sealed class CountingBinding : IStateBinding
+        {
+            public int Presses { get; private set; }
+
+            public void Press(TabletReference tablet, IDeviceReport report)
+            {
+                Presses++;
+            }
+
+            public void Release(TabletReference tablet, IDeviceReport report)
+            {
+            }
+        }
+    }
+}

--- a/OpenTabletDriver.Tests/Parsers/UCLogicV2WheelReportParserTests.cs
+++ b/OpenTabletDriver.Tests/Parsers/UCLogicV2WheelReportParserTests.cs
@@ -1,0 +1,57 @@
+using OpenTabletDriver.Configurations.Parsers.UCLogic;
+using OpenTabletDriver.Plugin.Tablet;
+using OpenTabletDriver.Plugin.Tablet.Wheel;
+using Xunit;
+
+namespace OpenTabletDriver.Tests.Parsers
+{
+    public class UCLogicV2WheelReportParserTests
+    {
+        [Theory]
+        [InlineData(0x01, 11)]
+        [InlineData(0x0B, 1)]
+        [InlineData(0x0C, 0)]
+        public void Parses_Wheel_Report_With_Clockwise_Increasing_Position(byte rawPosition, uint expectedPosition)
+        {
+            var parser = new UCLogicV2WheelReportParser();
+            var report = parser.Parse(CreateWheelReport(rawPosition));
+
+            var wheelReport = Assert.IsAssignableFrom<IAbsoluteWheelReport>(report);
+            Assert.Equal(new uint?[] { expectedPosition }, wheelReport.AnalogPositions);
+        }
+
+        [Fact]
+        public void Parses_Idle_Wheel_Report_As_Null_Position()
+        {
+            var parser = new UCLogicV2WheelReportParser();
+            var report = parser.Parse(CreateWheelReport(0x00));
+
+            var wheelReport = Assert.IsAssignableFrom<IAbsoluteWheelReport>(report);
+            Assert.Equal(new uint?[] { null }, wheelReport.AnalogPositions);
+        }
+
+        [Fact]
+        public void Preserves_UCLogic_V2_Aux_Report_Parsing()
+        {
+            var parser = new UCLogicV2WheelReportParser();
+            var report = parser.Parse([0x08, 0xE0, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x13, 0xF2]);
+
+            Assert.IsAssignableFrom<IAuxReport>(report);
+        }
+
+        [Fact]
+        public void Preserves_UCLogic_V2_Tablet_Report_Parsing()
+        {
+            var parser = new UCLogicV2WheelReportParser();
+            var report = parser.Parse([0x08, 0x80, 0x40, 0x1F, 0x20, 0x4E, 0x10, 0x00, 0x00, 0x20, 0x13, 0xF2]);
+
+            Assert.IsAssignableFrom<ITabletReport>(report);
+        }
+
+        private static byte[] CreateWheelReport(byte rawPosition) =>
+        [
+            0x08, 0xF0, 0x01, 0x01, 0x00, rawPosition,
+            0x00, 0x00, 0x00, 0x00, 0x13, 0xF2
+        ];
+    }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -260,7 +260,7 @@
 | Gaomon M10K Pro                    |  Missing Features | Wheel is not yet supported.
 | Gaomon M1220                       |  Missing Features | Wheel is not yet supported.
 | Gaomon M1230                       |  Missing Features | Touch bar is not yet supported.
-| Gaomon M6                          |  Missing Features | Wheel and touch bar are not yet supported.
+| Gaomon M6                          |  Missing Features | Touch bar is not yet supported.
 | Gaomon M8                          |  Missing Features | Wheel is not yet supported.
 | Gaomon M8 (Variant 2)              |  Missing Features | Wheel is not yet supported.
 | Gaomon PD156 Pro                   |  Missing Features | Wheel is not yet supported.


### PR DESCRIPTION
# Changes

- Add wheel support for the Gaomon M6.
- Add a UCLogic V2 wheel parser for `0xf0` reports where the wheel position is reported in `data[5]`.
- Configure the M6 as a 12-step absolute wheel without changing the shared `UCLogicV2ReportParser` used by other tablets.
- Update `TABLETS.md` so the M6 only lists the touch bar as unsupported.
- Add parser and binding tests covering wheel report parsing, idle wheel reports, clockwise rotation, and counter-clockwise rotation.

This intentionally only covers wheel rotation. Touch bar support and VMulti/Windows Ink mouse-scroll compatibility are outside the scope of this PR.

Validation:
- `git diff --check origin/0.6.x..HEAD`
- Static M6 config assertions: one wheel, `AbsoluteWheelMax = 11`, `ButtonCount = 0`, and both M6 digitizer identifiers use `UCLogicV2WheelReportParser`.
- `dotnet test` could not be run locally because this machine has no .NET SDK installed and dotnet reports the upstream `global.json` SDK version as invalid in this environment.