### PR TITLE
Added wheel support for Huion Q630M

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/Q630M.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/Q630M.json
@@ -12,8 +12,18 @@
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {
-      "ButtonCount": 6
-    }
+      "ButtonCount": 8
+    },
+    "Wheels": [
+      {
+        "RelativeWheelSteps": 24,
+        "ButtonCount": 0
+      },
+      {
+        "RelativeWheelSteps": 24,
+        "ButtonCount": 0
+      }
+    ]
   },
   "DigitizerIdentifiers": [
     {

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -61,6 +61,7 @@
 | Huion Note X10                     |     Supported     |
 | Huion Q11K                         |     Supported     |
 | Huion Q11K V2                      |     Supported     |
+| Huion Q630M                        |     Supported     |
 | Huion RDS-160                      |     Supported     |
 | Huion RDS-220                      |     Supported     |
 | Huion RTS-300                      |     Supported     | Uses the same configuration as the Huion H642.
@@ -285,7 +286,6 @@
 | Huion Kamvas Pro 24                |  Missing Features | Touch bar is not yet supported.
 | Huion Kamvas Pro 24 (Gen 3)        |  Missing Features | Touch is not yet supported.
 | Huion Q620M                        |  Missing Features | Wheel button is not yet supported.
-| Huion Q630M                        |  Missing Features | Dials/Wheels are not yet supported.
 | Huion RTM-500                      |  Missing Features | Touch bar is not yet supported.
 | Huion RTP-700                      |  Missing Features | Touch bar is not yet supported.
 | LifeTec LT9570                     |  Missing Features | Aux buttons and tilt is not yet supported.

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -61,7 +61,6 @@
 | Huion Note X10                     |     Supported     |
 | Huion Q11K                         |     Supported     |
 | Huion Q11K V2                      |     Supported     |
-| Huion Q630M                        |     Supported     |
 | Huion RDS-160                      |     Supported     |
 | Huion RDS-220                      |     Supported     |
 | Huion RTS-300                      |     Supported     | Uses the same configuration as the Huion H642.
@@ -234,6 +233,7 @@
 | Huion Kamvas 13 (Gen 3)            |    Has Quirks     | Function-switch buttons act as regular auxiliary keys.
 | Huion New 1060 Plus (2048)         |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 1
 | Huion osu! Tablet                  |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0. Uses the same configuration as the Huion 420.
+| Huion Q630M                        |    Has Quirks     | Aux buttons are not in order.
 | Huion WH1409 V2 (Variant 2)        |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0
 | KENTING K5540                      |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed
 | Monoprice 10594                    |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0


### PR DESCRIPTION
I have added wheel/dial support to the configuration json of the Huion Q630M.

This also includes the dial buttons as 2 additional auxiliary buttons

According to the guidelines i have thus also moved the tablet in the TABLETS.md to supported