### PR TITLE
Fix output mode selector not working

### DIFF
--- a/OpenTabletDriver.UX/Controls/Output/OutputModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/OutputModeEditor.cs
@@ -35,7 +35,7 @@ namespace OpenTabletDriver.UX.Controls.Output
             outputModeSelector.SelectedItemBinding.Convert<PluginSettingStore?>(
                 c => PluginSettingStore.FromPath(c?.FullName),
                 v => v?.GetTypeInfo()
-            ).Bind(ProfileBinding.Child(c => c != null ? c.OutputMode : null));
+            ).Bind(ProfileBinding.Child(c => (PluginSettingStore?)c!.OutputMode));
 
             outputModeSelector.SelectedValueChanged += (sender, e) => UpdateOutputMode(Profile?.OutputMode);
 


### PR DESCRIPTION
I have no clue why this doesn't work with the existing code.

Doesn't work:
```
c => c != null ? c.OutputMode : null
```
```
c => c != null ? (PluginSettingStore?)c.OutputMode : null
```

Works:
```
c => c.OutputMode
```
```
c => (PluginSettingStore?)c!.OutputMode)
```

Compiler is pulling some bs on us. The solution in this PR is the only way I could get it to not have warnings and work.