### PR TITLE
package.sh: Support linux-*arm64 too

### DIFF
--- a/eng/bash/package.sh
+++ b/eng/bash/package.sh
@@ -59,10 +59,14 @@ while [ ${#remaining_args[@]} -gt 0 ]; do
 done
 
 if [ -z "${NET_RUNTIME:-}" ]; then
+  case "${MACHTYPE}" in
+    aarch64*) arch="arm64" ;;
+    *) arch="x64" ;;
+  esac
   if is_musl_based_distro; then # is this command even portable?
-    NET_RUNTIME="linux-musl-x64"
+    NET_RUNTIME="linux-musl-${arch}"
   else
-    NET_RUNTIME="linux-x64"
+    NET_RUNTIME="linux-${arch}"
   fi
   echo "WARN: You must specify a runtime! Falling back to '${NET_RUNTIME}'"
 fi


### PR DESCRIPTION
Works now on ARM64 Linux hosts natively running the script without having to define `NET_RUNTIME` in environment.