### PR TITLE
Allow configs to match `HID_REPORTS` device attribute

### DIFF
--- a/OpenTabletDriver.Tests/ConfigurationTest/AttributesTest.SelfTests.cs
+++ b/OpenTabletDriver.Tests/ConfigurationTest/AttributesTest.SelfTests.cs
@@ -104,6 +104,7 @@ namespace OpenTabletDriver.Tests.ConfigurationTest
                 yield return new(Consts.VERIFIED_LPI_KEY, ConfigurationAttributes.CheckVerifiedLPI);
                 yield return new("FeatureInitDelayMs", ConfigurationAttributes.CheckFeatureInitDelayMs);
                 yield return new("WinUsage", ConfigurationAttributes.CheckWinUsage);
+                yield return new("HidReports", ConfigurationAttributes.CheckHidReports);
             }
         }
 

--- a/OpenTabletDriver.Tests/ConfigurationTest/AttributesTest.cs
+++ b/OpenTabletDriver.Tests/ConfigurationTest/AttributesTest.cs
@@ -61,6 +61,34 @@ namespace OpenTabletDriver.Tests.ConfigurationTest
             /// <returns><c>true</c> if string is a zero-padded string <see cref="uint"/> value that is exactly 2 characters</returns>
             internal static bool CheckWinUsage(string attributeValue) =>
                 uint.TryParse(attributeValue, out _) && attributeValue.Length == 2;
+
+
+            /// <summary>
+            /// Checks if <c>HidReports</c> matches expected format
+            /// </summary>
+            /// <param name="attributeValue">The value of the <c>HidReports</c> key</param>
+            /// <returns><c>true</c> if all HidReport values in string are <c>, </c> separated and follow the format <c>{byte:X2}:{ushort:X4}:{ushort:X4}</c></returns>
+            internal static bool CheckHidReports(string attributeValue)
+            {
+                var splitHidReports = attributeValue.Split(", ");
+                foreach (var hidReport in splitHidReports)
+                {
+                    var splitHidReport = hidReport.Split(":");
+                    if (splitHidReport.Length != 3)
+                        return false;
+
+                    if (splitHidReport[0].Length != 2 || splitHidReport[1].Length != 4 || splitHidReport[2].Length != 4)
+                        return false;
+
+                    if (!byte.TryParse(splitHidReport[0], System.Globalization.NumberStyles.HexNumber, null, out _)
+                        || !ushort.TryParse(splitHidReport[1], System.Globalization.NumberStyles.HexNumber, null, out _)
+                        || !ushort.TryParse(splitHidReport[2], System.Globalization.NumberStyles.HexNumber, null, out _))
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
         }
 
         [Theory, MemberData(nameof(TestData.TestTabletConfigurations), MemberType = typeof(TestData))]

--- a/OpenTabletDriver.Tests/ConfigurationTest/DeviceIdentifierTest.cs
+++ b/OpenTabletDriver.Tests/ConfigurationTest/DeviceIdentifierTest.cs
@@ -93,6 +93,12 @@ namespace OpenTabletDriver.Tests.ConfigurationTest
                     return false;
             }
 
+            if ((a.Attributes?.TryGetValue("HidReports", out string? aHidReports) ?? false) && (b.Attributes?.TryGetValue("HidReports", out string? bHidReports) ?? false))
+            {
+                if (aHidReports != bHidReports)
+                    return false;
+            }
+
             if (a.DeviceStrings is null || a.DeviceStrings.Count == 0 || b.DeviceStrings is null || b.DeviceStrings.Count == 0)
             {
                 return true; // One or both have no device strings, so they match.

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -228,7 +228,8 @@ namespace OpenTabletDriver
             }
 
             if (attributes.TryGetValue("HidReports", out var hidReports)
-                && (!device.DeviceAttributes.TryGetValue("HID_REPORTS", out var usbHidReports) || !Regex.IsMatch(usbHidReports, hidReports)))
+                && device.DeviceAttributes.TryGetValue("HID_REPORTS", out var usbHidReports)
+                && !Regex.IsMatch(usbHidReports, hidReports))
             {
                 return false; // HidReports specified and no HID Reports match.
             }

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -227,6 +227,12 @@ namespace OpenTabletDriver
                 }
             }
 
+            if (attributes.TryGetValue("HidReports", out var hidReports)
+                && (!device.DeviceAttributes.TryGetValue("HID_REPORTS", out var usbHidReports) || !Regex.IsMatch(usbHidReports, hidReports)))
+            {
+                return false; // HidReports specified and no HID Reports match.
+            }
+
             if (!attributes.TryGetValue("Interface", out var identifierInterface))
                 return true; // No interface specified, match.
 


### PR DESCRIPTION
Got a case where this will be necessary. Might update this PR to include dependant config later.

Example of what this looks like:
```json
"DigitizerIdentifiers": [
  {
    "VendorID": 1386,
    "ProductID": 1013,
    "InputReportLength": 192,
    "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV3.IntuosV3ReportParser",
    "FeatureInitReport": [
      "AgI="
    ],
    "Attributes": {
      "HidReports": "FE:0001:0080, 06:000D:0001, 1E:FF0D:0001, 11:FF0D:0001, 13:FF0D:0001, AC:FF0D:0001"
    }
  }
]
```

I don't totally love that this is string matching into something that should probably be a collection. But `HID_REPORTS` does appear to always be consistently ordered. And device attributes currently can only be a string. Could also split it apart for this check but that also seems a little jank. Can deal with this being a problem when it arises.