### PR TITLE
Add XP-Pen Deco Pro M wheel and touchpad support

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro Medium.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro Medium.json
@@ -13,7 +13,17 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    }
+    },
+    "Wheels": [
+      {
+        "RelativeWheelSteps": 24,
+        "ButtonCount": 0
+      },
+      {
+        "RelativeWheelSteps": 24,
+        "ButtonCount": 0
+      }
+    ]
   },
   "DigitizerIdentifiers": [
     {

--- a/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenAuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenAuxReport.cs
@@ -33,12 +33,28 @@ namespace OpenTabletDriver.Configurations.Parsers.XP_Pen
                 report[auxIndex + 2].IsBitSet(3),
             ];
 
-            // 0x01 for 1st wheel clockwise, 0x02 for counterclockwise, verified on XP Pen Artist 13.3 Pro V2
-            // 0x10 for 2nd wheel clockwise, 0x20 for counterclockwise, verified on XP Pen Artist 22R Pro
+            // 0x01 for 1st wheel clockwise, 0x02 for counterclockwise,
+            // verified on XP-Pen Artist 13.3 Pro V2 and Deco Pro M
+
+            // 0x10 for 2nd wheel clockwise, 0x20 for counterclockwise,
+            // verified on XP-Pen Artist 22R Pro
+
+            // 0x04 for touchpad clockwise, 0x08 for counterclockwise,
+            // verified on XP-Pen Deco Pro M
+
             AnalogDeltas =
             [
-                report[wheelIndex].IsBitSet(0) ? 1 : report[wheelIndex].IsBitSet(1) ? -1 : 0,
-                report[wheelIndex].IsBitSet(4) ? 1 : report[wheelIndex].IsBitSet(5) ? -1 : 0,
+                report[wheelIndex].IsBitSet(0)
+                    ? 1
+                    : report[wheelIndex].IsBitSet(1)
+                        ? -1
+                        : 0,
+
+                report[wheelIndex].IsBitSet(4) || report[wheelIndex].IsBitSet(2)
+                    ? 1
+                    : report[wheelIndex].IsBitSet(5) || report[wheelIndex].IsBitSet(3)
+                        ? -1
+                        : 0,
             ];
         }
 

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -197,6 +197,7 @@
 | XP-Pen Deco Fun S (CT640)          |     Supported     |
 | XP-Pen Deco Fun XS (CT430)         |     Supported     |
 | XP-Pen Deco M                      |     Supported     |
+| XP-Pen Deco Pro Medium             |     Supported     |
 | XP-Pen Deco MW                     |     Supported     |
 | XP-Pen Deco L                      |     Supported     |
 | XP-Pen Deco LW                     |     Supported     |
@@ -345,7 +346,6 @@
 | XP-Pen Artist Pro 19 (Gen2)        |  Missing Features | Scroll Wheel on Pen is not yet supported
 | XP-Pen Deco 02                     |  Missing Features | Wheel is not yet supported.
 | XP-Pen Deco mini7W V2              |  Missing Features | Wireless is not yet supported.
-| XP-Pen Deco Pro Medium             |  Missing Features | Tilt and wheel are not yet supported.
 | XP-Pen Deco Pro Small              |  Missing Features | Trackpad is not yet supported.
 | XP-Pen Deco Pro SW                 |  Missing Features | Wheel is not yet supported.
 | XP-Pen Deco Pro MW                 |  Missing Features | Touch wheel and physical wheel are not yet supported.


### PR DESCRIPTION
Adds support for the XP-Pen Deco Pro M wheel and touch wheel input mappings.

The tablet exposes two wheel-like inputs:

* an outer physical wheel using the existing mapping
* an inner touch wheel using different bits (`0x04` / `0x08`) 

This change adds support for the Deco Pro M touch wheel bit mapping while preserving compatibility with existing devices.

## Tested on

* XP-Pen Deco Pro Medium

## Notes

The inner control is technically a touch wheel/touchpad, but it behaves as a wheel-like rotational input in practice.

## Input mapping captures
<img width="935" height="617" alt="wheel1_counterclockwise" src="https://github.com/user-attachments/assets/e29e1bb5-0840-4091-a1f6-96491779f8ac" />
<img width="949" height="656" alt="wheel1" src="https://github.com/user-attachments/assets/645bcff7-5bde-4bfd-8ae1-cded0a2abe6e" />
<img width="942" height="613" alt="wheel2_counterclockwise" src="https://github.com/user-attachments/assets/05e21a17-59ff-4a63-a99b-8de545ae6656" />
<img width="935" height="619" alt="wheel2" src="https://github.com/user-attachments/assets/1f528e3a-25e5-4a5b-a1f3-0a5a87bb882c" />
