### PR TITLE
macos: Correct "Equal" key to kVK_ANSI_Equal instead of keypad

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/Keyboard/MacOSVirtualKeyboard.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Keyboard/MacOSVirtualKeyboard.cs
@@ -144,7 +144,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Keyboard
             //{ "Menu", CGKeyCode.kVK_ANSI_MENU },
             { "Backslash", CGKeyCode.kVK_ANSI_Backslash },
             { "Plus", CGKeyCode.kVK_ANSI_KeypadPlus },
-            { "Equal", CGKeyCode.kVK_ANSI_KeypadEquals },
+            { "Equal", CGKeyCode.kVK_ANSI_Equal },
             { "Semicolon", CGKeyCode.kVK_ANSI_Semicolon },
             { "Quote", CGKeyCode.kVK_ANSI_Quote },
             { "Comma", CGKeyCode.kVK_ANSI_Comma },

--- a/OpenTabletDriver.Desktop/Interop/Input/Keyboard/MacOSVirtualKeyboard.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Keyboard/MacOSVirtualKeyboard.cs
@@ -150,7 +150,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Keyboard
             { "Comma", CGKeyCode.kVK_ANSI_Comma },
             { "Period", CGKeyCode.kVK_ANSI_Period },
             { "ForwardSlash", CGKeyCode.kVK_ANSI_Slash },
-            { "Slash", CGKeyCode.kVK_ANSI_Backslash },
+            { "Slash", CGKeyCode.kVK_ANSI_Slash },
             { "RightBracket", CGKeyCode.kVK_ANSI_RightBracket },
             { "LeftBracket", CGKeyCode.kVK_ANSI_LeftBracket },
             //{ "ContextMenu", CGKeyCode.kVK_ANSI_MENU },


### PR DESCRIPTION
Some applications do not accept the numpad Equals key for hotkeys. This changes the mapping from kVK_ANSI_KeypadEquals to kVK_ANSI_Equal.