### PR TITLE
Skip known dangerous strings in string dump by default

### DIFF
--- a/OpenTabletDriver.UX/Windows/DeviceStringReader.cs
+++ b/OpenTabletDriver.UX/Windows/DeviceStringReader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -18,7 +19,7 @@ namespace OpenTabletDriver.UX.Windows
         {
             this.Title = "Device String Reader";
             this.Icon = App.Logo.WithSize(App.Logo.Size);
-            this.ClientSize = new Size(-1, 320);
+            this.ClientSize = new Size(-1, 345);
 
             var sendRequestButton = new Button
             {
@@ -54,6 +55,7 @@ namespace OpenTabletDriver.UX.Windows
                     productIdCtrl,
                     stringIndexCtrl,
                     requireReconnect,
+                    requestDangerous,
                     new StackLayoutItem(
                         new StackLayout
                         {
@@ -119,6 +121,15 @@ namespace OpenTabletDriver.UX.Windows
         private const string DisconnectionIndex = "Device disconnected";
         private const string OperationTimedOut = "Operation timed-out";
         private const string OperationFailed = "Operation failed";
+        private static Dictionary<int, string> GetDangerousStrings(int vendorId) => vendorId switch
+        {
+            // XP-Pen, UGEE, and XenceLabs
+            10429 => new()
+            {
+                [200] = "Common DFU String"
+            },
+            _ => [],
+        };
 
         private async void SendRequestAllStrings(object? sender, EventArgs args)
         {
@@ -138,10 +149,19 @@ namespace OpenTabletDriver.UX.Windows
                 return;
             }
 
+            var requestDangerousStrings = requestDangerous.Checked.HasValue && (bool)requestDangerous.Checked;
+            var dangerousStrings = requestDangerousStrings ? [] : GetDangerousStrings(vid);
+
             var stringDump = new StringBuilder();
 
             for (int i = 1; i < 256; i++)
             {
+                if (dangerousStrings.ContainsKey(i))
+                {
+                    stringDump.AppendLine($"{StringIndex} {i}: {{ OTD: {dangerousStrings[i]} }}");
+                    continue;
+                }
+
                 bool shouldRead = true;
                 await SendRequestWithTimeout($"{i}",
                     (str) => stringDump.AppendLine($"{StringIndex} {i}: {str}"),
@@ -266,6 +286,13 @@ namespace OpenTabletDriver.UX.Windows
             Text = "Require reconnect on fail",
             Checked = false,
             ToolTip = "Pauses string dump with a pop-up box if any string dump errors occur",
+        };
+
+        private readonly CheckBox requestDangerous = new()
+        {
+            Text = "Dump potentially dangerous strings",
+            Checked = false,
+            ToolTip = "Requests all strings in a string dump even if they are known to likely damage or disrupt usage of the tablet",
         };
     }
 }


### PR DESCRIPTION
Sometimes users run a string dump on their tablets without knowing they probably shouldn't be randomly doing that. This should allow for minimizing the risk.