### PR TITLE
Daemon: Fix scroll bindings in artist mode on Linux

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -501,8 +501,12 @@ namespace OpenTabletDriver.Daemon
             if (pointer is IMouseButtonHandler mouseButtonHandler)
                 bindingServiceProvider.AddService(() => mouseButtonHandler);
 
-            if (pointer is IMouseScrollHandler mouseScrollHandler)
-                bindingServiceProvider.AddService(() => mouseScrollHandler);
+            // Fall back to the virtual mouse for scroll when the output mode's pointer is a tablet
+            // device that libinput won't route scroll events from (e.g. Linux artist mode).
+            var scrollHandler = (pointer as IMouseScrollHandler)
+                ?? (DesktopInterop.RelativePointer as IMouseScrollHandler);
+            if (scrollHandler != null)
+                bindingServiceProvider.AddService(() => scrollHandler);
 
             if (pointer is IPenActionHandler penActionHandler)
                 bindingServiceProvider.AddService(() => penActionHandler);


### PR DESCRIPTION
In artist mode, the output pointer is a virtual tablet device that doesn't implement IMouseScrollHandler, so scroll bindings were silently dropped.

Now falls back to DesktopInterop.RelativePointer for scroll when the output mode's pointer doesn't provide it.