### PR TITLE
Fix double-applied virtual-screen offset in "Set to display"

### DIFF
--- a/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
@@ -295,17 +295,10 @@ namespace OpenTabletDriver.UX.Controls.Output
 
                 var subMenu = base.ContextMenu.Items.GetSubmenu("Set to display");
 
-                var displays = DesktopInterop.VirtualScreen?.Displays.ToArray()
+                var virtualScreen = DesktopInterop.VirtualScreen
                     ?? throw new InvalidOperationException("Could not get VirtualScreen");
 
-                // account for monitor layouts with negative offsets (e.g. Wayland supports this)
-                // skip IVirtualScreen's as these tend to be normalized to 0,0, which may confuse these methods
-                float xOffset = displays.Where(d => d is not IVirtualScreen).MinBy(d => d.Position.X)?.Position.X
-                    ?? throw new InvalidOperationException("Unable to look up X offset");
-                float yOffset = displays.Where(d => d is not IVirtualScreen).MinBy(d => d.Position.Y)?.Position.Y
-                    ?? throw new InvalidOperationException("Unable to look up Y offset");
-
-                foreach (var display in displays)
+                foreach (var display in virtualScreen.Displays)
                 {
                     subMenu.Items.Add(
                         new ActionCommand
@@ -316,23 +309,40 @@ namespace OpenTabletDriver.UX.Controls.Output
                                 if (this.Area == null)
                                     throw new InvalidOperationException("Area null, somehow?");
 
+                                var center = GetDisplayAreaCenter(display, virtualScreen);
+
                                 this.Area.Width = display.Width;
                                 this.Area.Height = display.Height;
-                                if (display is IVirtualScreen virtualScreen)
-                                {
-                                    this.Area.X = virtualScreen.Width / 2;
-                                    this.Area.Y = virtualScreen.Height / 2;
-                                }
-                                else
-                                {
-                                    virtualScreen = DesktopInterop.VirtualScreen;
-                                    this.Area.X = display.Position.X - xOffset + virtualScreen.Position.X + (display.Width / 2);
-                                    this.Area.Y = display.Position.Y - yOffset + virtualScreen.Position.Y + (display.Height / 2);
-                                }
+
+                                this.Area.X = center.X;
+                                this.Area.Y = center.Y;
                             }
                         }
                     );
                 }
+            }
+
+            internal static Vector2 GetDisplayAreaCenter(IDisplay display, IVirtualScreen virtualScreen)
+            {
+                if (display is IVirtualScreen)
+                    return new Vector2(virtualScreen.Width / 2, virtualScreen.Height / 2);
+
+                // area coordinates are relative to the virtual screen's top left corner, so
+                // normalize by the minimum display position. This handles platform differences
+                // in one step: Windows/X11 report positions relative to the primary display
+                // (negative for displays left of/above it), Wayland may report negative logical
+                // coordinates, and MacOS reports already-normalized positions.
+                // Skip IVirtualScreen's as these tend to be normalized to 0,0, which may confuse these methods
+                var displays = virtualScreen.Displays.Where(d => d is not IVirtualScreen).ToArray();
+
+                float xOffset = displays.MinBy(d => d.Position.X)?.Position.X
+                    ?? throw new InvalidOperationException("Unable to look up X offset");
+                float yOffset = displays.MinBy(d => d.Position.Y)?.Position.Y
+                    ?? throw new InvalidOperationException("Unable to look up Y offset");
+
+                return new Vector2(
+                    display.Position.X - xOffset + (display.Width / 2),
+                    display.Position.Y - yOffset + (display.Height / 2));
             }
         }
 


### PR DESCRIPTION
Hello, this has bugged me for a little while, so:

"Set to display" could target the wrong monitor when displays were left of or above the primary. 
This was due to a regression in [ff0c1e31](https://github.com/OpenTabletDriver/OpenTabletDriver/commit/ff0c1e31) where virtual-screen offset normalization was applied twice on Windows/X11.

I have removed the redundant offset.

Also, alignment menu actions may have a related negative-origin issue and are left for follow-up.

Closes #4832.