### PR TITLE
Fix Gaomon M10K Pro: Add Touch Ring support and unbind auxiliary buttons

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M10K Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M10K Pro.json
@@ -12,15 +12,21 @@
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {
-      "ButtonCount": 10
-    }
+      "ButtonCount": 11
+    },
+    "Wheels": [
+      {
+        "AbsoluteWheelMax": 13,
+        "ButtonCount": 0
+      }
+    ]
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 109,
       "InputReportLength": 12,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.HuionTiltReportParser",
       "DeviceStrings": {
         "201": "OEM02_T19n_\\d{6}$"
       },
@@ -32,7 +38,7 @@
       "VendorID": 9580,
       "ProductID": 111,
       "InputReportLength": 12,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.HuionTiltReportParser",
       "DeviceStrings": {
         "201": "OEM02_T19n_\\d{6}$"
       },

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -258,7 +258,7 @@
 | Artisul D16 Pro                    |  Missing Features | Wheel is not yet supported.
 | Artisul M0610 Pro                  |  Missing Features | Tablet buttons, tilt, and wheel are not yet supported.
 | Gaomon M10K                        |  Missing Features | Wheel is not yet supported.
-| Gaomon M10K Pro                    |  Missing Features | Wheel is not yet supported.
+| Gaomon M10K Pro                    |     Supported     | Center wheel button acts as auxiliary button 11.
 | Gaomon M1220                       |  Missing Features | Wheel is not yet supported.
 | Gaomon M1230                       |  Missing Features | Touch bar is not yet supported.
 | Gaomon M6                          |  Missing Features | Wheel and touch bar are not yet supported.


### PR DESCRIPTION
This PR fixes the Touch Ring and the center button behavior for the Gaomon M10K Pro.

Technical details:
1. Switched ReportParser from UCLogicTiltReportParser to HuionTiltReportParser. The previous parser was incorrectly interpreting the absolute wheel coordinates (0x01 - 0x0D) as auxiliary button presses.
2. Added Wheels array with AbsoluteWheelMax: 13. This enables smooth, directional scrolling/brush resizing.
3. Increased ButtonCount to 11. The physical center button sends "04" in the second auxiliary byte (Button 11). Previously, it was mirroring Button 3 due to the 10-button limit.

Tested on Gentoo Linux with OpenTabletDriver v0.6.7. Everything works as intended.