### PR TITLE
Absolute area editor fixups

### DIFF
--- a/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
@@ -207,9 +207,8 @@ namespace OpenTabletDriver.UX.Controls.Output
         {
             if (sender is not AreaDisplay display) return;
 
-            if (!handlingForcedArConstraint && !handlingSettingsChanging && display.LockToUsableArea && display.Area != null)
+            if (!handlingSettingsChanging && display.LockToUsableArea && display.Area != null)
             {
-                handlingForcedArConstraint = true;
                 Debug.Assert(display.FullAreaBounds.HasValue);
                 var fullBounds = display.FullAreaBounds.Value;
 
@@ -223,12 +222,16 @@ namespace OpenTabletDriver.UX.Controls.Output
                             display.Area.Height = fullBounds.Height;
                     }
 
+                    if (handlingForcedArConstraint) return;
+
+                    handlingForcedArConstraint = true;
+
                     var correction = GetOutOfBoundsAmount(display, display.Area.X, display.Area.Y);
                     display.Area.X -= correction.X;
                     display.Area.Y -= correction.Y;
-                }
 
-                handlingForcedArConstraint = false;
+                    handlingForcedArConstraint = false;
+                }
             }
         }
 

--- a/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
@@ -173,17 +173,7 @@ namespace OpenTabletDriver.UX.Controls.Output
             {
                 if (sender == tabletWidth || sender == tabletAreaEditor)
                 {
-                    var fullHeight = tabletAreaEditor.FullAreaBounds!.Value.Height;
-                    var scaledHeight = displayHeight.DataValue / displayWidth.DataValue * tabletWidth.DataValue;
-                    if (tabletAreaEditor.FullAreaCommandExecuting && scaledHeight > fullHeight)
-                    {
-                        tabletHeight.DataValue = fullHeight;
-                        tabletWidth.DataValue = displayWidth.DataValue / displayHeight.DataValue * fullHeight;
-                    }
-                    else
-                    {
-                        tabletHeight.DataValue = scaledHeight;
-                    }
+                    tabletHeight.DataValue = displayHeight.DataValue / displayWidth.DataValue * tabletWidth.DataValue;
                 }
                 else if (sender == tabletHeight)
                 {

--- a/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
@@ -93,7 +93,6 @@ namespace OpenTabletDriver.UX.Controls.Output
         internal TabletAreaEditor tabletAreaEditor;
 
         private bool arLockHooked;
-        private bool handlingArLock;
         private bool handlingForcedArConstraint;
         private bool handlingSettingsChanging;
         private float? prevDisplayWidth;
@@ -170,11 +169,8 @@ namespace OpenTabletDriver.UX.Controls.Output
 
         private void HandleAspectRatioLock(object? sender, EventArgs e)
         {
-            if (!handlingArLock && !handlingSettingsChanging)
+            if (!handlingSettingsChanging)
             {
-                // Avoids looping
-                handlingArLock = true;
-
                 if (sender == tabletWidth || sender == tabletAreaEditor)
                 {
                     var fullHeight = tabletAreaEditor.FullAreaBounds!.Value.Height;
@@ -204,8 +200,6 @@ namespace OpenTabletDriver.UX.Controls.Output
 
                 prevDisplayWidth = displayWidth.DataValue;
                 prevDisplayHeight = displayHeight.DataValue;
-
-                handlingArLock = false;
             }
         }
 

--- a/OpenTabletDriver.UX/Controls/Output/Area/AreaEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/Area/AreaEditor.cs
@@ -132,8 +132,6 @@ namespace OpenTabletDriver.UX.Controls.Output.Area
 
         public AreaDisplay Display { get; }
 
-        public bool FullAreaCommandExecuting { get; private set; }
-
         public override IEnumerable<RectangleF>? AreaBounds
         {
             set
@@ -247,12 +245,10 @@ namespace OpenTabletDriver.UX.Controls.Output.Area
                                 MenuText = "Full area",
                                 Action = () =>
                                 {
-                                    FullAreaCommandExecuting = true;
                                     Area!.Height = FullAreaBounds!.Value.Height;
                                     Area!.Width = FullAreaBounds!.Value.Width;
                                     Area!.Y = FullAreaBounds!.Value.Center.Y;
                                     Area!.X = FullAreaBounds!.Value.Center.X;
-                                    FullAreaCommandExecuting = false;
                                 }
                             },
                             new ActionCommand

--- a/OpenTabletDriver.UX/Controls/Output/Area/AreaEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/Area/AreaEditor.cs
@@ -245,8 +245,16 @@ namespace OpenTabletDriver.UX.Controls.Output.Area
                                 MenuText = "Full area",
                                 Action = () =>
                                 {
-                                    Area!.Height = FullAreaBounds!.Value.Height;
-                                    Area!.Width = FullAreaBounds!.Value.Width;
+                                    if (Display.Area!.Width > Display.Area.Height)
+                                    {
+                                        Area!.Height = FullAreaBounds!.Value.Height;
+                                        Area!.Width = FullAreaBounds!.Value.Width;
+                                    }
+                                    else // reorder setting order on vertical aspect ratios to un-jank 'force aspect ratio'
+                                    {
+                                        Area!.Width = FullAreaBounds!.Value.Width;
+                                        Area!.Height = FullAreaBounds!.Value.Height;
+                                    }
                                     Area!.Y = FullAreaBounds!.Value.Center.Y;
                                     Area!.X = FullAreaBounds!.Value.Center.X;
                                 }
@@ -256,8 +264,16 @@ namespace OpenTabletDriver.UX.Controls.Output.Area
                                 MenuText = "Quarter area",
                                 Action = () =>
                                 {
-                                    Area!.Height = FullAreaBounds!.Value.Height / 2;
-                                    Area!.Width = FullAreaBounds!.Value.Width / 2;
+                                    if (Display.Area!.Width > Display.Area.Height)
+                                    {
+                                        Area!.Height = FullAreaBounds!.Value.Height / 2;
+                                        Area!.Width = FullAreaBounds!.Value.Width / 2;
+                                    }
+                                    else // reorder setting order on vertical aspect ratios to un-jank 'force aspect ratio'
+                                    {
+                                        Area!.Width = FullAreaBounds!.Value.Width / 2;
+                                        Area!.Height = FullAreaBounds!.Value.Height / 2;
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Extends #4844 and fixes up some more area editor shenanigans and code quality

- Removing the confusing `FullAreaCommandExecuting` boolean
  - Seems to no longer be necessary after #4435
  - I'm guessing it existed to avoid an infinite loop, or weird state/outcomes. Seems to not cause any issues by removing it.
- Reduced scope of the area constraint lock as it was causing issues when validating user input with aspect ratio lock on.
  - As seen in #4844, locking out further field validation during field validation causes jank to happen in edge cases.
  - Instead of locking instantly when verifying area constraints, we only lock during offset calculations, as it unfortunately seems that floating point weirdness occasionally causes the calculations to never stabilize and eventually throws a stack overflow.
    - Forced max precision (e.g. integer based units or similar idea) would very likely solve the lock still being needed.
- Reordered order of assignments when display is vertical (aspect ratio below 1)
  - Otherwise, vertical displays would break "map to X area" on tablets with aspect ratio lock on.
  - I believe this was reported/discussed on our Discord at some point, but I was not able to find it tracked here on GitHub

Anyway, as usual with GUI stuff, test it out and see what you think. 0.6.7 is in a pretty rough state in regards to this.