### PR TITLE
Add BOSTO 12HD-A driver/config file.

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Bosto/BT-12HD-A.json
+++ b/OpenTabletDriver.Configurations/Configurations/Bosto/BT-12HD-A.json
@@ -1,0 +1,29 @@
+{
+  "Name": "BOSTO BT-12HD-A",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 256.0,
+      "Height": 145.0,
+      "MaxX": 17918.0,
+      "MaxY": 10228.0
+    },
+    "Pen": {
+      "MaxPressure": 16384,
+      "Buttons": {
+        "ButtonCount": 2
+      }
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 3793,
+      "ProductID": 30753,
+      "InputReportLength": 10,
+      "OutputReportLength": 0,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "FeatureInitReport": null,
+      "OutputInitReport": null,
+      "InitializationStrings": []
+    }
+  ]
+}

--- a/OpenTabletDriver.Configurations/Configurations/Bosto/BT-12HD-A.json
+++ b/OpenTabletDriver.Configurations/Configurations/Bosto/BT-12HD-A.json
@@ -1,5 +1,5 @@
 {
-  "Name": "BOSTO BT-12HD-A",
+  "Name": "Bosto BT-12HD-A",
   "Specifications": {
     "Digitizer": {
       "Width": 256.0,

--- a/OpenTabletDriver.Configurations/Configurations/Bosto/BT-12HD-A.json
+++ b/OpenTabletDriver.Configurations/Configurations/Bosto/BT-12HD-A.json
@@ -9,9 +9,7 @@
     },
     "Pen": {
       "MaxPressure": 16384,
-      "Buttons": {
-        "ButtonCount": 2
-      }
+      "ButtonCount": 2
     }
   },
   "DigitizerIdentifiers": [

--- a/OpenTabletDriver.Configurations/Configurations/Bosto/BT-12HD-A.json
+++ b/OpenTabletDriver.Configurations/Configurations/Bosto/BT-12HD-A.json
@@ -2,13 +2,13 @@
   "Name": "Bosto BT-12HD-A",
   "Specifications": {
     "Digitizer": {
-      "Width": 258.0,
-      "Height": 145.0,
+      "Width": 227.5586,
+      "Height": 129.8956,
       "MaxX": 17918.0,
       "MaxY": 10228.0
     },
     "Pen": {
-      "MaxPressure": 16384,
+      "MaxPressure": 8191,
       "ButtonCount": 2
     }
   },

--- a/OpenTabletDriver.Configurations/Configurations/Bosto/BT-12HD-A.json
+++ b/OpenTabletDriver.Configurations/Configurations/Bosto/BT-12HD-A.json
@@ -2,7 +2,7 @@
   "Name": "Bosto BT-12HD-A",
   "Specifications": {
     "Digitizer": {
-      "Width": 256.0,
+      "Width": 258.0,
       "Height": 145.0,
       "MaxX": 17918.0,
       "MaxY": 10228.0

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -219,6 +219,7 @@
 | XP-Pen Star G960S Plus             |     Supported     |
 | XP-Pen Deco 03                     |     Supported     |
 | Bosto BT-12HD                      |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0.
+| Bosto BT-12HD-A                    |     Supported     |
 | FlooGoo FMA100                     |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 1. Might also need to change the configuration depending on the tablet used.
 | Gaomon S56K                        |    Has Quirks     | Windows: Might need Zadig's WinUSB to be installed on interface 0 or 1
 | Gaomon S630                        |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0


### PR DESCRIPTION
Adds configuration file for BOSTO 12HD-A graphic tablet.

Config file tested on Nobara Linux 43 (KDE Plasma Desktop Edition) x86_64 (WM: KWin Wayland).

Closes #4881 