### PR TITLE
Add warning to device string reader window about arbitrary use

### DIFF
--- a/OpenTabletDriver.UX/Windows/DeviceStringReader.cs
+++ b/OpenTabletDriver.UX/Windows/DeviceStringReader.cs
@@ -19,7 +19,7 @@ namespace OpenTabletDriver.UX.Windows
         {
             this.Title = "Device String Reader";
             this.Icon = App.Logo.WithSize(App.Logo.Size);
-            this.ClientSize = new Size(-1, 345);
+            this.ClientSize = new Size(400, 410);
 
             var sendRequestButton = new Button
             {
@@ -50,6 +50,13 @@ namespace OpenTabletDriver.UX.Windows
                 HorizontalContentAlignment = HorizontalAlignment.Stretch,
                 Items =
                 {
+                    new Label
+                    {
+                        Text = "WARNING\nArbitrary use of this tool may cause damage or disrupt usage of your tablet",
+                        Font = SystemFonts.Bold(),
+                        TextAlignment = TextAlignment.Center,
+                        Wrap = WrapMode.Word,
+                    },
                     new Group("Connected HIDs", deviceDropDown, Orientation.Horizontal, false),
                     vendorIdCtrl,
                     productIdCtrl,


### PR DESCRIPTION
Locking debugger size for width to make the text wrap.

<img width="407" height="439" alt="image" src="https://github.com/user-attachments/assets/25d80323-0346-4358-bda4-2066743bd759" />

Open to suggestions if this text seems too scary. Just throwing in a label like this seems to be the most sane way to handle this in eto. I'd like something fancy like a bar maybe and a different text color but I don't want to define a custom color and then someone with a ridiculous theme cant see the text.