### PR TITLE
Remove intentional throw from unknown path on `outputModeSelector.SelectedItemBinding.Convert`

### DIFF
--- a/OpenTabletDriver.Desktop/Reflection/PluginSettingStore.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginSettingStore.cs
@@ -70,7 +70,7 @@ namespace OpenTabletDriver.Desktop.Reflection
             return obj;
         }
 
-        public static PluginSettingStore? FromPath(string path)
+        public static PluginSettingStore? FromPath(string? path)
         {
             var pathType = AppInfo.PluginManager.PluginTypes.FirstOrDefault(t => t.FullName == path);
             return pathType != null ? new PluginSettingStore(pathType) : null;

--- a/OpenTabletDriver.UX/Controls/Output/OutputModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/OutputModeEditor.cs
@@ -32,10 +32,10 @@ namespace OpenTabletDriver.UX.Controls.Output
             absoluteModeEditor.SettingsBinding.Bind(ProfileBinding.Child(p => p!.AbsoluteModeSettings));
             relativeModeEditor.SettingsBinding.Bind(ProfileBinding.Child(p => p!.RelativeModeSettings));
 
-            outputModeSelector.SelectedItemBinding.Convert<PluginSettingStore>(
-                c => (c != null ? PluginSettingStore.FromPath(c.FullName!) : null) ?? throw new InvalidOperationException($"TypeInfo lookup: unknown path '{c?.FullName}'"),
+            outputModeSelector.SelectedItemBinding.Convert<PluginSettingStore?>(
+                c => PluginSettingStore.FromPath(c?.FullName),
                 v => v?.GetTypeInfo()
-            ).Bind(ProfileBinding.Child(c => c!.OutputMode));
+            ).Bind(ProfileBinding.Child(c => c != null ? c.OutputMode : null));
 
             outputModeSelector.SelectedValueChanged += (sender, e) => UpdateOutputMode(Profile?.OutputMode);
 


### PR DESCRIPTION
It's okay if `PluginSettingStore` is null here.

I would like to do `c => c?.OutputMode` but that's not allowed. `An expression tree lambda may not contain a null propagating operator`

Regression from #4779