### PR TITLE
Fix full area resize breaking aspect ratio lock

### DIFF
--- a/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
@@ -191,7 +191,17 @@ namespace OpenTabletDriver.UX.Controls.Output
                 }
                 else if (sender == tabletHeight)
                 {
-                    tabletWidth.DataValue = displayWidth.DataValue / displayHeight.DataValue * tabletHeight.DataValue;
+                    var fullWidth = tabletAreaEditor.FullAreaBounds!.Value.Width;
+                    var scaledWidth = displayWidth.DataValue / displayHeight.DataValue * tabletHeight.DataValue;
+                    if (tabletAreaEditor.FullAreaCommandExecuting && scaledWidth > fullWidth)
+                    {
+                        tabletWidth.DataValue = fullWidth;
+                        tabletHeight.DataValue = displayHeight.DataValue / displayWidth.DataValue * fullWidth;
+                    }
+                    else
+                    {
+                        tabletWidth.DataValue = scaledWidth;
+                    }
                 }
                 else if ((sender == displayWidth) && prevDisplayWidth is float prevWidth)
                 {


### PR DESCRIPTION
Regression caused by #4435

Same deal as the logic above it running under `if (sender == tabletWidth || sender == tabletAreaEditor)` except flipped for height.

Without this when using the full area resize the height aspect ratio locker for may (if the ratio is >1) try to keep the height full and expand the width out of bounds. Then the area constrainer runs and sees that the width is out of bounds and snaps it into bounds. This leaves the user with the tablet's area set to the entire full area but ignoring their aspect ratio setting.

Why this wasn't broken before (v0.6.6.2), I'm not sure and I haven't looked into.

Also not entirely sure why this logic is locked behind `tabletAreaEditor.FullAreaCommandExecuting` since this allows the user to type in values manually that break the aspect ratio. But this matches the previous behavior.