### PR TITLE
Add additional CTH-460 endpoint

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-460.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/CTH-460.json
@@ -42,6 +42,15 @@
       "FeatureInitReport": [
         "AgI="
       ]
+    },
+    {
+      "VendorID": 1386,
+      "ProductID": 209,
+      "InputReportLength": 9,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.Intuos.IntuosReportParser",
+      "FeatureInitReport": [
+        "AgI="
+      ]
     }
   ],
   "AuxiliaryDeviceIdentifiers": [


### PR DESCRIPTION
This is one of the identifiers we consider as a the "flipped endpoint" variant of this tablet. Apparently it's possible for this to just work if the other endpoint is hidden. There's no downside to having it on the main config since the other identifiers will detect first if available.

User with only this endpoint visible on windows: [Diagnostics-067.json](https://github.com/user-attachments/files/29683926/Diagnostics-067.json)
Verification: https://discord.com/channels/615607687467761684/615611007951306863/1523498492671164497

The flipped endpoint config for reference: [CTH-460_flipped_endpoint.json](https://github.com/user-attachments/files/29683955/CTH-460_flipped_endpoint.json)
