### PR TITLE
Windows: add daemon autostart through Task Scheduler

### DIFF
--- a/OpenTabletDriver.UI.Library/ServiceExtensions.cs
+++ b/OpenTabletDriver.UI.Library/ServiceExtensions.cs
@@ -28,7 +28,8 @@ public static class ServiceExtensions
             .AddSingleton<IUISettingsProvider, UISettingsProvider>()
             .UseNavigation<NavigatorFactory>()
             .AddSingleton<IMessenger, StrongReferenceMessenger>()
-            .AddSingleton<IAutoStartService, NullAutoStartService>();
+            .AddSingleton<IAutoStartService, NullAutoStartService>()
+            .AddSingleton<IDriverDaemonAutoStartService, NullDriverDaemonAutoStartService>();
     }
 
     public static IServiceCollection WithUIEnvironmentFrom(this IServiceCollection services, string[] args)

--- a/OpenTabletDriver.UI.Library/Services/AutoStartService.cs
+++ b/OpenTabletDriver.UI.Library/Services/AutoStartService.cs
@@ -20,14 +20,18 @@ public interface IDriverDaemonAutoStartService
 {
     bool AutoStartSupported { get; }
     bool AutoStart { get; }
+    bool HideWindowSupported { get; }
+    bool HideWindow { get; }
     string? BackendName { get; }
-    bool TrySetAutoStart(bool autoStart);
+    bool TrySetAutoStart(bool autoStart, bool hideWindow);
 }
 
 public class NullDriverDaemonAutoStartService : IDriverDaemonAutoStartService
 {
     public bool AutoStartSupported => false;
     public bool AutoStart => false;
+    public bool HideWindowSupported => false;
+    public bool HideWindow => false;
     public string? BackendName => null;
-    public bool TrySetAutoStart(bool autoStart) => false;
+    public bool TrySetAutoStart(bool autoStart, bool hideWindow) => false;
 }

--- a/OpenTabletDriver.UI.Library/Services/AutoStartService.cs
+++ b/OpenTabletDriver.UI.Library/Services/AutoStartService.cs
@@ -15,3 +15,19 @@ public class NullAutoStartService : IAutoStartService
     public string? BackendName => null;
     public bool TrySetAutoStart(bool autoStart) => false;
 }
+
+public interface IDriverDaemonAutoStartService
+{
+    bool AutoStartSupported { get; }
+    bool AutoStart { get; }
+    string? BackendName { get; }
+    bool TrySetAutoStart(bool autoStart);
+}
+
+public class NullDriverDaemonAutoStartService : IDriverDaemonAutoStartService
+{
+    public bool AutoStartSupported => false;
+    public bool AutoStart => false;
+    public string? BackendName => null;
+    public bool TrySetAutoStart(bool autoStart) => false;
+}

--- a/OpenTabletDriver.UI.Library/Services/Windows/ServiceExtensions.cs
+++ b/OpenTabletDriver.UI.Library/Services/Windows/ServiceExtensions.cs
@@ -1,12 +1,15 @@
+using System.Runtime.Versioning;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace OpenTabletDriver.UI.Services.Windows;
 
 public static class ServiceExtensions
 {
+    [SupportedOSPlatform("windows")]
     public static IServiceCollection AddWindowsServices(this IServiceCollection services)
     {
         return services
-            .AddSingleton<IAutoStartService, ShortcutAutoStartService>();
+            .AddSingleton<IAutoStartService, ShortcutAutoStartService>()
+            .AddSingleton<IDriverDaemonAutoStartService, TaskSchedulerDaemonAutoStartService>();
     }
 }

--- a/OpenTabletDriver.UI.Library/Services/Windows/TaskSchedulerDaemonAutoStartService.cs
+++ b/OpenTabletDriver.UI.Library/Services/Windows/TaskSchedulerDaemonAutoStartService.cs
@@ -1,0 +1,116 @@
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Security.Principal;
+
+namespace OpenTabletDriver.UI.Services.Windows;
+
+/// <summary>
+/// Creates a per-user scheduled task that starts the daemon when the current user logs on.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public class TaskSchedulerDaemonAutoStartService : IDriverDaemonAutoStartService
+{
+    private const string TaskName = "OpenTabletDriver Daemon";
+    private const int TaskTriggerLogon = 9;
+    private const int TaskActionExecute = 0;
+    private const int TaskCreateOrUpdate = 6;
+    private const int TaskLogonInteractiveToken = 3;
+    private const int TaskRunLevelLua = 0;
+    private const int TaskInstancesIgnoreNew = 2;
+
+    public bool AutoStartSupported => true;
+    public bool AutoStart => TryGetTask(out _);
+    public string? BackendName => "Windows Task Scheduler";
+
+    public bool TrySetAutoStart(bool autoStart)
+    {
+        if (!autoStart)
+        {
+            if (!TryGetTask(out var rootFolder))
+                return true;
+
+            try
+            {
+                rootFolder!.DeleteTask(TaskName, 0);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        var daemonPath = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "OpenTabletDriver.Daemon.exe");
+        if (!File.Exists(daemonPath))
+            return false;
+
+        try
+        {
+            var service = CreateTaskService();
+            var rootFolder = service.GetFolder("\\");
+            var taskDefinition = service.NewTask(0);
+            var currentUser = WindowsIdentity.GetCurrent().Name;
+
+            taskDefinition.RegistrationInfo.Description = "Launch OpenTabletDriver daemon when the current user logs on.";
+            taskDefinition.Settings.Enabled = true;
+            taskDefinition.Settings.Hidden = false;
+            taskDefinition.Settings.AllowDemandStart = true;
+            taskDefinition.Settings.StartWhenAvailable = true;
+            taskDefinition.Settings.DisallowStartIfOnBatteries = false;
+            taskDefinition.Settings.StopIfGoingOnBatteries = false;
+            taskDefinition.Settings.ExecutionTimeLimit = "PT0S";
+            taskDefinition.Settings.MultipleInstances = TaskInstancesIgnoreNew;
+
+            var principal = taskDefinition.Principal;
+            principal.UserId = currentUser;
+            principal.LogonType = TaskLogonInteractiveToken;
+            principal.RunLevel = TaskRunLevelLua;
+
+            var trigger = taskDefinition.Triggers.Create(TaskTriggerLogon);
+            trigger.Id = "CurrentUserLogon";
+            trigger.UserId = currentUser;
+
+            var action = taskDefinition.Actions.Create(TaskActionExecute);
+            action.Id = "StartDaemon";
+            action.Path = daemonPath;
+            action.WorkingDirectory = AppDomain.CurrentDomain.BaseDirectory;
+
+            rootFolder.RegisterTaskDefinition(TaskName, taskDefinition, TaskCreateOrUpdate, null, null, TaskLogonInteractiveToken, null);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool TryGetTask(out dynamic? rootFolder)
+    {
+        rootFolder = null;
+        try
+        {
+            var service = CreateTaskService();
+            rootFolder = service.GetFolder("\\");
+            _ = rootFolder.GetTask(TaskName);
+            return true;
+        }
+        catch (COMException)
+        {
+            return false;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static dynamic CreateTaskService()
+    {
+        var taskServiceType = Type.GetTypeFromProgID("Schedule.Service")
+            ?? throw new InvalidOperationException("Task Scheduler COM service is not available.");
+        dynamic service = Activator.CreateInstance(taskServiceType)
+            ?? throw new InvalidOperationException("Failed to create Task Scheduler COM service.");
+        service.Connect();
+        return service;
+    }
+}

--- a/OpenTabletDriver.UI.Library/Services/Windows/TaskSchedulerDaemonAutoStartService.cs
+++ b/OpenTabletDriver.UI.Library/Services/Windows/TaskSchedulerDaemonAutoStartService.cs
@@ -19,18 +19,18 @@ public class TaskSchedulerDaemonAutoStartService : IDriverDaemonAutoStartService
     private const int TaskInstancesIgnoreNew = 2;
 
     public bool AutoStartSupported => true;
-    public bool AutoStart => TryGetTask(out _);
+    public bool AutoStart => TryGetTask(out _, out var task) && IsTaskForCurrentDaemon(task);
     public bool HideWindowSupported => true;
     public bool HideWindow
     {
         get
         {
-            if (!TryGetTask(out _, out var task))
+            if (!TryGetTask(out _, out var task) || !IsTaskForCurrentDaemon(task))
                 return true;
 
             try
             {
-                return task!.Definition.Actions[1].HideAppWindow;
+                return GetTaskAction(task)!.HideAppWindow;
             }
             catch
             {
@@ -59,7 +59,7 @@ public class TaskSchedulerDaemonAutoStartService : IDriverDaemonAutoStartService
             }
         }
 
-        var daemonPath = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "OpenTabletDriver.Daemon.exe");
+        var daemonPath = GetCurrentDaemonPath();
         if (!File.Exists(daemonPath))
             return false;
 
@@ -93,7 +93,7 @@ public class TaskSchedulerDaemonAutoStartService : IDriverDaemonAutoStartService
             action.Id = "StartDaemon";
             action.Path = daemonPath;
             action.HideAppWindow = hideWindow;
-            action.WorkingDirectory = AppDomain.CurrentDomain.BaseDirectory;
+            action.WorkingDirectory = GetCurrentWorkingDirectory();
 
             rootFolder.RegisterTaskDefinition(TaskName, taskDefinition, TaskCreateOrUpdate, null, null, TaskLogonInteractiveToken, null);
             return true;
@@ -102,6 +102,58 @@ public class TaskSchedulerDaemonAutoStartService : IDriverDaemonAutoStartService
         {
             return false;
         }
+    }
+
+    private static string GetCurrentDaemonPath()
+    {
+        return Path.Join(GetCurrentWorkingDirectory(), "OpenTabletDriver.Daemon.exe");
+    }
+
+    private static string GetCurrentWorkingDirectory()
+    {
+        return AppDomain.CurrentDomain.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    }
+
+    private static bool IsTaskForCurrentDaemon(dynamic? task)
+    {
+        try
+        {
+            var action = GetTaskAction(task);
+            if (action is null)
+                return false;
+
+            return PathsEqual(action.Path, GetCurrentDaemonPath())
+                && PathsEqual(action.WorkingDirectory, GetCurrentWorkingDirectory());
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static dynamic? GetTaskAction(dynamic? task)
+    {
+        if (task is null)
+            return null;
+
+        var taskValue = task;
+        if (taskValue.Definition.Actions.Count < 1)
+            return null;
+
+        return taskValue.Definition.Actions.Item(1);
+    }
+
+    private static bool PathsEqual(string? left, string? right)
+    {
+        if (string.IsNullOrWhiteSpace(left) || string.IsNullOrWhiteSpace(right))
+            return false;
+
+        return string.Equals(NormalizePath(left), NormalizePath(right), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string NormalizePath(string path)
+    {
+        return Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
     }
 
     private static bool TryGetTask(out dynamic? rootFolder)

--- a/OpenTabletDriver.UI.Library/Services/Windows/TaskSchedulerDaemonAutoStartService.cs
+++ b/OpenTabletDriver.UI.Library/Services/Windows/TaskSchedulerDaemonAutoStartService.cs
@@ -44,6 +44,8 @@ public class TaskSchedulerDaemonAutoStartService : IDriverDaemonAutoStartService
         if (!File.Exists(daemonPath))
             return false;
 
+        var launcherPath = WriteHiddenLauncher(daemonPath);
+
         try
         {
             var service = CreateTaskService();
@@ -72,7 +74,8 @@ public class TaskSchedulerDaemonAutoStartService : IDriverDaemonAutoStartService
 
             var action = taskDefinition.Actions.Create(TaskActionExecute);
             action.Id = "StartDaemon";
-            action.Path = daemonPath;
+            action.Path = Path.Join(Environment.SystemDirectory, "wscript.exe");
+            action.Arguments = $"\"{launcherPath}\"";
             action.WorkingDirectory = AppDomain.CurrentDomain.BaseDirectory;
 
             rootFolder.RegisterTaskDefinition(TaskName, taskDefinition, TaskCreateOrUpdate, null, null, TaskLogonInteractiveToken, null);
@@ -82,6 +85,25 @@ public class TaskSchedulerDaemonAutoStartService : IDriverDaemonAutoStartService
         {
             return false;
         }
+    }
+
+    private static string WriteHiddenLauncher(string daemonPath)
+    {
+        var baseDirectory = AppDomain.CurrentDomain.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var launcherPath = Path.Join(baseDirectory, "OpenTabletDriver.Daemon.hidden.vbs");
+        var script = string.Join(
+            Environment.NewLine,
+            "Set shell = CreateObject(\"WScript.Shell\")",
+            $"shell.CurrentDirectory = \"{EscapeVbsString(baseDirectory)}\"",
+            $"shell.Run \"\"\"{EscapeVbsString(daemonPath)}\"\"\", 0, False"
+        );
+        File.WriteAllText(launcherPath, script);
+        return launcherPath;
+    }
+
+    private static string EscapeVbsString(string value)
+    {
+        return value.Replace("\"", "\"\"");
     }
 
     private static bool TryGetTask(out dynamic? rootFolder)

--- a/OpenTabletDriver.UI.Library/Services/Windows/TaskSchedulerDaemonAutoStartService.cs
+++ b/OpenTabletDriver.UI.Library/Services/Windows/TaskSchedulerDaemonAutoStartService.cs
@@ -20,9 +20,28 @@ public class TaskSchedulerDaemonAutoStartService : IDriverDaemonAutoStartService
 
     public bool AutoStartSupported => true;
     public bool AutoStart => TryGetTask(out _);
+    public bool HideWindowSupported => true;
+    public bool HideWindow
+    {
+        get
+        {
+            if (!TryGetTask(out _, out var task))
+                return true;
+
+            try
+            {
+                return task!.Definition.Actions[1].HideAppWindow;
+            }
+            catch
+            {
+                return true;
+            }
+        }
+    }
+
     public string? BackendName => "Windows Task Scheduler";
 
-    public bool TrySetAutoStart(bool autoStart)
+    public bool TrySetAutoStart(bool autoStart, bool hideWindow)
     {
         if (!autoStart)
         {
@@ -43,8 +62,6 @@ public class TaskSchedulerDaemonAutoStartService : IDriverDaemonAutoStartService
         var daemonPath = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "OpenTabletDriver.Daemon.exe");
         if (!File.Exists(daemonPath))
             return false;
-
-        var launcherPath = WriteHiddenLauncher(daemonPath);
 
         try
         {
@@ -74,8 +91,8 @@ public class TaskSchedulerDaemonAutoStartService : IDriverDaemonAutoStartService
 
             var action = taskDefinition.Actions.Create(TaskActionExecute);
             action.Id = "StartDaemon";
-            action.Path = Path.Join(Environment.SystemDirectory, "wscript.exe");
-            action.Arguments = $"\"{launcherPath}\"";
+            action.Path = daemonPath;
+            action.HideAppWindow = hideWindow;
             action.WorkingDirectory = AppDomain.CurrentDomain.BaseDirectory;
 
             rootFolder.RegisterTaskDefinition(TaskName, taskDefinition, TaskCreateOrUpdate, null, null, TaskLogonInteractiveToken, null);
@@ -87,33 +104,20 @@ public class TaskSchedulerDaemonAutoStartService : IDriverDaemonAutoStartService
         }
     }
 
-    private static string WriteHiddenLauncher(string daemonPath)
-    {
-        var baseDirectory = AppDomain.CurrentDomain.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        var launcherPath = Path.Join(baseDirectory, "OpenTabletDriver.Daemon.hidden.vbs");
-        var script = string.Join(
-            Environment.NewLine,
-            "Set shell = CreateObject(\"WScript.Shell\")",
-            $"shell.CurrentDirectory = \"{EscapeVbsString(baseDirectory)}\"",
-            $"shell.Run \"\"\"{EscapeVbsString(daemonPath)}\"\"\", 0, False"
-        );
-        File.WriteAllText(launcherPath, script);
-        return launcherPath;
-    }
-
-    private static string EscapeVbsString(string value)
-    {
-        return value.Replace("\"", "\"\"");
-    }
-
     private static bool TryGetTask(out dynamic? rootFolder)
     {
+        return TryGetTask(out rootFolder, out _);
+    }
+
+    private static bool TryGetTask(out dynamic? rootFolder, out dynamic? task)
+    {
         rootFolder = null;
+        task = null;
         try
         {
             var service = CreateTaskService();
             rootFolder = service.GetFolder("\\");
-            _ = rootFolder.GetTask(TaskName);
+            task = rootFolder.GetTask(TaskName);
             return true;
         }
         catch (COMException)

--- a/OpenTabletDriver.UI.Library/ViewModels/UISettingsViewModel.cs
+++ b/OpenTabletDriver.UI.Library/ViewModels/UISettingsViewModel.cs
@@ -27,6 +27,12 @@ public partial class UISettingsViewModel : ActivatableViewModelBase
     [ObservableProperty]
     private bool _driverDaemonAutoStart;
 
+    [ObservableProperty]
+    private bool _driverDaemonAutoStartHideWindowVisible;
+
+    [ObservableProperty]
+    private bool _driverDaemonAutoStartHideWindow;
+
     private bool _modified;
 
     public bool Modified
@@ -74,6 +80,8 @@ public partial class UISettingsViewModel : ActivatableViewModelBase
 
             AutoStart = _autoStartService.AutoStart;
             DriverDaemonAutoStart = _driverDaemonAutoStartService.AutoStart;
+            DriverDaemonAutoStartHideWindow = _driverDaemonAutoStartService.HideWindow;
+            DriverDaemonAutoStartHideWindowVisible = _driverDaemonAutoStartService.HideWindowSupported;
 
             // Maybe convert to a drop-down to select auto-start backend?
             AutoStartLabel = !string.IsNullOrEmpty(_autoStartService.BackendName)
@@ -104,10 +112,11 @@ public partial class UISettingsViewModel : ActivatableViewModelBase
             AutoStart = _autoStartService.AutoStart;
         }
 
-        if (!_driverDaemonAutoStartService.TrySetAutoStart(DriverDaemonAutoStart))
+        if (!_driverDaemonAutoStartService.TrySetAutoStart(DriverDaemonAutoStart, DriverDaemonAutoStartHideWindow))
         {
             // TODO: notify failure
             DriverDaemonAutoStart = _driverDaemonAutoStartService.AutoStart;
+            DriverDaemonAutoStartHideWindow = _driverDaemonAutoStartService.HideWindow;
         }
 
         Modified = false;
@@ -134,4 +143,5 @@ public partial class UISettingsViewModel : ActivatableViewModelBase
     private bool IsModified() => Modified;
     partial void OnAutoStartChanging(bool value) => Modified = true;
     partial void OnDriverDaemonAutoStartChanging(bool value) => Modified = true;
+    partial void OnDriverDaemonAutoStartHideWindowChanging(bool value) => Modified = true;
 }

--- a/OpenTabletDriver.UI.Library/ViewModels/UISettingsViewModel.cs
+++ b/OpenTabletDriver.UI.Library/ViewModels/UISettingsViewModel.cs
@@ -10,6 +10,7 @@ public partial class UISettingsViewModel : ActivatableViewModelBase
 {
     private readonly IUISettingsProvider _settingsProvider;
     private readonly IAutoStartService _autoStartService;
+    private readonly IDriverDaemonAutoStartService _driverDaemonAutoStartService;
 
     [ObservableProperty]
     private UISettings? _settings;
@@ -19,6 +20,12 @@ public partial class UISettingsViewModel : ActivatableViewModelBase
 
     [ObservableProperty]
     private bool _autoStart;
+
+    [ObservableProperty]
+    private string? _driverDaemonAutoStartLabel;
+
+    [ObservableProperty]
+    private bool _driverDaemonAutoStart;
 
     private bool _modified;
 
@@ -32,10 +39,15 @@ public partial class UISettingsViewModel : ActivatableViewModelBase
         }
     }
 
-    public UISettingsViewModel(IUISettingsProvider settingsProvider, IAutoStartService autoStartService)
+    public UISettingsViewModel(
+        IUISettingsProvider settingsProvider,
+        IAutoStartService autoStartService,
+        IDriverDaemonAutoStartService driverDaemonAutoStartService
+    )
     {
         _settingsProvider = settingsProvider;
         _autoStartService = autoStartService;
+        _driverDaemonAutoStartService = driverDaemonAutoStartService;
 
         WhenActivated(d =>
         {
@@ -61,10 +73,14 @@ public partial class UISettingsViewModel : ActivatableViewModelBase
             ).DisposeWith(d);
 
             AutoStart = _autoStartService.AutoStart;
+            DriverDaemonAutoStart = _driverDaemonAutoStartService.AutoStart;
 
             // Maybe convert to a drop-down to select auto-start backend?
             AutoStartLabel = !string.IsNullOrEmpty(_autoStartService.BackendName)
-                ? "Auto-start with " + _autoStartService.BackendName
+                ? "Open UI on login with " + _autoStartService.BackendName
+                : null;
+            DriverDaemonAutoStartLabel = !string.IsNullOrEmpty(_driverDaemonAutoStartService.BackendName)
+                ? "Start daemon on login with " + _driverDaemonAutoStartService.BackendName
                 : null;
 
             Modified = modified;
@@ -86,6 +102,12 @@ public partial class UISettingsViewModel : ActivatableViewModelBase
         {
             // TODO: notify failure
             AutoStart = _autoStartService.AutoStart;
+        }
+
+        if (!_driverDaemonAutoStartService.TrySetAutoStart(DriverDaemonAutoStart))
+        {
+            // TODO: notify failure
+            DriverDaemonAutoStart = _driverDaemonAutoStartService.AutoStart;
         }
 
         Modified = false;
@@ -111,4 +133,5 @@ public partial class UISettingsViewModel : ActivatableViewModelBase
 
     private bool IsModified() => Modified;
     partial void OnAutoStartChanging(bool value) => Modified = true;
+    partial void OnDriverDaemonAutoStartChanging(bool value) => Modified = true;
 }

--- a/OpenTabletDriver.UI.Library/Views/UISettingsView.axaml
+++ b/OpenTabletDriver.UI.Library/Views/UISettingsView.axaml
@@ -28,6 +28,10 @@
             IsVisible="{Binding DriverDaemonAutoStartLabel, Converter={x:Static ObjectConverters.IsNotNull}}"
             Value="{Binding DriverDaemonAutoStart}" />
         <tc:BooleanInput
+            Label="Hide daemon auto-start window"
+            IsVisible="{Binding DriverDaemonAutoStartHideWindowVisible}"
+            Value="{Binding DriverDaemonAutoStartHideWindow}" />
+        <tc:BooleanInput
             Label="{Binding AutoStartLabel}"
             IsVisible="{Binding AutoStartLabel, Converter={x:Static ObjectConverters.IsNotNull}}"
             Value="{Binding AutoStart}" />

--- a/OpenTabletDriver.UI.Library/Views/UISettingsView.axaml
+++ b/OpenTabletDriver.UI.Library/Views/UISettingsView.axaml
@@ -24,6 +24,10 @@
             Label="Transparency"
             Value="{Binding Settings.Transparency}" />
         <tc:BooleanInput
+            Label="{Binding DriverDaemonAutoStartLabel}"
+            IsVisible="{Binding DriverDaemonAutoStartLabel, Converter={x:Static ObjectConverters.IsNotNull}}"
+            Value="{Binding DriverDaemonAutoStart}" />
+        <tc:BooleanInput
             Label="{Binding AutoStartLabel}"
             IsVisible="{Binding AutoStartLabel, Converter={x:Static ObjectConverters.IsNotNull}}"
             Value="{Binding AutoStart}" />

--- a/OpenTabletDriver.UI.Tests/ViewModels/UISettingsViewModelTests.cs
+++ b/OpenTabletDriver.UI.Tests/ViewModels/UISettingsViewModelTests.cs
@@ -16,6 +16,7 @@ public partial class UISettingsViewModelTests
     {
         var serviceProvider = new ServiceCollection()
             .AddSingleton<IAutoStartService, NullAutoStartService>()
+            .AddSingleton<IDriverDaemonAutoStartService, NullDriverDaemonAutoStartService>()
             .AddSingleton<UISettingsProviderMock>()
             .AddSingleton<IUISettingsProvider, UISettingsProviderMock>(s => s.GetRequiredService<UISettingsProviderMock>())
             .AddTransient<UISettingsViewModel>()


### PR DESCRIPTION
# Changes

Closes #4861.

This PR adds a Windows daemon autostart option to the Avalonia UI.

- Adds a Windows Task Scheduler based daemon autostart service.
- Adds a UI setting to start the daemon on login.
- Adds a UI setting to hide the daemon autostart window.
- Validates that an existing scheduled task points to the current daemon executable so stale tasks do not appear enabled incorrectly.

Validation:
- `dotnet build OpenTabletDriver.UI -c Release --no-restore`
- Local manual test: daemon starts on login and can be configured to start without showing a window.

Note: this implementation was AI-assisted, then manually reviewed and tested locally before submission.