### PR TITLE
global.json: Fix invalid version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.0",
+    "version": "10.0.100",
     "rollForward": "latestMinor",
     "allowPrerelease": false
   }


### PR DESCRIPTION
See `dotnet --info` output while in the root of the git tree

# Pre-PR

`dotnet --info`:
```
global.json file:
  Invalid [/_opentabletdriver/opentabletdriver/global.json]
    Version '10.0.0' is not valid for the 'sdk/version' value. SDK feature bands start at 1 - for example, 10.0.100
```

# Post-PR

`dotnet --info`:
```
global.json file:
  /_opentabletdriver/opentabletdriver/global.json
```