### PR TITLE
Huion HS611 support for touch strip/wheel and touch buttons

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/HS611.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/HS611.json
@@ -13,14 +13,21 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 10
-    }
+    },
+    "Wheels": [
+      {
+        "AbsoluteWheelMax": 7,
+        "AngleOfZeroReading": 90.0,
+        "ButtonCount": 0
+      }
+    ]
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.HS611ReportParser",
       "DeviceStrings": {
         "201": "HUION_T19c_\\d{6}$"
       },
@@ -32,7 +39,7 @@
       "VendorID": 9580,
       "ProductID": 111,
       "InputReportLength": 12,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.HS611ReportParser",
       "DeviceStrings": {
         "201": "HUION_T19c_\\d{6}$"
       },

--- a/OpenTabletDriver.Configurations/Configurations/Huion/HS611.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/HS611.json
@@ -64,6 +64,22 @@
       "Attributes": {
         "Interface": "2"
       }
+    },
+    {
+      "VendorID": 9580,
+      "ProductID": 109,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.HS611MediaAuxReportParser",
+      "Attributes": {
+        "Interface": "1"
+      }
+    },
+    {
+      "VendorID": 9580,
+      "ProductID": 111,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.HS611MediaAuxReportParser",
+      "Attributes": {
+        "Interface": "1"
+      }
     }
   ],
   "Attributes": {

--- a/OpenTabletDriver.Configurations/Configurations/Huion/HS611.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/HS611.json
@@ -12,7 +12,7 @@
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {
-      "ButtonCount": 10
+      "ButtonCount": 18
     },
     "Wheels": [
       {
@@ -46,6 +46,24 @@
       "InitializationStrings": [
         200
       ]
+    }
+  ],
+  "AuxiliaryDeviceIdentifiers": [
+    {
+      "VendorID": 9580,
+      "ProductID": 109,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.HS611MediaAuxReportParser",
+      "Attributes": {
+        "Interface": "2"
+      }
+    },
+    {
+      "VendorID": 9580,
+      "ProductID": 111,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.HS611MediaAuxReportParser",
+      "Attributes": {
+        "Interface": "2"
+      }
     }
   ],
   "Attributes": {

--- a/OpenTabletDriver.Configurations/Parsers/Huion/HS611AuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Huion/HS611AuxReport.cs
@@ -1,0 +1,55 @@
+using OpenTabletDriver.Configurations.Parsers.UCLogic;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Huion
+{
+    public struct HS611AuxReport : IAuxReport
+    {
+        public HS611AuxReport(byte[] report)
+        {
+            Raw = report;
+            var auxReport = new UCLogicAuxReport(report);
+            AuxButtons = HS611AuxState.UpdatePadButtons(auxReport.AuxButtons);
+        }
+
+        public bool[] AuxButtons { get; set; }
+        public byte[] Raw { get; set; }
+    }
+
+    internal static class HS611AuxState
+    {
+        // Pad buttons (indices 0-9) arrive on the digitizer interface, touch buttons
+        // (indices 10-17) on the media aux interface; both are merged into Buttons.
+        private const int PAD_BUTTON_COUNT = 10;
+        private const int TOTAL_BUTTON_COUNT = 18;
+
+        private static readonly object Lock = new();
+        private static readonly bool[] Buttons = new bool[TOTAL_BUTTON_COUNT];
+
+        public static bool[] UpdatePadButtons(bool[] auxButtons)
+        {
+            lock (Lock)
+            {
+                for (int i = 0; i < PAD_BUTTON_COUNT; i++)
+                    Buttons[i] = i < auxButtons.Length && auxButtons[i];
+
+                return (bool[])Buttons.Clone();
+            }
+        }
+
+        public static bool[] SetTouchButton(int buttonIndex, bool pressed)
+        {
+            lock (Lock)
+            {
+                Buttons[buttonIndex] = pressed;
+                return (bool[])Buttons.Clone();
+            }
+        }
+
+        public static bool[] Snapshot()
+        {
+            lock (Lock)
+                return (bool[])Buttons.Clone();
+        }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Huion/HS611MediaAuxReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Huion/HS611MediaAuxReportParser.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Huion
+{
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    public class HS611MediaAuxReportParser : IReportParser<IDeviceReport>
+    {
+        // data[0] report IDs emitted by the touch buttons on the media aux interface.
+        private const byte CONSUMER_REPORT = 0x01;
+        private const byte KEYBOARD_REPORT = 0x03;
+
+        private static readonly Dictionary<ushort, int> ConsumerButtonMap = new()
+        {
+            [0x00E2] = 10, // Mute
+            [0x00EA] = 11, // Volume down
+            [0x00E9] = 12, // Volume up
+            [0x00B6] = 13, // Previous track
+            [0x00CD] = 14, // Play/pause
+            [0x00B5] = 15  // Next track
+        };
+
+        private static readonly Dictionary<(byte Modifier, byte KeyCode), int> KeyboardButtonMap = new()
+        {
+            [(0x08, 0x2B)] = 16, // Left GUI + Tab
+            [(0x08, 0x07)] = 17  // Left GUI + D
+        };
+
+        private int? _activeConsumerButton;
+        private int? _activeKeyboardButton;
+
+        public IDeviceReport Parse(byte[] data)
+        {
+            if (data.Length < 3)
+                return new DeviceReport(data);
+
+            return data[0] switch
+            {
+                CONSUMER_REPORT => ParseConsumerReport(data),
+                KEYBOARD_REPORT => ParseKeyboardReport(data),
+                _ => new DeviceReport(data)
+            };
+        }
+
+        private HS611TouchAuxReport ParseConsumerReport(byte[] data)
+        {
+            if (_activeConsumerButton is int previousButton)
+                HS611AuxState.SetTouchButton(previousButton, false);
+
+            _activeConsumerButton = null;
+
+            // HID consumer usage is reported little-endian in bytes 1-2.
+            ushort usage = BitConverter.ToUInt16(data, 1);
+            if (usage != 0 && ConsumerButtonMap.TryGetValue(usage, out int buttonIndex))
+            {
+                _activeConsumerButton = buttonIndex;
+                return new HS611TouchAuxReport(data, HS611AuxState.SetTouchButton(buttonIndex, true));
+            }
+
+            return new HS611TouchAuxReport(data, HS611AuxState.Snapshot());
+        }
+
+        private HS611TouchAuxReport ParseKeyboardReport(byte[] data)
+        {
+            if (_activeKeyboardButton is int previousButton)
+                HS611AuxState.SetTouchButton(previousButton, false);
+
+            _activeKeyboardButton = null;
+
+            byte modifier = data[1];
+            byte keyCode = data[2];
+            if (modifier != 0 || keyCode != 0)
+            {
+                var combo = (modifier, keyCode);
+                if (!KeyboardButtonMap.TryGetValue(combo, out int buttonIndex))
+                    return new HS611TouchAuxReport(data, HS611AuxState.Snapshot());
+
+                _activeKeyboardButton = buttonIndex;
+                return new HS611TouchAuxReport(data, HS611AuxState.SetTouchButton(buttonIndex, true));
+            }
+
+            return new HS611TouchAuxReport(data, HS611AuxState.Snapshot());
+        }
+    }
+
+    public struct HS611TouchAuxReport : IAuxReport
+    {
+        public HS611TouchAuxReport(byte[] raw, bool[] auxButtons)
+        {
+            Raw = raw;
+            AuxButtons = auxButtons;
+        }
+
+        public bool[] AuxButtons { get; set; }
+        public byte[] Raw { get; set; }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Huion/HS611ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Huion/HS611ReportParser.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using OpenTabletDriver.Configurations.Parsers.UCLogic;
 using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Configurations.Parsers.Huion
@@ -15,7 +14,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Huion
             return data[1] switch
             {
                 TOUCH_STRIP => new HuionWheelReport(data),
-                _ when data[1].IsBitSet(6) => new UCLogicAuxReport(data),
+                _ when data[1].IsBitSet(6) => new HS611AuxReport(data),
                 _ => new TiltTabletReport(data, false, true)
             };
         }

--- a/OpenTabletDriver.Configurations/Parsers/Huion/HS611ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Huion/HS611ReportParser.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics.CodeAnalysis;
+using OpenTabletDriver.Configurations.Parsers.UCLogic;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Huion
+{
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    public class HS611ReportParser : IReportParser<IDeviceReport>
+    {
+        // data[1] value identifying a touch strip (wheel) report.
+        private const byte TOUCH_STRIP = 0xF0;
+
+        public IDeviceReport Parse(byte[] data)
+        {
+            return data[1] switch
+            {
+                TOUCH_STRIP => new HuionWheelReport(data),
+                _ when data[1].IsBitSet(6) => new UCLogicAuxReport(data),
+                _ => new TiltTabletReport(data, false, true)
+            };
+        }
+    }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -282,7 +282,7 @@
 | Huion H610 Pro V3                  |  Missing Features | Tablet buttons are not yet supported. Windows: Requires Zadig's WinUSB to be installed on interface 1. Current tablet configuration has very low resolution.
 | Huion HC16                         |  Missing Features | Wheel is not yet supported.
 | Huion HC16 (Variant 2)             |  Missing Features | Wheel is not yet supported.
-| Huion HS611                        |  Missing Features | Touch bar is not yet supported.
+| Huion HS611                        |  Missing Features | Touch strip is supported, but touch bar buttons are not yet supported.
 | Huion Kamvas Pro 12                |  Missing Features | Touch bar is not yet supported.
 | Huion Kamvas Pro 13                |  Missing Features | Touch bar is not yet supported.
 | Huion Kamvas Pro 16                |  Missing Features | Touch bar is not yet supported.

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -38,6 +38,7 @@
 | Huion HS64                         |     Supported     |
 | Huion HS95                         |     Supported     |
 | Huion HS610                        |     Supported     |
+| Huion HS611                        |     Supported     | Top-Right Touch buttons act like auxiliary buttons.
 | Huion Kamvas 12                    |     Supported     |
 | Huion Kamvas 13                    |     Supported     |
 | Huion Kamvas 16                    |     Supported     |
@@ -282,7 +283,6 @@
 | Huion H610 Pro V3                  |  Missing Features | Tablet buttons are not yet supported. Windows: Requires Zadig's WinUSB to be installed on interface 1. Current tablet configuration has very low resolution.
 | Huion HC16                         |  Missing Features | Wheel is not yet supported.
 | Huion HC16 (Variant 2)             |  Missing Features | Wheel is not yet supported.
-| Huion HS611                        |  Missing Features | Touch strip is supported, but touch bar buttons are not yet supported.
 | Huion Kamvas Pro 12                |  Missing Features | Touch bar is not yet supported.
 | Huion Kamvas Pro 13                |  Missing Features | Touch bar is not yet supported.
 | Huion Kamvas Pro 16                |  Missing Features | Touch bar is not yet supported.


### PR DESCRIPTION
Closes #4217

Adds touch bar support for HS611, both wheel/strip and touch buttons as auxiliary buttons

Tested it