### PR TITLE
Add support for buttons and tilt on artisul m0610 variants that support it

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Artisul/M0610 Pro.json
+++ b/OpenTabletDriver.Configurations/Configurations/Artisul/M0610 Pro.json
@@ -32,7 +32,7 @@
       "VendorID": 9580,
       "ProductID": 111,
       "InputReportLength": 12,
-      "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
       "DeviceStrings": {
         "201": "OEM16_T205_\\d{6}$"
       },
@@ -44,7 +44,7 @@
       "VendorID": 9580,
       "ProductID": 110,
       "InputReportLength": 12,
-      "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
       "DeviceStrings": {
         "201": "OEM16_T205_\\d{6}$"
       },

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -256,7 +256,7 @@
 | Artisul A1201                      |  Missing Features | Touch bar is not yet supported.
 | Artisul AP604 (Pencil Small)       |  Missing Features | Aux buttons and eraser detection are not yet supported. Windows: Requires Zadig's WinUSB to be installed on interface 1.
 | Artisul D16 Pro                    |  Missing Features | Wheel is not yet supported.
-| Artisul M0610 Pro                  |  Missing Features | Tablet buttons, tilt, and wheel are not yet supported.
+| Artisul M0610 Pro                  |  Missing Features | Wheel is not yet supported.
 | Gaomon M10K                        |  Missing Features | Wheel is not yet supported.
 | Gaomon M10K Pro                    |  Missing Features | Wheel is not yet supported.
 | Gaomon M1220                       |  Missing Features | Wheel is not yet supported.


### PR DESCRIPTION
First variant in this config was added in #1147. User helping get this supported shows some data here that only has 10 bytes. This is not enough for tilt so I've excluded tilt from this variant in the config.
<img width="629" height="658" alt="bruuuuuuuuuuuuuh" src="https://github.com/user-attachments/assets/53086921-a8bb-4b30-8171-c4a2d1940694" />

Newer variant has 12 bytes which is expected for a tablet that supports tilt.
Data from newer variants (some pen movement at the top then buttons pressed in order): [tablet-data_1782406657.txt](https://github.com/user-attachments/files/29350788/tablet-data_1782406657.txt)
Strings from newer variant: [string-dump_9580-111.txt](https://github.com/user-attachments/files/29350830/string-dump_9580-111.txt)
Verification: https://discord.com/channels/615607687467761684/1519649118509858927/1519756547314417856

This tablet also has a wheel. Not adding support for it in this PR.