### PR TITLE
Cleanup debugger recording and additional data accessibility/discoverability

### DIFF
--- a/OpenTabletDriver.Desktop/AppInfo.cs
+++ b/OpenTabletDriver.Desktop/AppInfo.cs
@@ -19,7 +19,8 @@ namespace OpenTabletDriver.Desktop
             temporaryDirectory,
             cacheDirectory,
             backupDirectory,
-            trashDirectory;
+            trashDirectory,
+            recordingDirectory;
 
         public AppInfo()
         {
@@ -129,6 +130,13 @@ namespace OpenTabletDriver.Desktop
             get => this.trashDirectory ?? GetDefaultTrashDirectory();
         }
 
+        [AllowNull]
+        public string RecordingDirectory
+        {
+            set => this.recordingDirectory = value;
+            get => this.recordingDirectory ?? GetDefaultRecordingDirectory();
+        }
+
         public static string ProgramDirectory => AppContext.BaseDirectory;
 
         private string GetDefaultConfigurationDirectory() => GetExistingPathOrLast(
@@ -145,6 +153,7 @@ namespace OpenTabletDriver.Desktop
         private string GetDefaultCacheDirectory() => Path.Join(AppDataDirectory, "Cache");
         private string GetDefaultBackupDirectory() => Path.Join(AppDataDirectory, "Backup");
         private string GetDefaultTrashDirectory() => Path.Join(AppDataDirectory, "Trash");
+        private string GetDefaultRecordingDirectory() => Path.Join(AppDataDirectory, "Recording");
 
         private static bool IsEnvVarUnset(string envVar) =>
             string.IsNullOrEmpty(Environment.GetEnvironmentVariable(envVar));

--- a/OpenTabletDriver.Desktop/ViewModels/TabletDebuggerViewModel.cs
+++ b/OpenTabletDriver.Desktop/ViewModels/TabletDebuggerViewModel.cs
@@ -266,7 +266,7 @@ public sealed class TabletDebuggerViewModel : ViewModel, IDisposable
         set => RaiseAndSetIfChanged(ref _isVisualizerEnabled, value);
     }
 
-    private bool _showAdditionalStatistics;
+    private bool _showAdditionalStatistics = true;
     public bool ShowAdditionalStatistics
     {
         get => _showAdditionalStatistics;

--- a/OpenTabletDriver.Desktop/ViewModels/TabletDebuggerViewModel.cs
+++ b/OpenTabletDriver.Desktop/ViewModels/TabletDebuggerViewModel.cs
@@ -251,7 +251,7 @@ public sealed class TabletDebuggerViewModel : ViewModel, IDisposable
                 ResetStatistics();
 
                 string fileName = "tablet-data_" + DateTimeOffset.UtcNow.ToUnixTimeSeconds() + ".txt";
-                _tabletRecordingFileStream = File.OpenWrite(Path.Join(AppInfo.Current.AppDataDirectory, fileName));
+                _tabletRecordingFileStream = File.OpenWrite(Path.Join(AppInfo.Current.RecordingDirectory, fileName));
                 _tabletRecordingStreamWriter = new StreamWriter(_tabletRecordingFileStream);
             }
             else

--- a/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
+++ b/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
@@ -327,8 +327,8 @@ namespace OpenTabletDriver.UX.Windows.Tablet
                 ApplicationItems =
                 {
                     visualizerEnabledMenuItem,
-                    decodingSwitchMenuItem,
                     additionalStatisticsMenuItem,
+                    decodingSwitchMenuItem,
                 },
                 QuitItem = new ButtonMenuItem((_, _) => Application.Instance.AsyncInvoke(Close))
                 {

--- a/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
+++ b/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
@@ -268,6 +268,21 @@ namespace OpenTabletDriver.UX.Windows.Tablet
 
             dataRecordingMenuItem.BindDataContext(x => x.Checked, (TDVM vm) => vm.DataRecordingEnabled);
 
+            var openDataRecordingDirectoryMenuItem = new Command
+            {
+                MenuText = "Open recordings directory...",
+            };
+            openDataRecordingDirectoryMenuItem.Executed += (sender, e) => DesktopInterop.OpenFolder(AppInfo.Current.RecordingDirectory);
+
+            ButtonMenuItem recordingTab = new()
+            {
+                Text = "Recording",
+                Visible = true,
+                Items = {
+                    dataRecordingMenuItem,
+                    openDataRecordingDirectoryMenuItem,
+                }
+            };
 
             var visualizerEnabledMenuItem = new CheckMenuItem
             {
@@ -310,7 +325,6 @@ namespace OpenTabletDriver.UX.Windows.Tablet
             {
                 ApplicationItems =
                 {
-                    dataRecordingMenuItem,
                     visualizerEnabledMenuItem,
                     decodingSwitchMenuItem,
                     additionalStatisticsMenuItem,
@@ -321,6 +335,7 @@ namespace OpenTabletDriver.UX.Windows.Tablet
                 },
                 Items =
                 {
+                    recordingTab,
                     _debuggedTablets,
                     _debuggedReports,
                 },

--- a/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
+++ b/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
@@ -90,7 +90,7 @@ namespace OpenTabletDriver.UX.Windows.Tablet
                 VerticalContentAlignment = VerticalAlignment.Stretch,
                 Spacing = 5,
                 Padding = 5,
-                MinimumSize = new Size(940, 560),
+                MinimumSize = new Size(1025, 560),
                 Items =
                 {
                     new StackLayoutItem

--- a/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
+++ b/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
@@ -222,7 +222,8 @@ namespace OpenTabletDriver.UX.Windows.Tablet
                 {
                     >= 1300 => 5,
                     > 1160 => 4,
-                    <= 1160 => 3,
+                    > 1000 => 3,
+                    <= 1000 => 2,
                 };
 
                 if (oldValue == newValue) return;

--- a/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
+++ b/OpenTabletDriver.UX/Windows/Tablet/TabletDebugger.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Numerics;
 using System.Text;
@@ -11,6 +12,7 @@ using System.Threading.Tasks;
 using Eto.Drawing;
 using Eto.Forms;
 using OpenTabletDriver.Desktop;
+using OpenTabletDriver.Desktop.Interop;
 using OpenTabletDriver.Desktop.RPC;
 using OpenTabletDriver.Desktop.ViewModels;
 using OpenTabletDriver.Desktop.ViewModels.Utility;
@@ -70,6 +72,14 @@ namespace OpenTabletDriver.UX.Windows.Tablet
         {
             if (App.Driver.IsConnected)
                 HandleTabletsChanged(null, App.Driver.Instance.GetTablets().Result);
+
+            var recordingDir = new DirectoryInfo(AppInfo.Current.RecordingDirectory);
+
+            if (!recordingDir.Exists)
+            {
+                recordingDir.Create();
+                Log.Write("TabletDebugger", $"The recording directory '{recordingDir.FullName}' has been created");
+            }
 
             var viewmodel = new TDVM();
             DataContext = viewmodel;


### PR DESCRIPTION
Users never know where the recordings are stored so having a button to open the directory is needed. Switching to a separate directory for the recordings so they dont clog up the appdata directory. The open recordings directory button is also shown to the user when they start the recording so there shouldnt be any issue with them finding it.

Having a separate tab for recording to have that label there also helps with discoverability. And I think it's a bit cleaner to not put that in the file tab.

Also enabling the additional statistics by default should help for making configs since users will be able to more easily find the listing of maxes. This is probably more useful for most users and if a user does need to closely inspect the visualizer, they can still turn off the additional statistics.

Linux:

<img width="1030" height="615" alt="image" src="https://github.com/user-attachments/assets/58a4fdb0-3f6b-427c-a35c-8e13054fc1c4" />
<img width="332" height="130" alt="image" src="https://github.com/user-attachments/assets/314d42ad-b0fe-4414-b25a-b9b7d0d53e3a" />

Windows:
<img width="1021" height="599" alt="image" src="https://github.com/user-attachments/assets/c84b265f-7e4a-450d-adf4-489b96760ef4" />

The spacing and width of additional statistics is kinda goofy on windows here but... eto. It works at least.