### PR TITLE
Dont block ITouchReport from AsyncPositionedPipelineElement Consume

### DIFF
--- a/OpenTabletDriver.Plugin/Output/AsyncPositionedPipelineElement.cs
+++ b/OpenTabletDriver.Plugin/Output/AsyncPositionedPipelineElement.cs
@@ -67,8 +67,8 @@ namespace OpenTabletDriver.Plugin.Output
 
         public void Consume(T? value)
         {
-            // Block DeviceReport and ITouchReport from being consumed for now
-            if (value is DeviceReport or ITouchReport)
+            // Block DeviceReport from being consumed for now
+            if (value is DeviceReport)
                 return;
 
             lock (synchronizationObject)


### PR DESCRIPTION
Regression caused by #2802 (has been in since v0.6.2.0).

<img width="381" height="50" alt="image" src="https://github.com/user-attachments/assets/dd237a0d-3dba-4894-a5a4-988ca2873cba" />

This was originally done to resolve #2387. My changes in this PR cause the opposite regression.

When `Consume` runs it hits `ConsumeState` in the plugin but it also sets the next state to be used by `UpdateState`. When a position interpolator gets data that isnt a position it tends to do nothing so it effectively drops a report out of the interpolation. This is not a problem for small cases like pressing an aux button but for tablets that send touch at 100-200hz constantly while being touched by a hand with no way to turn it off, it becomes a problem.

Disallowing `ITouchReport` to be consumed by async filters makes it so that any report containing `ITouchReport` is kicked out of the pipeline entirely. We have `WacomTouchReport` that is both an `ITouchReport` and `IAuxReport` which means it discards aux data while an async filter is enabled.

Unsure what a good way to fix this is. The solution provided in this PR really isnt great and even `DeviceReport` probably shouldnt be filtered out. Could have these reports entirely skip async pipeline elements but that's expanding the scope of this little hack a bit too much imo.
Might be best to have async plugins define a filter method that allows filtering the reports they want to receive. Could probably implement that somewhat non-breaking.
It is also technically possible for plugins to cache their own reports and work around this issue but I don't really like the idea of that being required to have a durable interpolator implementation. And that would still break if the tablet is reporting at a higher report rate than the user's interpolator timer hz.