### PR TITLE
macOS: restore menu bar and bring window to foreground

### DIFF
--- a/OpenTabletDriver.UX.MacOS/FormHandler.cs
+++ b/OpenTabletDriver.UX.MacOS/FormHandler.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Linq;
+using Eto.Forms;
+using MonoMac.AppKit;
+
+namespace OpenTabletDriver.UX.MacOS;
+
+internal class FormHandler : Eto.Mac.Forms.FormHandler
+{
+    protected override void Initialize()
+    {
+        base.Initialize();
+        Widget.WindowStateChanged += UpdateActivationPolicy;
+        Widget.LostFocus += UpdateActivationPolicy;
+        Widget.GotFocus += UpdateActivationPolicy;
+    }
+
+    public override void Show()
+    {
+        NSApplication.SharedApplication.ActivateIgnoringOtherApps(true);
+        base.Show();
+    }
+
+    private void UpdateActivationPolicy(object sender, EventArgs e)
+    {
+        var hasNonMinimizedVisibleWindow =
+            Application.Instance.Windows.Any(window => window.Visible && window.WindowState != WindowState.Minimized);
+        NSApplication.SharedApplication.ActivationPolicy = hasNonMinimizedVisibleWindow
+            ? NSApplicationActivationPolicy.Regular : NSApplicationActivationPolicy.Accessory;
+    }
+}

--- a/OpenTabletDriver.UX.MacOS/Platform.cs
+++ b/OpenTabletDriver.UX.MacOS/Platform.cs
@@ -1,0 +1,11 @@
+using Eto.Forms;
+
+namespace OpenTabletDriver.UX.MacOS;
+
+public class Platform : Eto.Mac.Platform
+{
+    public Platform() : base()
+    {
+        Add<Form.IHandler>(() => new FormHandler());
+    }
+}

--- a/OpenTabletDriver.UX.MacOS/Program.cs
+++ b/OpenTabletDriver.UX.MacOS/Program.cs
@@ -9,7 +9,7 @@ namespace OpenTabletDriver.UX.MacOS
         {
             if (PermissionHelper.HasPermissions())
             {
-                App.Run(Eto.Platforms.Mac64, args);
+                App.Run("OpenTabletDriver.UX.MacOS.Platform, OpenTabletDriver.UX.MacOS", args);
             }
         }
     }

--- a/eng/bash/macos/Info.plist
+++ b/eng/bash/macos/Info.plist
@@ -30,6 +30,6 @@
     <key>NSRequiresAquaSystemAppearance</key>
     <string>False</string>
     <key>LSUIElement</key>
-    <string>true</string>
+    <string>False</string>
   </dict>
 </plist>


### PR DESCRIPTION
Use NSApplicationActivationPolicy to dynamically hide the Dock icon when the MainForm loses focus or is minimized. Call ActivateIgnoringOtherApps to properly bring the application to the foreground when it gains focus or is de-minimized.

Supersedes #4816 #4817