### PR TITLE
Windows: refresh display topology after monitor changes

### DIFF
--- a/OpenTabletDriver.Daemon.Contracts/IDriverDaemon.cs
+++ b/OpenTabletDriver.Daemon.Contracts/IDriverDaemon.cs
@@ -17,6 +17,7 @@ namespace OpenTabletDriver.Daemon.Contracts
         event EventHandler<IEnumerable<PluginSettings>>? ToolsChanged;
         event EventHandler<PluginContextDto>? PluginAdded;
         event EventHandler<PluginContextDto>? PluginRemoved;
+        event EventHandler? DisplayChanged;
 
         Task Initialize();
 

--- a/OpenTabletDriver.Daemon.Library/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon.Library/DriverDaemon.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Win32;
 using OpenTabletDriver.Components;
 using OpenTabletDriver.Daemon.Contracts;
 using OpenTabletDriver.Daemon.Contracts.Persistence;
@@ -53,6 +54,7 @@ namespace OpenTabletDriver.Daemon.Library
         private Settings? _lastValidSettings;
         private bool _debugging;
         private bool _isScanningDevices;
+        private bool _displayChangeEventsInitialized;
 
         public DriverDaemon(
             IServiceProvider serviceProvider,
@@ -90,6 +92,7 @@ namespace OpenTabletDriver.Daemon.Library
         public event EventHandler<IEnumerable<PluginSettings>>? ToolsChanged;
         public event EventHandler<PluginContextDto>? PluginAdded;
         public event EventHandler<PluginContextDto>? PluginRemoved;
+        public event EventHandler? DisplayChanged;
 
         public async Task Initialize()
         {
@@ -101,6 +104,7 @@ namespace OpenTabletDriver.Daemon.Library
             };
 
             InitializePlatform();
+            InitializeDisplayChangeEvents();
             _driver.InputDeviceAdded += (sender, e) =>
             {
                 // hookEndpoint(e.Digitizer);
@@ -192,6 +196,37 @@ namespace OpenTabletDriver.Daemon.Library
                 Log.Write(nameof(DriverDaemon), "Sleep detected...", LogLevel.Info);
                 await DetectTablets();
             };
+        }
+
+        private void InitializeDisplayChangeEvents()
+        {
+            if (_displayChangeEventsInitialized)
+                return;
+
+            if (!OperatingSystem.IsWindows())
+                return;
+
+            try
+            {
+                SystemEvents.DisplaySettingsChanged += OnDisplaySettingsChanged;
+                _displayChangeEventsInitialized = true;
+                Log.Debug("Display", "Display settings change events enabled");
+            }
+            catch (Exception ex)
+            {
+                Log.Write("Display", $"Failed to initialize display settings change events: {ex.Message}", LogLevel.Warning);
+            }
+        }
+
+        private void OnDisplaySettingsChanged(object? sender, EventArgs e)
+        {
+            Log.Debug("Display", "Display settings changed");
+            var displays = _serviceProvider.GetRequiredService<IVirtualScreen>().Displays
+                .Where(t => t is not IVirtualScreen)
+                .Select(t => $"{t.Width}x{t.Height}@{t.Position}")
+                .ToArray();
+            Log.Debug("Display", $"Display layout refresh event: {string.Join(", ", displays)}");
+            _synchronizationContext.Post(_ => DisplayChanged?.Invoke(this, EventArgs.Empty), null);
         }
 
         public async Task<IEnumerable<PluginMetadata>> GetInstallablePlugins(string owner, string name, string gitRef)

--- a/OpenTabletDriver.Daemon.Library/Interop/Display/WindowsDisplay.cs
+++ b/OpenTabletDriver.Daemon.Library/Interop/Display/WindowsDisplay.cs
@@ -20,27 +20,6 @@ namespace OpenTabletDriver.Daemon.Library.Interop.Display
                 Log.Debug("Display", "DPI Awareness enabled");
             }
             catch { }
-
-            var monitors = GetDisplays();
-            var primary = monitors.First(m => m.IsPrimary);
-
-            var displays = new List<IDisplay>();
-            displays.Add(this);
-            foreach (var monitor in monitors)
-            {
-                var display = new Display(
-                    monitor.Width,
-                    monitor.Height,
-                    new Vector2(monitor.Left, monitor.Top),
-                    monitors.IndexOf(monitor) + 1);
-                displays.Add(display);
-            }
-
-            var x = primary.Left - monitors.Min(m => m.Left);
-            var y = primary.Top - monitors.Min(m => m.Top);
-
-            Displays = displays;
-            Position = new Vector2(x, y);
         }
 
         private static List<DisplayInfo> GetDisplays()
@@ -72,14 +51,21 @@ namespace OpenTabletDriver.Daemon.Library.Interop.Display
             return displayCollection;
         }
 
-        private IEnumerable<DisplayInfo> InternalDisplays => GetDisplays().OrderBy(e => e.Left);
+        private static List<DisplayInfo> InternalDisplays => GetDisplays()
+            .OrderBy(e => e.Left)
+            .ThenBy(e => e.Top)
+            .ToList();
 
         public float Width
         {
             get
             {
-                var left = InternalDisplays.Min(d => d.Left);
-                var right = InternalDisplays.Max(d => d.Right);
+                var displays = InternalDisplays;
+                if (displays.Count == 0)
+                    return 0;
+
+                var left = displays.Min(d => d.Left);
+                var right = displays.Max(d => d.Right);
                 return right - left;
             }
         }
@@ -88,15 +74,49 @@ namespace OpenTabletDriver.Daemon.Library.Interop.Display
         {
             get
             {
-                var top = InternalDisplays.Min(d => d.Top);
-                var bottom = InternalDisplays.Max(d => d.Bottom);
+                var displays = InternalDisplays;
+                if (displays.Count == 0)
+                    return 0;
+
+                var top = displays.Min(d => d.Top);
+                var bottom = displays.Max(d => d.Bottom);
                 return bottom - top;
             }
         }
 
-        public Vector2 Position { private set; get; }
+        public Vector2 Position
+        {
+            get
+            {
+                var displays = InternalDisplays;
+                if (displays.Count == 0)
+                    return Vector2.Zero;
 
-        public IEnumerable<IDisplay> Displays { private set; get; }
+                var primary = displays.FirstOrDefault(m => m.IsPrimary) ?? displays[0];
+                var x = primary.Left - displays.Min(m => m.Left);
+                var y = primary.Top - displays.Min(m => m.Top);
+                return new Vector2(x, y);
+            }
+        }
+
+        public IEnumerable<IDisplay> Displays
+        {
+            get
+            {
+                var monitors = InternalDisplays;
+                yield return this;
+
+                for (var index = 0; index < monitors.Count; index++)
+                {
+                    var monitor = monitors[index];
+                    yield return new Display(
+                        monitor.Width,
+                        monitor.Height,
+                        new Vector2(monitor.Left, monitor.Top),
+                        index + 1);
+                }
+            }
+        }
 
         public int Index => 0;
 

--- a/OpenTabletDriver.Daemon.Library/OpenTabletDriver.Daemon.Library.csproj
+++ b/OpenTabletDriver.Daemon.Library/OpenTabletDriver.Daemon.Library.csproj
@@ -10,6 +10,7 @@
   <ItemGroup Label="NuGet Packages">
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
+    <PackageReference Include="Microsoft.Win32.SystemEvents" Version="8.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20253.1" />
     <PackageReference Include="WaylandNET" Version="0.2.0" />
   </ItemGroup>

--- a/OpenTabletDriver.UI.Library/Controls/AreaDisplay.axaml.cs
+++ b/OpenTabletDriver.UI.Library/Controls/AreaDisplay.axaml.cs
@@ -138,21 +138,28 @@ public partial class AreaDisplay : UserControl
             var padding = VIEW_AreaBorder.Padding;
             var maxCanvasSize = finalSize.Deflate(padding);
 
+            if (vm.MaximumBounds.Width <= 0 || vm.MaximumBounds.Height <= 0 || maxCanvasSize.Width <= 0 || maxCanvasSize.Height <= 0)
+                return base.ArrangeOverride(finalSize);
+
             var scaledWidth = maxCanvasSize.Height / vm.MaximumBounds.Height * vm.MaximumBounds.Width;
             var scaledHeight = maxCanvasSize.Width / vm.MaximumBounds.Width * vm.MaximumBounds.Height;
+            double canvasWidth;
+            double canvasHeight;
 
             if (scaledWidth > maxCanvasSize.Width)
             {
-                VIEW_AreaCanvas.Width = maxCanvasSize.Width;
-                VIEW_AreaCanvas.Height = scaledHeight;
+                canvasWidth = maxCanvasSize.Width;
+                canvasHeight = scaledHeight;
             }
             else
             {
-                VIEW_AreaCanvas.Width = scaledWidth;
-                VIEW_AreaCanvas.Height = maxCanvasSize.Height;
+                canvasWidth = scaledWidth;
+                canvasHeight = maxCanvasSize.Height;
             }
 
-            _scale = VIEW_AreaCanvas.Bounds.Width / vm.MaximumBounds.Width;
+            VIEW_AreaCanvas.Width = canvasWidth;
+            VIEW_AreaCanvas.Height = canvasHeight;
+            _scale = canvasWidth / vm.MaximumBounds.Width;
 
             foreach (var border in VIEW_AreaCanvas.Children.OfType<Border>())
             {
@@ -236,8 +243,8 @@ public partial class AreaDisplay : UserControl
 
     private static void SetSize(Border border, Mapping mapping, double scale)
     {
-        border.Width = (mapping.Width * scale) - 1;
-        border.Height = (mapping.Height * scale) - 1;
+        border.Width = Math.Max(0, (mapping.Width * scale) - 1);
+        border.Height = Math.Max(0, (mapping.Height * scale) - 1);
     }
 
     private void SetPosition(Border border, Mapping mapping, double scale)

--- a/OpenTabletDriver.UI.Library/ViewModels/TabletViewModel.cs
+++ b/OpenTabletDriver.UI.Library/ViewModels/TabletViewModel.cs
@@ -21,6 +21,7 @@ public partial class TabletViewModel : ActivatableViewModelBase
     private bool _modified;
     private bool _saved = true;
     private DateTime _lastApply;
+    private bool _isDisplayRefreshConfirmationOpen;
     private const int ApplyThresholdMs = 120;
 
     [ObservableProperty]
@@ -79,6 +80,7 @@ public partial class TabletViewModel : ActivatableViewModelBase
     public ObservableCollection<PluginSettingViewModel> OutputModeSettings { get; } = new();
     public ObservableCollection<BindingSettingViewModel> PenButtonBindings { get; } = new();
     public ObservableCollection<BindingSettingViewModel> TabletButtonBindings { get; } = new();
+    public event Func<Task<bool>>? DisplayLayoutRefreshConfirmationRequested;
 
     public bool Modified
     {
@@ -121,6 +123,16 @@ public partial class TabletViewModel : ActivatableViewModelBase
                 (s, p) => Profile = p,
                 invokeOnCreation: false)
             .DisposeWith(d);
+
+            if (_daemonService.Instance is { } daemon)
+            {
+                EventHandler displayChangedHandler = (_, _) => _dispatcher.Post(
+                    () => _ = RefreshDisplayLayoutFromSystemEvent(),
+                    DispatcherPriority.Background
+                );
+                daemon.DisplayChanged += displayChangedHandler;
+                new ActionDisposable(() => daemon.DisplayChanged -= displayChangedHandler).DisposeWith(d);
+            }
         });
 
         // propagate plugin changes as well
@@ -149,6 +161,119 @@ public partial class TabletViewModel : ActivatableViewModelBase
         SetupBindings(Profile);
         await InitializeProfileAsync(Profile);
         IsInitialized = true;
+    }
+
+    [RelayCommand]
+    private async Task RefreshDisplayLayout()
+    {
+        if (Modified)
+            await WriteProfileAsync(Profile);
+
+        await RefreshDisplayLayoutAsync(Saved);
+    }
+
+    private async Task RefreshDisplayLayoutFromSystemEvent()
+    {
+        if (!IsInitialized)
+            return;
+
+        if (Modified)
+        {
+            if (_isDisplayRefreshConfirmationOpen)
+                return;
+
+            _isDisplayRefreshConfirmationOpen = true;
+            try
+            {
+                if (DisplayLayoutRefreshConfirmationRequested is not { } requestConfirmation || !await requestConfirmation())
+                    return;
+            }
+            finally
+            {
+                _isDisplayRefreshConfirmationOpen = false;
+            }
+
+            await WriteProfileAsync(Profile);
+        }
+
+        await RefreshDisplayLayoutAsync(Saved);
+    }
+
+    private async Task RefreshDisplayLayoutAsync(bool wasSaved)
+    {
+        var shouldMapToCurrentVirtualDesktop = ShouldMapDisplayAreaToMaximumBounds();
+        await InitializeProfileAsync(Profile);
+        shouldMapToCurrentVirtualDesktop |= ShouldMapDisplayAreaToMaximumBounds();
+
+        if (shouldMapToCurrentVirtualDesktop)
+        {
+            MapDisplayAreaToMaximumBounds();
+            await WriteProfileAsync(Profile);
+        }
+
+        Modified = false;
+        Saved = wasSaved && !shouldMapToCurrentVirtualDesktop;
+    }
+
+    private bool ShouldMapDisplayAreaToMaximumBounds()
+    {
+        if (DisplayArea is null)
+            return false;
+
+        var mapping = DisplayArea.Mapping;
+        var maximumBounds = DisplayArea.MaximumBounds;
+
+        var isFullVirtualDesktop =
+            NearlyEqual(mapping.UntranslatedX, maximumBounds.X) &&
+            NearlyEqual(mapping.UntranslatedY, maximumBounds.Y) &&
+            NearlyEqual(mapping.Width, maximumBounds.Width) &&
+            NearlyEqual(mapping.Height, maximumBounds.Height);
+        var isOutsideCurrentVirtualDesktop =
+            mapping.UntranslatedX < maximumBounds.X - 1 ||
+            mapping.UntranslatedY < maximumBounds.Y - 1 ||
+            mapping.UntranslatedX + mapping.Width > maximumBounds.X + maximumBounds.Width + 1 ||
+            mapping.UntranslatedY + mapping.Height > maximumBounds.Y + maximumBounds.Height + 1 ||
+            mapping.Width > maximumBounds.Width + 1 ||
+            mapping.Height > maximumBounds.Height + 1;
+
+        return isFullVirtualDesktop || isOutsideCurrentVirtualDesktop;
+    }
+
+    private void MapDisplayAreaToMaximumBounds()
+    {
+        var maximumBounds = DisplayArea.MaximumBounds;
+        DisplayArea.SetProcessRestrictions(false);
+        DisplayArea.Mapping.UntranslatedX = maximumBounds.X;
+        DisplayArea.Mapping.UntranslatedY = maximumBounds.Y;
+        DisplayArea.Mapping.Width = maximumBounds.Width;
+        DisplayArea.Mapping.Height = maximumBounds.Height;
+        DisplayArea.Mapping.Rotation = maximumBounds.Rotation;
+        DisplayArea.SetProcessRestrictions(true);
+    }
+
+    private static bool NearlyEqual(double left, double right)
+    {
+        return Math.Abs(left - right) <= 1;
+    }
+
+    private sealed class ActionDisposable : IDisposable
+    {
+        private readonly Action _dispose;
+        private bool _disposed;
+
+        public ActionDisposable(Action dispose)
+        {
+            _dispose = dispose;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            _dispose();
+        }
     }
 
     [RelayCommand(CanExecute = nameof(Modified))]
@@ -198,10 +323,10 @@ public partial class TabletViewModel : ActivatableViewModelBase
         }
 
         var daemon = _daemonService.Instance!;
-        var displayDtos = await daemon.GetDisplays();
-        var displayBounds = displayDtos
+        var displayDtos = (await daemon.GetDisplays())
             .OrderBy(d => d.Index)
-            .Select(d => Bounds.FromDto(d));
+            .ToArray();
+        var displayBounds = displayDtos.Select(d => Bounds.FromDto(d));
         PluginSettings? outputMode = profile.OutputMode;
 
         var tabletWidth = _tabletService.Configuration.Specifications.Digitizer!.Width;
@@ -267,7 +392,8 @@ public partial class TabletViewModel : ActivatableViewModelBase
         {
             var input = outputMode["Input"];
 
-            input.SetValue(new {
+            input.SetValue(new
+            {
                 XPosition = tabletArea.Mapping.X,
                 YPosition = tabletArea.Mapping.Y,
                 Width = (double)tabletArea.Mapping.Width,
@@ -417,7 +543,8 @@ public partial class TabletViewModel : ActivatableViewModelBase
 
         var input = outputMode["Input"];
 
-        input.SetValue(new {
+        input.SetValue(new
+        {
             XPosition = TabletArea.Mapping.X,
             YPosition = TabletArea.Mapping.Y,
             Width = (double)TabletArea.Mapping.Width,

--- a/OpenTabletDriver.UI.Library/Views/TabletView.axaml
+++ b/OpenTabletDriver.UI.Library/Views/TabletView.axaml
@@ -55,6 +55,11 @@
           <StackPanel
               Spacing="4"
               Grid.IsSharedSizeScope="True">
+            <Button
+                Content="Refresh displays"
+                Command="{Binding RefreshDisplayLayoutCommand}"
+                HorizontalAlignment="Right"
+                ToolTip.Tip="Refresh the display layout after monitors are plugged in or unplugged." />
             <Grid
                 ColumnDefinitions="*,*"
                 Margin="-2">

--- a/OpenTabletDriver.UI.Library/Views/TabletView.axaml.cs
+++ b/OpenTabletDriver.UI.Library/Views/TabletView.axaml.cs
@@ -1,11 +1,100 @@
+using Avalonia.Controls;
+using Avalonia.Layout;
 using OpenTabletDriver.UI.Controls;
+using OpenTabletDriver.UI.ViewModels;
 
 namespace OpenTabletDriver.UI.Views;
 
 public partial class TabletView : ActivatableUserControl
 {
+    private TabletViewModel? _viewModel;
+
     public TabletView()
     {
         InitializeComponent();
+    }
+
+    protected override void OnDataContextChanged(EventArgs e)
+    {
+        if (_viewModel is not null)
+            _viewModel.DisplayLayoutRefreshConfirmationRequested -= ConfirmDisplayLayoutRefresh;
+
+        _viewModel = DataContext as TabletViewModel;
+        if (_viewModel is not null)
+            _viewModel.DisplayLayoutRefreshConfirmationRequested += ConfirmDisplayLayoutRefresh;
+
+        base.OnDataContextChanged(e);
+    }
+
+    private async Task<bool> ConfirmDisplayLayoutRefresh()
+    {
+        var owner = TopLevel.GetTopLevel(this) as Window;
+        if (owner is null)
+            return false;
+
+        var dialog = new Window
+        {
+            Title = "Refresh displays?",
+            Width = 420,
+            Height = 190,
+            MinWidth = 360,
+            MinHeight = 170,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            CanResize = false,
+            Content = CreateDisplayLayoutRefreshDialogContent()
+        };
+
+        return await dialog.ShowDialog<bool>(owner);
+    }
+
+    private static Control CreateDisplayLayoutRefreshDialogContent()
+    {
+        var message = new TextBlock
+        {
+            Text = "The display layout changed, but this tablet has unsaved settings. Apply the current changes and refresh the display layout?",
+            TextWrapping = Avalonia.Media.TextWrapping.Wrap
+        };
+
+        var refreshButton = new Button
+        {
+            Content = "Apply and refresh",
+            HorizontalAlignment = HorizontalAlignment.Right,
+            IsDefault = true
+        };
+
+        var cancelButton = new Button
+        {
+            Content = "Not now",
+            HorizontalAlignment = HorizontalAlignment.Right,
+            IsCancel = true
+        };
+
+        var buttons = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Spacing = 8,
+            Children =
+            {
+                cancelButton,
+                refreshButton
+            }
+        };
+
+        var panel = new StackPanel
+        {
+            Margin = new Avalonia.Thickness(18),
+            Spacing = 18,
+            Children =
+            {
+                message,
+                buttons
+            }
+        };
+
+        refreshButton.Click += (_, _) => (TopLevel.GetTopLevel(refreshButton) as Window)?.Close(true);
+        cancelButton.Click += (_, _) => (TopLevel.GetTopLevel(cancelButton) as Window)?.Close(false);
+
+        return panel;
     }
 }


### PR DESCRIPTION
# Changes

Closes #4859.

This PR updates the Avalonia branch to refresh Windows display topology after monitor layout changes.

- Listens for Windows display settings change events in the daemon.
- Refreshes display enumeration instead of keeping stale topology.
- Adds a manual `Refresh displays` action in the tablet view.
- Keeps unsaved-profile behavior safe by prompting/applying before refresh where needed.
- Fixes area display scaling so topology changes do not render the mapped area as a tiny point.

Validation:
- `dotnet build OpenTabletDriver.UI -c Release --no-restore`
- `dotnet build OpenTabletDriver.Daemon -c Release --no-restore`
- `dotnet test OpenTabletDriver.Tests -c Release --no-restore --filter Configuration`

Note: this implementation was AI-assisted, then manually reviewed and tested locally before submission.