### PR TITLE
Bump all mentions of .NET SDK in readmes to .NET 10 SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The requirements to build OpenTabletDriver are consistent across all platforms. 
 
 ### All platforms
 
-- .NET 8 SDK (can be obtained from [here](https://dotnet.microsoft.com/download/dotnet/8.0) - You want the SDK for your platform, Linux users should install via package manager where possible)
+- .NET 10 SDK (can be obtained from [here](https://dotnet.microsoft.com/download/dotnet/10.0) - You want the SDK for your platform, Linux users should install via package manager where possible)
 
 #### Windows
 

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -39,7 +39,7 @@ OpenTabletDriver 由两个独立进程协同工作：守护进程`OpenTabletDriv
 
 ### 所有平台
 
-- .NET 8 SDK (点击[这里](https://dotnet.microsoft.com/download/dotnet/8.0)获取 - 需要对应平台的SDK， Linux建议通过包管理器安装)
+- .NET 10 SDK (点击[这里](https://dotnet.microsoft.com/download/dotnet/10.0)获取 - 需要对应平台的SDK， Linux建议通过包管理器安装)
 
 #### Windows
 

--- a/docs/README_DE.md
+++ b/docs/README_DE.md
@@ -36,7 +36,7 @@ Die Voraussetzungen für OpenTabletDriver sind auf allen Platformen gleich. Abh�
 
 ### Alle Platformen
 
-- .NET 6 SDK (kann [hier](https://dotnet.microsoft.com/download/dotnet/6.0) heruntergeladen werden - Die SDK für die jeweilige Platform wird benötigt, Linuxnutzer sollten die SDK nach möglichkeit mithilfe eines Package-Managers installieren)
+- .NET 10 SDK (kann [hier](https://dotnet.microsoft.com/download/dotnet/10.0) heruntergeladen werden - Die SDK für die jeweilige Platform wird benötigt, Linuxnutzer sollten die SDK nach möglichkeit mithilfe eines Package-Managers installieren)
 
 #### Windows
 

--- a/docs/README_ES.md
+++ b/docs/README_ES.md
@@ -36,7 +36,7 @@ Los requisitos para compilar OpenTabletDriver son consistentes en todas las plat
 
 ### Todas las plataformas
 
-- .NET 6 SDK (Puede ser obtenido desde [aquí](https://dotnet.microsoft.com/download/dotnet/6.0) - Usted necesita el SDK compatible con su plataforma, los usuarios de Linux deben de instalarlo a través del gestor de paquetes siempre que sea posible)
+- .NET 10 SDK (Puede ser obtenido desde [aquí](https://dotnet.microsoft.com/download/dotnet/10.0) - Usted necesita el SDK compatible con su plataforma, los usuarios de Linux deben de instalarlo a través del gestor de paquetes siempre que sea posible)
 
 #### Windows
 

--- a/docs/README_FR.md
+++ b/docs/README_FR.md
@@ -36,7 +36,7 @@ Les exigences pour build OpenTabletDriver sont cohérentes sur toutes les platef
 
 ### Toutes les plateformes
 
-- .NET 6 SDK (peut-être obtenu [Ici](https://dotnet.microsoft.com/download/dotnet/6.0) - Prendre le SDK pour votre plateforme, les utilisateurs Linux doivent installer via un gestionnaire de paquets qui fournit le paquet .NET 6)
+- .NET 10 SDK (peut-être obtenu [Ici](https://dotnet.microsoft.com/download/dotnet/10.0) - Prendre le SDK pour votre plateforme, les utilisateurs Linux doivent installer via un gestionnaire de paquets qui fournit le paquet .NET 6)
 
 #### Windows
 

--- a/docs/README_KO.md
+++ b/docs/README_KO.md
@@ -36,7 +36,7 @@ OpenTabletDriver를 빌드하기 위해 필요한 것들은 모든 플랫폼에�
 
 ### 모든 플랫폼
 
-- .NET 6 SDK
+- .NET 10 SDK
 
 #### Windows
 

--- a/docs/README_RU.md
+++ b/docs/README_RU.md
@@ -44,7 +44,7 @@ OpenTabletDriver работает в двух процессах, взаимод
 
 ### Все платформы
 
-- .NET 6 SDK
+- .NET 10 SDK
 
 #### Windows
 


### PR DESCRIPTION
Closes #4780

Some of these listed .NET 6 still.... Just updating what is obvious to update. The translated readmes could use some updating in general.