### PR TITLE
PluginSettingStore: Simplify constructor taking `object`

### DIFF
--- a/OpenTabletDriver.Console/Program.Commands.cs
+++ b/OpenTabletDriver.Console/Program.Commands.cs
@@ -199,7 +199,7 @@ namespace OpenTabletDriver.Console
         {
             await ModifyProfile(tablet, p =>
             {
-                var tipBinding = AppInfo.PluginManager.ConstructObject<IBinding>(name);
+                var tipBinding = AppInfo.PluginManager.ConstructObject<IBinding>(name) ?? throw new InvalidOperationException($"Could not construct binding with name {name}");
 
                 p.BindingSettings.TipButton = new PluginSettingStore(tipBinding);
                 p.BindingSettings.TipActivationThreshold = threshold;
@@ -210,7 +210,7 @@ namespace OpenTabletDriver.Console
         {
             await ModifyProfile(tablet, p =>
             {
-                var binding = AppInfo.PluginManager.ConstructObject<IBinding>(name);
+                var binding = AppInfo.PluginManager.ConstructObject<IBinding>(name) ?? throw new InvalidOperationException($"Could not construct binding with name {name}");
 
                 p.BindingSettings.PenButtons[index] = new PluginSettingStore(binding);
             });
@@ -220,7 +220,7 @@ namespace OpenTabletDriver.Console
         {
             await ModifyProfile(tablet, p =>
             {
-                var binding = AppInfo.PluginManager.ConstructObject<IBinding>(name);
+                var binding = AppInfo.PluginManager.ConstructObject<IBinding>(name) ?? throw new InvalidOperationException($"Could not construct binding with name {name}");
 
                 p.BindingSettings.AuxButtons[index] = new PluginSettingStore(binding);
             });

--- a/OpenTabletDriver.Console/Program.Misc.cs
+++ b/OpenTabletDriver.Console/Program.Misc.cs
@@ -101,7 +101,7 @@ namespace OpenTabletDriver.Console
                 var existing = pssc.FirstOrDefault(x => x?.Path == path);
                 if (existing == null)
                 {
-                    var obj = PluginSettingStore.FromPath(path)?.Construct<T>();
+                    var obj = PluginSettingStore.FromPath(path)?.Construct<T>() ?? throw new InvalidOperationException($"Could not construct settings from path {path}");
                     pssc.Add(new PluginSettingStore(obj));
                 }
                 else

--- a/OpenTabletDriver.Desktop/Reflection/PluginSettingStore.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginSettingStore.cs
@@ -20,21 +20,15 @@ namespace OpenTabletDriver.Desktop.Reflection
             Enable = enable;
         }
 
-        public PluginSettingStore(object? source, bool enable = true)
+        public PluginSettingStore(object source, bool enable = true)
         {
-            if (source != null)
-            {
-                var sourceType = source.GetType();
+            var sourceType = source.GetType();
 
-                Path = sourceType.FullName ??
-                       throw new InvalidOperationException($"Could not look up full name for type {sourceType}");
-                Settings = GetSettingsForType(sourceType, source);
-                Enable = enable;
-            }
-            else
-            {
-                throw new NullReferenceException("Creating a plugin setting store from a null object is not allowed.");
-            }
+            Path = sourceType.FullName ??
+                   throw new InvalidOperationException($"Could not look up {nameof(Path)}'s full name via type '{sourceType}'");
+
+            Settings = GetSettingsForType(sourceType, source);
+            Enable = enable;
         }
 
         [JsonConstructor]


### PR DESCRIPTION
The constructor will throw when supplying a null object, so there's no reason to mark support for it taking a null object.

Essentially a continuation of the NRT pull request (OpenTabletDriver/OpenTabletDriver#4779)

Should be 1:1 to behavior as before, as both before and after the PR will throw a null reference exception - the only true difference is that pre-PR has a custom message for the exception.

I've also changed the `InvalidOperationException` message to clearer differentiate it from the other constructor, to clarify future stack traces.

Official code style [CA2201](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2201) also seems to suggest that C# programmers should not be sending reserved exceptions like `NullReferenceException`, but it is not enabled by default, suggesting its use is debatable (though personally I think it makes sense).