### PR TITLE
Mention some UC-Logic 1060N require winusb

### DIFF
--- a/TABLETS.md
+++ b/TABLETS.md
@@ -74,7 +74,6 @@
 | Parblo Ninos N4                    |     Supported     |
 | Parblo Ninos N7                    |     Supported     |
 | RobotPen T9A                       |     Supported     |
-| UC-Logic 1060N                     |     Supported     |
 | UC-Logic PF1209                    |     Supported     |
 | UGEE EX08                          |     Supported     | Uses the same configuration as the XP-Pen Deco 01 V2.
 | UGEE M708 V2                       |     Supported     |
@@ -242,6 +241,7 @@
 | Parblo Ninos S                     |    Has Quirks     | Aux buttons are not in order.
 | Trust Flex Design Tablet           |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed
 | Turcom TS-6580                     |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0
+| UC-Logic 1060N                     |    Has Quirks     | Windows: Some variants require Zadig's WinUSB to be installed on interface 0
 | UC-Logic TWMNA62                   |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0
 | UGEE M708                          |    Has Quirks     | Windows: Might need Zadig's WinUSB to be installed on interface 0
 | Wacom PTH-460                      |    Has Quirks     | Wheel reports in reverse direction.


### PR DESCRIPTION
Verification: https://discord.com/channels/615607687467761684/615611007951306863/1519756382881058977

Very thorough runthrough with this user. Checking all updatable device endpoints and nothing allowed them to be detected properly except adding winusb. No config changes needed for this tablet, winusb did not change the endpoint lengths.

Diag (with winusb interface 0): [Diagnostics-067 UC-Logic 1060N.json](https://github.com/user-attachments/files/29350389/Diagnostics-067.UC-Logic.1060N.json)
Diag (no winusb): [Diagnostics-067-32.json](https://github.com/user-attachments/files/29350400/Diagnostics-067-32.json)
