### PR TITLE
macOS: Bring window to foreground when shown

### DIFF
--- a/OpenTabletDriver.UX.MacOS/FormHandler.cs
+++ b/OpenTabletDriver.UX.MacOS/FormHandler.cs
@@ -1,0 +1,12 @@
+using MonoMac.AppKit;
+
+namespace OpenTabletDriver.UX.MacOS;
+
+class FormHandler : Eto.Mac.Forms.FormHandler
+{
+    public override void Show()
+    {
+        NSApplication.SharedApplication.ActivateIgnoringOtherApps(true);
+        base.Show();
+    }
+}

--- a/OpenTabletDriver.UX.MacOS/Platform.cs
+++ b/OpenTabletDriver.UX.MacOS/Platform.cs
@@ -1,0 +1,11 @@
+using Eto.Forms;
+
+namespace OpenTabletDriver.UX.MacOS;
+
+public class Platform : Eto.Mac.Platform
+{
+    public Platform() : base()
+    {
+        Add<Form.IHandler>(() => new FormHandler());
+    }
+}

--- a/OpenTabletDriver.UX.MacOS/Program.cs
+++ b/OpenTabletDriver.UX.MacOS/Program.cs
@@ -9,7 +9,7 @@ namespace OpenTabletDriver.UX.MacOS
         {
             if (PermissionHelper.HasPermissions())
             {
-                App.Run(Eto.Platforms.Mac64, args);
+                App.Run("OpenTabletDriver.UX.MacOS.Platform, OpenTabletDriver.UX.MacOS", args);
             }
         }
     }


### PR DESCRIPTION
Since we set LSUIElement to hide the dock, the app can no longer bring its windows to the front. We now manually call ActivateIgnoringOtherApps to ensure the window is brought to the foreground.