### PR TITLE
UCLogic wheel support for Gaomon M10K / M10K Pro, artist mode scroll fix

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M10K Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M10K Pro.json
@@ -13,7 +13,14 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 10
-    }
+    },
+    "Wheels": [
+      {
+        "AbsoluteWheelMax": 11,
+        "AngleOfZeroReading": 180.0,
+        "ButtonCount": 0
+      }
+    ]
   },
   "DigitizerIdentifiers": [
     {

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M10K Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M10K Pro.json
@@ -12,11 +12,11 @@
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {
-      "ButtonCount": 10
+      "ButtonCount": 11
     },
     "Wheels": [
       {
-        "AbsoluteWheelMax": 11,
+        "AbsoluteWheelMax": 12,
         "AngleOfZeroReading": 180.0,
         "ButtonCount": 0
       }

--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M10K.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M10K.json
@@ -13,7 +13,14 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 11
-    }
+    },
+    "Wheels": [
+      {
+        "AbsoluteWheelMax": 11,
+        "AngleOfZeroReading": 180.0,
+        "ButtonCount": 0
+      }
+    ]
   },
   "DigitizerIdentifiers": [
     {

--- a/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicReportParser.cs
@@ -11,6 +11,9 @@ namespace OpenTabletDriver.Configurations.Parsers.UCLogic
             if (data[1] == 0xC0)
                 return new OutOfRangeReport(data);
 
+            if (data[1] == 0xf0)
+                return new UCLogicWheelReport(data);
+
             if (data[1].IsBitSet(6))
                 return new UCLogicAuxReport(data);
             else

--- a/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicTiltReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicTiltReportParser.cs
@@ -8,6 +8,9 @@ namespace OpenTabletDriver.Configurations.Parsers.UCLogic
     {
         public IDeviceReport Parse(byte[] data)
         {
+            if (data[1] == 0xf0)
+                return new UCLogicWheelReport(data);
+
             if (data[1].IsBitSet(6))
                 return new UCLogicAuxReport(data);
             else

--- a/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicV2ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicV2ReportParser.cs
@@ -11,8 +11,7 @@ namespace OpenTabletDriver.Configurations.Parsers.UCLogic
             return data[1] switch
             {
                 0xe0 => new UCLogicAuxReport(data),
-                // 0xf0 is for wheel data, reported in data[5], ignore for now
-                0xf0 => new DeviceReport(data),
+                0xf0 => new UCLogicWheelReport(data),
                 _ => new TiltTabletReport(data)
             };
         }

--- a/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicWheelReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicWheelReport.cs
@@ -1,0 +1,18 @@
+using OpenTabletDriver.Plugin.Tablet.Wheel;
+
+namespace OpenTabletDriver.Configurations.Parsers.UCLogic
+{
+    public struct UCLogicWheelReport : IAbsoluteWheelReport
+    {
+        public UCLogicWheelReport(byte[] data)
+        {
+            Raw = data;
+            var pos = data[5];
+            // pos == 0 means the ring is not being touched; subtract 1 to make it 0-indexed
+            AnalogPositions = [pos != 0 ? pos - 1u : null];
+        }
+
+        public byte[] Raw { set; get; }
+        public uint?[] AnalogPositions { set; get; }
+    }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -257,8 +257,8 @@
 | Artisul AP604 (Pencil Small)       |  Missing Features | Aux buttons and eraser detection are not yet supported. Windows: Requires Zadig's WinUSB to be installed on interface 1.
 | Artisul D16 Pro                    |  Missing Features | Wheel is not yet supported.
 | Artisul M0610 Pro                  |  Missing Features | Tablet buttons, tilt, and wheel are not yet supported.
-| Gaomon M10K                        |  Missing Features | Wheel is not yet supported.
-| Gaomon M10K Pro                    |  Missing Features | Wheel is not yet supported.
+| Gaomon M10K                        |  Supported        |
+| Gaomon M10K Pro                    |  Supported        |
 | Gaomon M1220                       |  Missing Features | Wheel is not yet supported.
 | Gaomon M1230                       |  Missing Features | Touch bar is not yet supported.
 | Gaomon M6                          |  Missing Features | Wheel and touch bar are not yet supported.


### PR DESCRIPTION
## What this does

The Gaomon M10K and M10K Pro have a touch ring. The 0xf0 report byte carrying wheel data was being parsed and thrown away. This wires it up, and also fixes scroll bindings doing nothing in artist mode on Linux.

### UCLogic wheel support

New `UCLogicWheelReport` struct handles 0xf0 reports across all three UCLogic parsers. Position comes from data[5]; 0 means not touching, otherwise decremented to zero-index it. The M10K and M10K Pro configs now declare the wheel (AbsoluteWheelMax: 11, AngleOfZeroReading: 180), and both are marked Supported in TABLETS.md.

### Artist mode scroll fix

In Linux artist mode the output pointer is a uinput tablet device — it doesn't implement IMouseScrollHandler, so scroll bindings were registered against nothing. The daemon now falls back to the relative pointer (virtual mouse) for scroll when the output mode's pointer doesn't provide it.

## Testing

Tested on a Gaomon M10K Pro. Touch ring works in artist mode, and scroll bindings work in both absolute and artist output modes.