### PR TITLE
Bump StreamJsonRpc to 2.25.29

### DIFF
--- a/OpenTabletDriver.Desktop/OpenTabletDriver.Desktop.csproj
+++ b/OpenTabletDriver.Desktop/OpenTabletDriver.Desktop.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
-    <PackageReference Include="StreamJsonRpc" Version="2.22.23" />
+    <PackageReference Include="StreamJsonRpc" Version="2.25.29" />
     <PackageReference Include="System.CommandLine" Version="2.0.1" />
     <PackageReference Include="WaylandNET" Version="0.2.0" />
   </ItemGroup>


### PR DESCRIPTION
```
OpenTabletDriver.Desktop.csproj : warning NU1903: Package 'MessagePack' 2.5.192 has a known high severity vulnerability, https://github.com/advisories/GHSA-hv8m-jj95-wg3x
```
https://github.com/advisories/GHSA-hv8m-jj95-wg3x


Dependency tree from `dotnet nuget why OpenTabletDriver.sln MessagePack`:
```
  [net10.0/linux-x64]                                                                                                                                                           
  [net10.0]                                                                                                                                                                     
  └── OpenTabletDriver.Desktop (v0.6.7)                                                                                                                                         
      └── StreamJsonRpc (v2.25.29)                                                                                                                                              
          └── MessagePack (v2.5.302)    
```

This doesn't actually hit OTD since we don't handle untrusted data but bumping anyways to get rid of the annoying warnings.

I don't see any changes that should be breaking here. Tested lightly on linux.