### PR TITLE
Windows: add Windows Ink output mode with VMulti guidance

### DIFF
--- a/OpenTabletDriver.Daemon.Contracts/IDriverDaemon.cs
+++ b/OpenTabletDriver.Daemon.Contracts/IDriverDaemon.cs
@@ -28,6 +28,7 @@ namespace OpenTabletDriver.Daemon.Contracts
 
         Task<IEnumerable<DeviceEndpointDto>> GetDevices();
         Task<IEnumerable<DisplayDto>> GetDisplays();
+        Task<VMultiDeviceStatusDto> GetVMultiDeviceStatus();
 
         Task DetectTablets();
         Task<IEnumerable<int>> GetTablets();

--- a/OpenTabletDriver.Daemon.Contracts/VMultiDeviceStatusDto.cs
+++ b/OpenTabletDriver.Daemon.Contracts/VMultiDeviceStatusDto.cs
@@ -1,0 +1,37 @@
+using Newtonsoft.Json;
+
+namespace OpenTabletDriver.Daemon.Contracts
+{
+    public enum VMultiDeviceStatusKind
+    {
+        Ready,
+        Missing,
+        Incomplete,
+        OpenFailed
+    }
+
+    public sealed class VMultiDeviceStatusDto
+    {
+        [JsonConstructor]
+        public VMultiDeviceStatusDto(
+            VMultiDeviceStatusKind kind,
+            bool isAvailable,
+            bool isExtendedDigitizerAvailable,
+            string message,
+            string downloadUrl
+        )
+        {
+            Kind = kind;
+            IsAvailable = isAvailable;
+            IsExtendedDigitizerAvailable = isExtendedDigitizerAvailable;
+            Message = message;
+            DownloadUrl = downloadUrl;
+        }
+
+        public VMultiDeviceStatusKind Kind { get; }
+        public bool IsAvailable { get; }
+        public bool IsExtendedDigitizerAvailable { get; }
+        public string Message { get; }
+        public string DownloadUrl { get; }
+    }
+}

--- a/OpenTabletDriver.Daemon.Library/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon.Library/DriverDaemon.cs
@@ -16,6 +16,7 @@ using OpenTabletDriver.Daemon.Contracts.Persistence;
 using OpenTabletDriver.Daemon.Library.Binding;
 using OpenTabletDriver.Daemon.Library.Components;
 using OpenTabletDriver.Daemon.Library.Output;
+using OpenTabletDriver.Daemon.Library.Output.WindowsInk;
 using OpenTabletDriver.Daemon.Library.Reflection;
 using OpenTabletDriver.Daemon.Library.Updater;
 using OpenTabletDriver.Interop;
@@ -232,6 +233,11 @@ namespace OpenTabletDriver.Daemon.Library
                 .Select(t => new DisplayDto(t));
 
             return Task.FromResult(displays);
+        }
+
+        public Task<VMultiDeviceStatusDto> GetVMultiDeviceStatus()
+        {
+            return Task.FromResult(VMultiDeviceDetector.GetStatus());
         }
 
         public Task DetectTablets()

--- a/OpenTabletDriver.Daemon.Library/Output/WindowsInk/DigitizerInputReport.cs
+++ b/OpenTabletDriver.Daemon.Library/Output/WindowsInk/DigitizerInputReport.cs
@@ -1,0 +1,49 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace OpenTabletDriver.Daemon.Library.Output.WindowsInk
+{
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    internal struct VMultiReportHeader
+    {
+        public VMultiReportHeader(int size, byte reportId)
+        {
+            VMultiId = 0x40;
+            ReportLength = (byte)(size - 1);
+            ReportId = reportId;
+            Buttons = 0;
+        }
+
+        public byte VMultiId;
+        public byte ReportLength;
+        public byte ReportId;
+        public byte Buttons;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    internal struct DigitizerInputReport
+    {
+        public const byte NormalReportId = 0x05;
+        public const byte ExtendedReportId = 0x06;
+
+        private DigitizerInputReport(byte reportId)
+        {
+            Header = new VMultiReportHeader(Unsafe.SizeOf<DigitizerInputReport>(), reportId);
+            X = 0;
+            Y = 0;
+            Pressure = 0;
+            XTilt = 0;
+            YTilt = 0;
+        }
+
+        public static DigitizerInputReport Normal() => new(NormalReportId);
+        public static DigitizerInputReport Extended() => new(ExtendedReportId);
+
+        public VMultiReportHeader Header;
+        public ushort X;
+        public ushort Y;
+        public ushort Pressure;
+        public byte XTilt;
+        public byte YTilt;
+    }
+}

--- a/OpenTabletDriver.Daemon.Library/Output/WindowsInk/ThinOsPointer.cs
+++ b/OpenTabletDriver.Daemon.Library/Output/WindowsInk/ThinOsPointer.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Numerics;
+using System.Runtime.InteropServices;
+using OpenTabletDriver.Platform.Display;
+
+namespace OpenTabletDriver.Daemon.Library.Output.WindowsInk
+{
+    internal class ThinOsPointer
+    {
+        private readonly Vector2 _conversion;
+        private readonly Input[] _inputs =
+        {
+            new()
+            {
+                Type = InputType.MouseInput,
+                Mouse = new MouseInput
+                {
+                    Time = 0,
+                    ExtraInfo = UIntPtr.Zero
+                }
+            }
+        };
+
+        public ThinOsPointer(IVirtualScreen screen)
+        {
+            _conversion = new Vector2(screen.Width, screen.Height) / 65535;
+        }
+
+        public void SetPosition(Vector2 position)
+        {
+            var converted = position / _conversion;
+
+            _inputs[0].Mouse.Flags = MouseEventFlags.Absolute | MouseEventFlags.Move | MouseEventFlags.VirtualDesk;
+            _inputs[0].Mouse.Dx = (int)converted.X;
+            _inputs[0].Mouse.Dy = (int)converted.Y;
+            _ = SendInput(1, _inputs, Input.Size);
+        }
+
+        [DllImport("user32.dll")]
+        private static extern uint SendInput(uint inputCount, [MarshalAs(UnmanagedType.LPArray), In] Input[] inputs, int inputSize);
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct Input
+    {
+        public InputType Type;
+        public MouseInput Mouse;
+
+        public static int Size => Marshal.SizeOf<Input>();
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct MouseInput
+    {
+        public int Dx;
+        public int Dy;
+        public uint MouseData;
+        public MouseEventFlags Flags;
+        public uint Time;
+        public UIntPtr ExtraInfo;
+    }
+
+    internal enum InputType
+    {
+        MouseInput,
+        KeyboardInput,
+        HardwareInput
+    }
+
+    [Flags]
+    internal enum MouseEventFlags : uint
+    {
+        Move = 0x0001,
+        Absolute = 0x8000,
+        VirtualDesk = 0x4000,
+        MoveNoCoalesce = 0x2000
+    }
+}

--- a/OpenTabletDriver.Daemon.Library/Output/WindowsInk/VMultiDeviceDetector.cs
+++ b/OpenTabletDriver.Daemon.Library/Output/WindowsInk/VMultiDeviceDetector.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Linq;
+using HidSharp;
+using HidSharp.Reports;
+using OpenTabletDriver.Daemon.Contracts;
+
+namespace OpenTabletDriver.Daemon.Library.Output.WindowsInk
+{
+    internal static class VMultiDeviceDetector
+    {
+        public const int VendorId = 0x00ff;
+        public const int ProductId = 0xbacc;
+        public const string DownloadUrl = "https://github.com/X9VoiD/vmulti-bin/releases/latest";
+
+        public static VMultiDeviceStatusDto GetStatus()
+        {
+            try
+            {
+                var devices = DeviceList.Local.GetHidDevices(vendorID: VendorId, productID: ProductId).ToArray();
+                return GetStatusFromDevices(devices, null, false);
+            }
+            catch (Exception ex)
+            {
+                return CreateStatus(
+                    VMultiDeviceStatusKind.OpenFailed,
+                    false,
+                    false,
+                    $"VMulti status could not be read: {ex.Message}"
+                );
+            }
+        }
+
+        public static bool TryOpenOutputDevice(out HidStream? stream, out VMultiDeviceStatusDto status)
+        {
+            stream = null;
+
+            try
+            {
+                var devices = DeviceList.Local.GetHidDevices(vendorID: VendorId, productID: ProductId).ToArray();
+
+                foreach (var device in devices)
+                {
+                    if (IsOutputEndpoint(device) && device.TryOpen(out var openedStream))
+                    {
+                        stream = openedStream;
+                        break;
+                    }
+                }
+
+                status = GetStatusFromDevices(devices, stream, true);
+                if (!status.IsAvailable)
+                {
+                    stream?.Dispose();
+                    stream = null;
+                    return false;
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                stream?.Dispose();
+                stream = null;
+                status = CreateStatus(
+                    VMultiDeviceStatusKind.OpenFailed,
+                    false,
+                    false,
+                    $"VMulti status could not be read: {ex.Message}"
+                );
+                return false;
+            }
+        }
+
+        private static VMultiDeviceStatusDto GetStatusFromDevices(HidDevice[] devices, HidStream? openedOutputStream, bool requireOpenOutputStream)
+        {
+            if (devices.Length == 0)
+            {
+                return CreateStatus(
+                    VMultiDeviceStatusKind.Missing,
+                    false,
+                    false,
+                    "VMulti VirtualHID was not found. Download VMulti, extract it, run install_hiddriver.bat as administrator, then restart OpenTabletDriver."
+                );
+            }
+
+            var normalDigitizerReportAvailable = false;
+            var extendedDigitizerReportAvailable = false;
+            var outputDeviceAvailable = false;
+
+            foreach (var device in devices)
+            {
+                outputDeviceAvailable |= IsOutputEndpoint(device);
+
+                if (device.GetMaxInputReportLength() != 10)
+                    continue;
+
+                var reportDescriptor = device.GetReportDescriptor();
+                if (reportDescriptor.TryGetReport(ReportType.Input, DigitizerInputReport.NormalReportId, out _))
+                    normalDigitizerReportAvailable = true;
+                if (reportDescriptor.TryGetReport(ReportType.Input, DigitizerInputReport.ExtendedReportId, out _))
+                    extendedDigitizerReportAvailable = true;
+            }
+
+            if (!outputDeviceAvailable || (!normalDigitizerReportAvailable && !extendedDigitizerReportAvailable))
+            {
+                return CreateStatus(
+                    VMultiDeviceStatusKind.Incomplete,
+                    false,
+                    extendedDigitizerReportAvailable,
+                    "VMulti was found, but its HID endpoints or digitizer reports are incomplete. Reinstall VMulti as administrator, then restart OpenTabletDriver."
+                );
+            }
+
+            if (requireOpenOutputStream && openedOutputStream == null)
+            {
+                return CreateStatus(
+                    VMultiDeviceStatusKind.OpenFailed,
+                    false,
+                    extendedDigitizerReportAvailable,
+                    "VMulti was found, but OpenTabletDriver could not open the VirtualHID output endpoint. Restart OpenTabletDriver or reinstall VMulti as administrator."
+                );
+            }
+
+            return CreateStatus(
+                VMultiDeviceStatusKind.Ready,
+                true,
+                extendedDigitizerReportAvailable,
+                extendedDigitizerReportAvailable
+                    ? "VMulti is installed and ready. Extended Windows Ink digitizer reports are available."
+                    : "VMulti is installed and ready. Standard Windows Ink digitizer reports are available."
+            );
+        }
+
+        private static bool IsOutputEndpoint(HidDevice device)
+        {
+            return device.GetMaxOutputReportLength() == 65 && device.GetMaxInputReportLength() == 65;
+        }
+
+        private static VMultiDeviceStatusDto CreateStatus(
+            VMultiDeviceStatusKind kind,
+            bool isAvailable,
+            bool isExtendedDigitizerAvailable,
+            string message
+        )
+        {
+            return new VMultiDeviceStatusDto(kind, isAvailable, isExtendedDigitizerAvailable, message, DownloadUrl);
+        }
+    }
+}

--- a/OpenTabletDriver.Daemon.Library/Output/WindowsInk/VMultiInstance.cs
+++ b/OpenTabletDriver.Daemon.Library/Output/WindowsInk/VMultiInstance.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using HidSharp;
-using HidSharp.Reports;
 using OpenTabletDriver.Logging;
 
 namespace OpenTabletDriver.Daemon.Library.Output.WindowsInk
@@ -45,46 +43,15 @@ namespace OpenTabletDriver.Daemon.Library.Output.WindowsInk
 
         private static HidStream? Retrieve(string name, out bool extended)
         {
-            HidStream? virtualHidDevice = null;
-            var devices = DeviceList.Local.GetHidDevices(vendorID: 0x00ff, productID: 0xbacc).ToArray();
-
-            foreach (var device in devices)
+            if (VMultiDeviceDetector.TryOpenOutputDevice(out var virtualHidDevice, out var status))
             {
-                if (device.GetMaxOutputReportLength() == 65 && device.GetMaxInputReportLength() == 65)
-                {
-                    if (device.TryOpen(out virtualHidDevice))
-                        break;
-                }
+                extended = status.IsExtendedDigitizerAvailable;
+                return virtualHidDevice;
             }
 
-            var normal = false;
             extended = false;
-
-            foreach (var device in devices)
-            {
-                if (device.GetMaxInputReportLength() != 10)
-                    continue;
-
-                var reportDescriptor = device.GetReportDescriptor();
-                if (reportDescriptor.TryGetReport(ReportType.Input, DigitizerInputReport.NormalReportId, out _))
-                    normal = true;
-                if (reportDescriptor.TryGetReport(ReportType.Input, DigitizerInputReport.ExtendedReportId, out _))
-                    extended = true;
-
-                if (normal && extended)
-                    break;
-            }
-
-            if (virtualHidDevice == null || (!normal && !extended))
-            {
-                Log.WriteNotify(
-                    name,
-                    "Cannot find VMulti VirtualHID. Install VMulti driver, then restart OpenTabletDriver.",
-                    LogLevel.Error
-                );
-            }
-
-            return virtualHidDevice;
+            Log.WriteNotify(name, status.Message, LogLevel.Error);
+            return null;
         }
     }
 

--- a/OpenTabletDriver.Daemon.Library/Output/WindowsInk/VMultiInstance.cs
+++ b/OpenTabletDriver.Daemon.Library/Output/WindowsInk/VMultiInstance.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using HidSharp;
+using HidSharp.Reports;
+using OpenTabletDriver.Logging;
+
+namespace OpenTabletDriver.Daemon.Library.Output.WindowsInk
+{
+    internal class VMultiInstance
+    {
+        private readonly HidStream? _device;
+        protected readonly byte[] Buffer;
+
+        public unsafe VMultiReportHeader* Header { get; }
+        public bool Extended { get; }
+
+        public unsafe VMultiInstance(string name, int size)
+        {
+            Buffer = GC.AllocateArray<byte>(size, pinned: true);
+            Header = (VMultiReportHeader*)Unsafe.AsPointer(ref Buffer[0]);
+            _device = Retrieve(name, out var extended);
+            Extended = extended;
+        }
+
+        public void Write()
+        {
+            _device?.Write(Buffer);
+        }
+
+        public unsafe void EnableButtonBit(int bit)
+        {
+            Header->Buttons = (byte)(Header->Buttons | bit);
+        }
+
+        public unsafe void DisableButtonBit(int bit)
+        {
+            Header->Buttons = (byte)(Header->Buttons & ~bit);
+        }
+
+        public static bool HasBit(byte buttons, int bit)
+        {
+            return (buttons & bit) != 0;
+        }
+
+        private static HidStream? Retrieve(string name, out bool extended)
+        {
+            HidStream? virtualHidDevice = null;
+            var devices = DeviceList.Local.GetHidDevices(vendorID: 0x00ff, productID: 0xbacc).ToArray();
+
+            foreach (var device in devices)
+            {
+                if (device.GetMaxOutputReportLength() == 65 && device.GetMaxInputReportLength() == 65)
+                {
+                    if (device.TryOpen(out virtualHidDevice))
+                        break;
+                }
+            }
+
+            var normal = false;
+            extended = false;
+
+            foreach (var device in devices)
+            {
+                if (device.GetMaxInputReportLength() != 10)
+                    continue;
+
+                var reportDescriptor = device.GetReportDescriptor();
+                if (reportDescriptor.TryGetReport(ReportType.Input, DigitizerInputReport.NormalReportId, out _))
+                    normal = true;
+                if (reportDescriptor.TryGetReport(ReportType.Input, DigitizerInputReport.ExtendedReportId, out _))
+                    extended = true;
+
+                if (normal && extended)
+                    break;
+            }
+
+            if (virtualHidDevice == null || (!normal && !extended))
+            {
+                Log.WriteNotify(
+                    name,
+                    "Cannot find VMulti VirtualHID. Install VMulti driver, then restart OpenTabletDriver.",
+                    LogLevel.Error
+                );
+            }
+
+            return virtualHidDevice;
+        }
+    }
+
+    internal class VMultiInstance<T> : VMultiInstance where T : unmanaged
+    {
+        public unsafe T* Pointer { get; }
+
+        public unsafe VMultiInstance(string name, Func<bool, T> initialValue) : base(name, Unsafe.SizeOf<T>())
+        {
+            Pointer = (T*)Unsafe.AsPointer(ref Buffer[0]);
+            *Pointer = initialValue(Extended);
+        }
+    }
+}

--- a/OpenTabletDriver.Daemon.Library/Output/WindowsInk/WindowsInkAbsoluteMode.cs
+++ b/OpenTabletDriver.Daemon.Library/Output/WindowsInk/WindowsInkAbsoluteMode.cs
@@ -1,0 +1,54 @@
+using System.ComponentModel;
+using OpenTabletDriver.Attributes;
+using OpenTabletDriver.Output;
+using OpenTabletDriver.Platform.Display;
+using OpenTabletDriver.Platform.Pointer;
+
+namespace OpenTabletDriver.Daemon.Library.Output.WindowsInk
+{
+    [PluginName("Windows Ink Absolute Mode"), SupportedPlatform(SystemPlatform.Windows)]
+    public class WindowsInkAbsoluteMode : AbsoluteOutputMode, IMouseButtonSource
+    {
+        private readonly WindowsInkPointer _windowsInkPointer;
+        private bool _sync = true;
+        private bool _forcedSync;
+
+        public WindowsInkAbsoluteMode(
+            InputDevice tablet,
+            IVirtualScreen virtualScreen,
+            ISettingsProvider settingsProvider
+        ) : base(tablet, new WindowsInkPointer(virtualScreen))
+        {
+            _windowsInkPointer = (WindowsInkPointer)Pointer;
+            settingsProvider.Inject(this);
+            _windowsInkPointer.Sync = _sync;
+            _windowsInkPointer.ForcedSync = _forcedSync;
+        }
+
+        [Setting("Sync OS Cursor", "Synchronize the normal OS cursor with the Windows Ink pen position when the pen leaves range."), DefaultValue(true)]
+        public bool Sync
+        {
+            set
+            {
+                _sync = value;
+                if (_windowsInkPointer is not null)
+                    _windowsInkPointer.Sync = value;
+            }
+            get => _sync;
+        }
+
+        [Setting("Forced Sync", "Synchronize the normal OS cursor on every Windows Ink report."), DefaultValue(false)]
+        public bool ForcedSync
+        {
+            set
+            {
+                _forcedSync = value;
+                if (_windowsInkPointer is not null)
+                    _windowsInkPointer.ForcedSync = value;
+            }
+            get => _forcedSync;
+        }
+
+        public IMouseButtonHandler MouseButtonHandler => _windowsInkPointer;
+    }
+}

--- a/OpenTabletDriver.Daemon.Library/Output/WindowsInk/WindowsInkButtonFlags.cs
+++ b/OpenTabletDriver.Daemon.Library/Output/WindowsInk/WindowsInkButtonFlags.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace OpenTabletDriver.Daemon.Library.Output.WindowsInk
+{
+    [Flags]
+    internal enum WindowsInkButtonFlags : byte
+    {
+        Press = 1,
+        Barrel = 2,
+        Eraser = 4,
+        Invert = 8,
+        InRange = 16
+    }
+}

--- a/OpenTabletDriver.Daemon.Library/Output/WindowsInk/WindowsInkPointer.cs
+++ b/OpenTabletDriver.Daemon.Library/Output/WindowsInk/WindowsInkPointer.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Numerics;
+using OpenTabletDriver.Platform.Display;
+using OpenTabletDriver.Platform.Pointer;
+
+namespace OpenTabletDriver.Daemon.Library.Output.WindowsInk
+{
+    internal unsafe class WindowsInkPointer : IAbsolutePointer, IPressureHandler, ITiltHandler, IEraserHandler, ISynchronousPointer
+    {
+        private readonly Vector2 _conversionFactor;
+        private readonly IVirtualScreen _screen;
+        private readonly VMultiInstance<DigitizerInputReport> _instance;
+        private readonly DigitizerInputReport* _rawPointer;
+        private ThinOsPointer? _osPointer;
+        private Vector2 _internalPosition;
+        private Vector2 _previousPosition;
+        private bool _dirty;
+        private bool _isEraser;
+
+        public WindowsInkPointer(IVirtualScreen screen)
+        {
+            _screen = screen;
+            _conversionFactor = new Vector2(32767, 32767) / new Vector2(screen.Width, screen.Height);
+            _instance = new VMultiInstance<DigitizerInputReport>("Windows Ink", extended => extended ? DigitizerInputReport.Extended() : DigitizerInputReport.Normal());
+            _rawPointer = _instance.Pointer;
+
+            if (_instance.Extended)
+                Log.Write("Windows Ink", "Using extended VMulti digitizer");
+        }
+
+        public bool Sync
+        {
+            set => _osPointer = value ? new ThinOsPointer(_screen) : null;
+        }
+
+        public bool ForcedSync { get; set; }
+
+        public void SetPosition(Vector2 position)
+        {
+            if (position == _previousPosition)
+                return;
+
+            _internalPosition = position;
+            _instance.EnableButtonBit((int)WindowsInkButtonFlags.InRange);
+            var convertedPosition = Convert(position);
+            _rawPointer->X = (ushort)Math.Clamp(convertedPosition.X, 0, 32767);
+            _rawPointer->Y = (ushort)Math.Clamp(convertedPosition.Y, 0, 32767);
+            _dirty = true;
+            _previousPosition = position;
+        }
+
+        public void SetPressure(float percentage)
+        {
+            var maximumPressure = _instance.Extended ? 16383 : 8191;
+            _rawPointer->Pressure = (ushort)Math.Clamp(percentage * maximumPressure, 0, maximumPressure);
+            _dirty = true;
+        }
+
+        public void SetTilt(Vector2 tilt)
+        {
+            _rawPointer->XTilt = unchecked((byte)Math.Clamp((int)tilt.X, -127, 127));
+            _rawPointer->YTilt = unchecked((byte)Math.Clamp((int)tilt.Y, -127, 127));
+            _dirty = true;
+        }
+
+        public void SetEraser(bool isEraser)
+        {
+            if (_isEraser == isEraser)
+                return;
+
+            TransitionEraserState(isEraser);
+            _isEraser = isEraser;
+            _dirty = true;
+        }
+
+        public void MouseDown(MouseButton button)
+        {
+            switch (button)
+            {
+                case MouseButton.Left:
+                    _instance.EnableButtonBit((int)(_isEraser ? WindowsInkButtonFlags.Eraser : WindowsInkButtonFlags.Press));
+                    break;
+                case MouseButton.Right:
+                case MouseButton.Middle:
+                case MouseButton.Backward:
+                case MouseButton.Forward:
+                    _instance.EnableButtonBit((int)WindowsInkButtonFlags.Barrel);
+                    break;
+            }
+            _instance.Write();
+        }
+
+        public void MouseUp(MouseButton button)
+        {
+            switch (button)
+            {
+                case MouseButton.Left:
+                    _instance.DisableButtonBit((int)(WindowsInkButtonFlags.Press | WindowsInkButtonFlags.Eraser));
+                    _rawPointer->Pressure = 0;
+                    break;
+                case MouseButton.Right:
+                case MouseButton.Middle:
+                case MouseButton.Backward:
+                case MouseButton.Forward:
+                    _instance.DisableButtonBit((int)WindowsInkButtonFlags.Barrel);
+                    break;
+            }
+            _instance.Write();
+        }
+
+        public void Reset()
+        {
+            if (_osPointer is not null && !ForcedSync)
+                SyncOsCursor();
+
+            _instance.DisableButtonBit((int)(WindowsInkButtonFlags.Press | WindowsInkButtonFlags.Eraser | WindowsInkButtonFlags.Barrel | WindowsInkButtonFlags.InRange | WindowsInkButtonFlags.Invert));
+            _rawPointer->Pressure = 0;
+            _instance.Write();
+        }
+
+        public void Flush()
+        {
+            if (!_dirty)
+                return;
+
+            _dirty = false;
+            if (ForcedSync)
+                SyncOsCursor();
+            _instance.Write();
+        }
+
+        private Vector2 Convert(Vector2 position)
+        {
+            return position * _conversionFactor;
+        }
+
+        private void SyncOsCursor()
+        {
+            _osPointer?.SetPosition(_internalPosition);
+        }
+
+        private void TransitionEraserState(bool isEraser)
+        {
+            var buttons = _rawPointer->Header.Buttons;
+            var pressure = _rawPointer->Pressure;
+
+            _instance.DisableButtonBit((int)(WindowsInkButtonFlags.Press | WindowsInkButtonFlags.Eraser));
+            _rawPointer->Pressure = 0;
+            _instance.Write();
+
+            _rawPointer->Header.Buttons = 0;
+            _instance.Write();
+
+            _instance.EnableButtonBit((int)WindowsInkButtonFlags.InRange);
+            if (isEraser)
+                _instance.EnableButtonBit((int)WindowsInkButtonFlags.Invert);
+            else
+                _instance.DisableButtonBit((int)WindowsInkButtonFlags.Invert);
+            _instance.Write();
+
+            if (VMultiInstance.HasBit(buttons, (int)(WindowsInkButtonFlags.Press | WindowsInkButtonFlags.Eraser)))
+                _instance.EnableButtonBit((int)(isEraser ? WindowsInkButtonFlags.Eraser : WindowsInkButtonFlags.Press));
+            _rawPointer->Pressure = pressure;
+        }
+    }
+}

--- a/OpenTabletDriver.UI.Library/ViewModels/TabletViewModel.cs
+++ b/OpenTabletDriver.UI.Library/ViewModels/TabletViewModel.cs
@@ -22,6 +22,8 @@ public partial class TabletViewModel : ActivatableViewModelBase
     private bool _saved = true;
     private DateTime _lastApply;
     private const int ApplyThresholdMs = 120;
+    private const string WindowsInkOutputModePath = "OpenTabletDriver.Daemon.Library.Output.WindowsInk.WindowsInkAbsoluteMode";
+    private const string VMultiDownloadUrlFallback = "https://github.com/X9VoiD/vmulti-bin/releases/latest";
 
     [ObservableProperty]
     private bool _isInitialized;
@@ -79,6 +81,41 @@ public partial class TabletViewModel : ActivatableViewModelBase
     public ObservableCollection<PluginSettingViewModel> OutputModeSettings { get; } = new();
     public ObservableCollection<BindingSettingViewModel> PenButtonBindings { get; } = new();
     public ObservableCollection<BindingSettingViewModel> TabletButtonBindings { get; } = new();
+
+    private bool _isVMultiStatusVisible;
+    public bool IsVMultiStatusVisible
+    {
+        get => _isVMultiStatusVisible;
+        set => SetProperty(ref _isVMultiStatusVisible, value);
+    }
+
+    private bool _isVMultiDownloadVisible;
+    public bool IsVMultiDownloadVisible
+    {
+        get => _isVMultiDownloadVisible;
+        set => SetProperty(ref _isVMultiDownloadVisible, value);
+    }
+
+    private string _vMultiStatusHeader = string.Empty;
+    public string VMultiStatusHeader
+    {
+        get => _vMultiStatusHeader;
+        set => SetProperty(ref _vMultiStatusHeader, value);
+    }
+
+    private string _vMultiStatusText = string.Empty;
+    public string VMultiStatusText
+    {
+        get => _vMultiStatusText;
+        set => SetProperty(ref _vMultiStatusText, value);
+    }
+
+    private string _vMultiDownloadUrl = VMultiDownloadUrlFallback;
+    public string VMultiDownloadUrl
+    {
+        get => _vMultiDownloadUrl;
+        set => SetProperty(ref _vMultiDownloadUrl, value);
+    }
 
     public bool Modified
     {
@@ -151,6 +188,52 @@ public partial class TabletViewModel : ActivatableViewModelBase
         IsInitialized = true;
     }
 
+    [RelayCommand]
+    private async Task RefreshVMultiStatus()
+    {
+        if (!IsWindowsInkOutputMode(SelectedOutputMode))
+            return;
+
+        if (_daemonService.Instance is not { } daemon)
+        {
+            VMultiStatusHeader = "VMulti status unavailable";
+            VMultiStatusText = "The daemon is not connected. Start or reconnect the daemon, then refresh VMulti status.";
+            VMultiDownloadUrl = VMultiDownloadUrlFallback;
+            IsVMultiDownloadVisible = true;
+            return;
+        }
+
+        try
+        {
+            var status = await daemon.GetVMultiDeviceStatus();
+            VMultiStatusHeader = status.Kind switch
+            {
+                VMultiDeviceStatusKind.Ready when status.IsExtendedDigitizerAvailable => "VMulti ready (extended digitizer)",
+                VMultiDeviceStatusKind.Ready => "VMulti ready",
+                VMultiDeviceStatusKind.Missing => "VMulti missing",
+                VMultiDeviceStatusKind.Incomplete => "VMulti installation incomplete",
+                VMultiDeviceStatusKind.OpenFailed => "VMulti could not be opened",
+                _ => "VMulti status unavailable"
+            };
+            VMultiStatusText = status.Message;
+            VMultiDownloadUrl = string.IsNullOrWhiteSpace(status.DownloadUrl) ? VMultiDownloadUrlFallback : status.DownloadUrl;
+            IsVMultiDownloadVisible = !status.IsAvailable;
+        }
+        catch (Exception ex)
+        {
+            VMultiStatusHeader = "VMulti status unavailable";
+            VMultiStatusText = $"OpenTabletDriver could not query VMulti status: {ex.Message}";
+            VMultiDownloadUrl = VMultiDownloadUrlFallback;
+            IsVMultiDownloadVisible = true;
+        }
+    }
+
+    [RelayCommand]
+    private void OpenVMultiDownloadPage()
+    {
+        var url = string.IsNullOrWhiteSpace(VMultiDownloadUrl) ? VMultiDownloadUrlFallback : VMultiDownloadUrl;
+        Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+    }
     [RelayCommand(CanExecute = nameof(Modified))]
     private async Task Apply()
     {
@@ -503,6 +586,7 @@ public partial class TabletViewModel : ActivatableViewModelBase
     partial void OnSelectedOutputModeChanged(PluginDto? value)
     {
         OutputModeSettings.Clear();
+        UpdateVMultiStatusVisibility(value);
 
         if (value is null)
             return;
@@ -523,6 +607,25 @@ public partial class TabletViewModel : ActivatableViewModelBase
         settings.ForEach(s => s.PropertyChanged += HandleSettingsChanged);
         OutputModeSettings.AddRange(settings);
     }
+
+    private void UpdateVMultiStatusVisibility(PluginDto? outputMode)
+    {
+        IsVMultiStatusVisible = IsWindowsInkOutputMode(outputMode);
+        if (!IsVMultiStatusVisible)
+            return;
+
+        VMultiStatusHeader = "Checking VMulti status...";
+        VMultiStatusText = "Windows Ink output mode requires the external VMulti VirtualHID driver. OpenTabletDriver does not install this kernel driver automatically.";
+        VMultiDownloadUrl = VMultiDownloadUrlFallback;
+        IsVMultiDownloadVisible = true;
+        _ = RefreshVMultiStatus();
+    }
+
+    private static bool IsWindowsInkOutputMode(PluginDto? outputMode)
+    {
+        return outputMode?.Path == WindowsInkOutputModePath;
+    }
+
     partial void OnSensitivityXChanged(double value) => HandleSettingsChanged(null, null!);
     partial void OnSensitivityYChanged(double value) => HandleSettingsChanged(null, null!);
     partial void OnResetDelayChanged(double value) => HandleSettingsChanged(null, null!);

--- a/OpenTabletDriver.UI.Library/Views/TabletView.axaml
+++ b/OpenTabletDriver.UI.Library/Views/TabletView.axaml
@@ -39,6 +39,35 @@
           </Grid>
         </tc:Section>
 
+        <!-- Windows Ink / VMulti dependency -->
+        <tc:Section
+            Header="Windows Ink dependency"
+            IsVisible="{Binding IsVMultiStatusVisible}">
+          <StackPanel Spacing="8">
+            <TextBlock
+                Text="{Binding VMultiStatusHeader}"
+                FontWeight="SemiBold" />
+            <TextBlock
+                Text="{Binding VMultiStatusText}"
+                TextWrapping="Wrap" />
+            <TextBlock
+                Text="VMulti remains an external dependency. Download it, extract the archive, run install_hiddriver.bat as administrator, then restart OpenTabletDriver."
+                TextWrapping="Wrap"
+                IsVisible="{Binding IsVMultiDownloadVisible}" />
+            <StackPanel
+                Orientation="Horizontal"
+                Spacing="8">
+              <Button
+                  Content="Open VMulti download page"
+                  Command="{Binding OpenVMultiDownloadPageCommand}"
+                  IsVisible="{Binding IsVMultiDownloadVisible}" />
+              <Button
+                  Content="Refresh VMulti status"
+                  Command="{Binding RefreshVMultiStatusCommand}" />
+            </StackPanel>
+          </StackPanel>
+        </tc:Section>
+
         <!-- Display Area -->
         <tc:Section
             Classes="Emphasized"


### PR DESCRIPTION
# Changes

Closes #4862.

This PR adds a Windows Ink absolute output mode backed by the external VMulti VirtualHID driver, plus UI guidance for that dependency.

- Adds `Windows Ink Absolute Mode` as a Windows-only output mode.
- Emits VMulti digitizer reports with pressure/button state.
- Adds a VMulti status detector with centralized VID/PID/report constants.
- Adds daemon API `GetVMultiDeviceStatus()`.
- Adds Avalonia UI status guidance shown only when Windows Ink output is selected.
- Links to the VMulti download page, but does not download, bundle, silently install, or request elevation for the kernel driver.

Validation:
- `dotnet build OpenTabletDriver.UI -c Release --no-restore`
- `dotnet build OpenTabletDriver.Daemon -c Release --no-restore`
- `dotnet test OpenTabletDriver.Tests -c Release --no-restore --filter Configuration`
- Local manual test: UI reports `VMulti ready (extended digitizer)`, and pressure-sensitive Windows Ink drawing works with Gaomon WH851 in Anki/QtWebEngine.

Note: this implementation was AI-assisted, then manually reviewed and tested locally before submission.