### PR TITLE
Allow PluginSettingStore Path to be null and handle it as such

### DIFF
--- a/OpenTabletDriver.Desktop/Reflection/PluginSettingStore.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginSettingStore.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
 using Newtonsoft.Json;
+using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Attributes;
 using OpenTabletDriver.Plugin.DependencyInjection;
 using OpenTabletDriver.Plugin.Tablet;
@@ -48,7 +49,11 @@ namespace OpenTabletDriver.Desktop.Reflection
 
         public T? Construct<T>(TabletReference? tabletReference = null, bool trigger = true) where T : class
         {
-            if (Path == null) return null;
+            if (Path == null)
+            {
+                Log.Write($"Construct<T>", $"{nameof(Path)} is null, returning null", LogLevel.Debug);
+                return null;
+            }
 
             var obj = AppInfo.PluginManager.ConstructObject<T>(Path);
             ApplySettings(obj);

--- a/OpenTabletDriver.Desktop/Reflection/PluginSettingStore.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginSettingStore.cs
@@ -15,8 +15,8 @@ namespace OpenTabletDriver.Desktop.Reflection
 
         public PluginSettingStore(Type type, bool enable = true)
         {
-            Path = type.FullName ?? throw new InvalidOperationException($"Could not look up full name for type {type}");
-            Settings = GetSettingsForType(type);
+            Path = type?.FullName;
+            Settings = type != null ? GetSettingsForType(type) : new ObservableCollection<PluginSetting>();
             Enable = enable;
         }
 
@@ -24,8 +24,7 @@ namespace OpenTabletDriver.Desktop.Reflection
         {
             var sourceType = source.GetType();
 
-            Path = sourceType.FullName ??
-                   throw new InvalidOperationException($"Could not look up {nameof(Path)}'s full name via type '{sourceType}'");
+            Path = sourceType.FullName;
 
             Settings = GetSettingsForType(sourceType, source);
             Enable = enable;
@@ -38,10 +37,10 @@ namespace OpenTabletDriver.Desktop.Reflection
             Settings = settings;
         }
 
-        public string Path { set; get; }
+        public string? Path { set; get; }
 
         [JsonIgnore]
-        public string? Name => AppInfo.PluginManager.GetFriendlyName(Path);
+        public string? Name => Path != null ? AppInfo.PluginManager.GetFriendlyName(Path) : null;
 
         public ObservableCollection<PluginSetting> Settings { set; get; }
 
@@ -49,6 +48,8 @@ namespace OpenTabletDriver.Desktop.Reflection
 
         public T? Construct<T>(TabletReference? tabletReference = null, bool trigger = true) where T : class
         {
+            if (Path == null) return null;
+
             var obj = AppInfo.PluginManager.ConstructObject<T>(Path);
             ApplySettings(obj);
             if (trigger)

--- a/OpenTabletDriver.Desktop/Reflection/PluginSettingStore.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginSettingStore.cs
@@ -38,6 +38,7 @@ namespace OpenTabletDriver.Desktop.Reflection
             Settings = settings;
         }
 
+        // TODO: make non-nullable or similar fix, since it never makes sense to have a null/empty path? -gonX
         public string? Path { set; get; }
 
         [JsonIgnore]

--- a/OpenTabletDriver.Desktop/Reflection/PluginSettingStore.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginSettingStore.cs
@@ -14,7 +14,7 @@ namespace OpenTabletDriver.Desktop.Reflection
     {
         private static readonly Type _tabletRefType = typeof(TabletReference);
 
-        public PluginSettingStore(Type type, bool enable = true)
+        public PluginSettingStore(Type? type, bool enable = true)
         {
             Path = type?.FullName;
             Settings = type != null ? GetSettingsForType(type) : new ObservableCollection<PluginSetting>();

--- a/OpenTabletDriver.UX/Windows/Bindings/AdvancedBindingEditorDialog.cs
+++ b/OpenTabletDriver.UX/Windows/Bindings/AdvancedBindingEditorDialog.cs
@@ -70,7 +70,7 @@ namespace OpenTabletDriver.UX.Windows.Bindings
                 }
             };
 
-            bindingTypeDropDown.SelectedItemBinding.Convert(t => new PluginSettingStore(t!)).Bind(settingStoreEditor.StoreBinding!);
+            bindingTypeDropDown.SelectedItemBinding.Convert(t => new PluginSettingStore(t)).Bind(settingStoreEditor.StoreBinding!);
             bindingTypeDropDown.SelectedItem = currentBinding?.GetTypeInfo();
             settingStoreEditor.Store = currentBinding;
         }


### PR DESCRIPTION
Issue that snuck in with NRT. Restoring this to the original behavior instead of throwing.

Added `if (Path == null) return null;` is new and likely not possible to hit this case but silencing the warning.

Fixes #4895