### PR TITLE
Lock Huion HS611 interface to 0

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/HS611.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/HS611.json
@@ -42,6 +42,7 @@
     }
   ],
   "Attributes": {
-    "libinputoverride": "1"
+    "libinputoverride": "1",
+    "Interface": "0"
   }
 }


### PR DESCRIPTION
Diag seen here detecting on interface 1, user reporting tablet does not work: [Diagnostics-067 Huion HS611.json](https://github.com/user-attachments/files/28561872/Diagnostics-067.Huion.HS611.json)
Verification: https://discord.com/channels/615607687467761684/723399565780189234/1511776476125728869

Prior issue on `111` pid variant (#2766) shows both of these conflicting identifiers too but interface `0` shows up first so it detects correctly.

I can't find any info about the very start of this config. It think it was pulled in from hawku driver with no verification on our end. It probably works fine on windows without this change but needs it on linux.