### PR TITLE
Add support for weird kamvas 16 gen3

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 16 (Gen 3).json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Kamvas 16 (Gen 3).json
@@ -36,7 +36,25 @@
       },
       "InitializationStrings": [
         200
-      ]
+      ],
+      "Attributes": {
+        "HidReports": "08:FF00:0001"
+      }
+    },
+    {
+      "VendorID": 9580,
+      "ProductID": 8201,
+      "InputReportLength": 14,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.KamvasOffsetReportParser",
+      "DeviceStrings": {
+        "201": "HUION_M22d_\\d{6}$"
+      },
+      "InitializationStrings": [
+        200
+      ],
+      "Attributes": {
+        "HidReports": "08:000D:0002, 09:0001:0007, AC:0001:0007"
+      }
     }
   ],
   "Attributes": {

--- a/OpenTabletDriver.Configurations/Parsers/Huion/KamvasOffsetReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Huion/KamvasOffsetReport.cs
@@ -13,14 +13,14 @@ namespace OpenTabletDriver.Configurations.Parsers.Huion
             Position = new Vector2
             {
                 X = Unsafe.ReadUnaligned<ushort>(ref report[2]) | ((report[4] & 1) << 16),
-                Y = Unsafe.ReadUnaligned<ushort>(ref report[5]) | ((report[7] & 1) << 16)
+                Y = Unsafe.ReadUnaligned<ushort>(ref report[5])
             };
             Tilt = new Vector2
             {
                 X = (sbyte)report[10] * -1,
                 Y = (sbyte)report[11] * -1
             };
-            Pressure = Unsafe.ReadUnaligned<ushort>(ref report[8]);
+            Pressure = Unsafe.ReadUnaligned<ushort>(ref report[7]);
 
             PenButtons =
             [

--- a/OpenTabletDriver.Configurations/Parsers/Huion/KamvasOffsetReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Huion/KamvasOffsetReport.cs
@@ -1,0 +1,39 @@
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Huion
+{
+    public struct KamvasOffsetReport : ITabletReport, ITiltReport
+    {
+        internal KamvasOffsetReport(byte[] report)
+        {
+            Raw = report;
+
+            Position = new Vector2
+            {
+                X = Unsafe.ReadUnaligned<ushort>(ref report[2]) | ((report[4] & 1) << 16),
+                Y = Unsafe.ReadUnaligned<ushort>(ref report[5]) | ((report[7] & 1) << 16)
+            };
+            Tilt = new Vector2
+            {
+                X = (sbyte)report[10] * -1,
+                Y = (sbyte)report[11] * -1
+            };
+            Pressure = Unsafe.ReadUnaligned<ushort>(ref report[8]);
+
+            PenButtons =
+            [
+                report[1].IsBitSet(1),
+                report[1].IsBitSet(2),
+                report[1].IsBitSet(3),
+            ];
+        }
+
+        public byte[] Raw { set; get; }
+        public Vector2 Position { set; get; }
+        public Vector2 Tilt { set; get; }
+        public uint Pressure { set; get; }
+        public bool[] PenButtons { set; get; }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Huion/KamvasOffsetReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Huion/KamvasOffsetReportParser.cs
@@ -1,0 +1,20 @@
+using System.Diagnostics.CodeAnalysis;
+using OpenTabletDriver.Configurations.Parsers.UCLogic;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Huion
+{
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    public class KamvasOffsetReportParser : IReportParser<IDeviceReport>
+    {
+        public IDeviceReport Parse(byte[] data)
+        {
+            if (data[1] == 0xF1)
+                return new KamvasRelWheelReport(data);
+            if (data[1].IsBitSet(5) && data[1].IsBitSet(6))
+                return new UCLogicAuxReport(data);
+            else
+                return new KamvasOffsetReport(data);
+        }
+    }
+}


### PR DESCRIPTION
Tablet might be in android mode but it appears that huion has not provided any way to get it out of android mode.

Uses/depends on #4836

Fixes #4837

Confirmed working in https://github.com/OpenTabletDriver/OpenTabletDriver/issues/4837#issuecomment-4529867574

Will need `UCLogicAuxRelWheelReport` from #4788 added in for proper wheel support.