### PR TITLE
Cache device strings during detect

### DIFF
--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -211,7 +211,7 @@ namespace OpenTabletDriver
 
                     deviceString ??= device.GetDeviceString(matchQuery.Key);
 
-                    if (!stringCache.TryAdd(device, new Dictionary<byte, string?>{{matchQuery.Key, deviceString}}))
+                    if (!stringCache.TryAdd(device, new Dictionary<byte, string?> { { matchQuery.Key, deviceString } }))
                         stringCache[device].TryAdd(matchQuery.Key, deviceString);
 
                     // nullcheck after cache update to ensure nulls are cached

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -171,9 +171,9 @@ namespace OpenTabletDriver
             return null;
         }
 
-        private IEnumerable<IDeviceEndpoint> GetMatchingDevices(TabletConfiguration configuration, DeviceIdentifier identifier)
+        private IDeviceEndpoint[] GetMatchingDevices(TabletConfiguration configuration, DeviceIdentifier identifier)
         {
-            return from device in CompositeDeviceHub.GetDevices()
+            return [.. from device in CompositeDeviceHub.GetDevices()
                    where identifier.VendorID == device.VendorID
                    where identifier.ProductID == device.ProductID
                    where device.CanOpen
@@ -182,7 +182,7 @@ namespace OpenTabletDriver
                    where identifier.FeatureReportLength == null || identifier.FeatureReportLength == device.FeatureReportLength
                    where DeviceMatchesStrings(device, identifier.DeviceStrings, DeviceStringCache)
                    where DeviceMatchesAttribute(device, identifier.Attributes, configuration.Attributes)
-                   select device;
+                   select device];
         }
 
         private static bool DeviceMatchesStrings(IDeviceEndpoint device, Dictionary<byte, string>? deviceStrings, Dictionary<IDeviceEndpoint, Dictionary<byte, string?>> stringCache)

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -196,17 +196,14 @@ namespace OpenTabletDriver
                 try
                 {
                     string? deviceString = null;
-                    if (stringCache.TryGetValue(device, out var deviceCachedStrings))
+                    if (stringCache.TryGetValue(device, out var deviceCachedStrings) && deviceCachedStrings.TryGetValue(matchQuery.Key, out var cacheDeviceString))
                     {
-                        if (deviceCachedStrings.TryGetValue(matchQuery.Key, out var cacheDeviceString))
+                        if (cacheDeviceString == null)
                         {
-                            if (cacheDeviceString == null)
-                            {
-                                Log.Write("Detect", $"Cached null string for index {matchQuery.Key}, skipping", LogLevel.Debug);
-                                return false;
-                            }
-                            deviceString = cacheDeviceString;
+                            Log.Write("Detect", $"Cached null for index {matchQuery.Key}, skipping", LogLevel.Debug);
+                            return false;
                         }
+                        deviceString = cacheDeviceString;
                     }
 
                     deviceString ??= device.GetDeviceString(matchQuery.Key);

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -34,7 +34,7 @@ namespace OpenTabletDriver
         public ImmutableArray<InputDeviceTree> InputDevices => _inputDeviceTrees;
         public IEnumerable<TabletReference> Tablets => InputDevices.Select(c => c.CreateReference());
 
-        private Dictionary<IDeviceEndpoint, Dictionary<byte, string>> DeviceStringCache = [];
+        private Dictionary<IDeviceEndpoint, Dictionary<byte, string?>> DeviceStringCache = [];
 
         public IReportParser<IDeviceReport> GetReportParser(DeviceIdentifier identifier)
         {
@@ -185,7 +185,7 @@ namespace OpenTabletDriver
                    select device;
         }
 
-        private static bool DeviceMatchesStrings(IDeviceEndpoint device, Dictionary<byte, string>? deviceStrings, Dictionary<IDeviceEndpoint, Dictionary<byte, string>> stringCache)
+        private static bool DeviceMatchesStrings(IDeviceEndpoint device, Dictionary<byte, string>? deviceStrings, Dictionary<IDeviceEndpoint, Dictionary<byte, string?>> stringCache)
         {
             if (deviceStrings == null || deviceStrings.Count == 0)
                 return true;
@@ -196,13 +196,27 @@ namespace OpenTabletDriver
                 try
                 {
                     string? deviceString = null;
-                    if (stringCache.TryGetValue(device, out var deviceCachedStrings) && deviceCachedStrings.TryGetValue(matchQuery.Key, out var cacheDeviceString))
-                        deviceString = cacheDeviceString;
+                    if (stringCache.TryGetValue(device, out var deviceCachedStrings))
+                    {
+                        if (deviceCachedStrings.TryGetValue(matchQuery.Key, out var cacheDeviceString))
+                        {
+                            if (cacheDeviceString == null)
+                            {
+                                Log.Write("Detect", $"Cached null string for index {matchQuery.Key}, skipping", LogLevel.Debug);
+                                return false;
+                            }
+                            deviceString = cacheDeviceString;
+                        }
+                    }
 
-                    deviceString ??= device.GetDeviceString(matchQuery.Key) ?? throw new IOException($"Unable to look up string index {matchQuery.Key}");
+                    deviceString ??= device.GetDeviceString(matchQuery.Key);
 
-                    if (!stringCache.TryAdd(device, new Dictionary<byte, string>{{matchQuery.Key, deviceString}}))
+                    if (!stringCache.TryAdd(device, new Dictionary<byte, string?>{{matchQuery.Key, deviceString}}))
                         stringCache[device].TryAdd(matchQuery.Key, deviceString);
+
+                    // nullcheck after cache update to ensure nulls are cached
+                    if (deviceString == null)
+                        throw new IOException($"Unable to look up string index {matchQuery.Key}");
 
                     var pattern = matchQuery.Value;
                     if (!Regex.IsMatch(deviceString, pattern))

--- a/OpenTabletDriver/Driver.cs
+++ b/OpenTabletDriver/Driver.cs
@@ -34,6 +34,8 @@ namespace OpenTabletDriver
         public ImmutableArray<InputDeviceTree> InputDevices => _inputDeviceTrees;
         public IEnumerable<TabletReference> Tablets => InputDevices.Select(c => c.CreateReference());
 
+        private Dictionary<IDeviceEndpoint, Dictionary<byte, string>> DeviceStringCache = [];
+
         public IReportParser<IDeviceReport> GetReportParser(DeviceIdentifier identifier)
         {
             return _reportParserProvider.GetReportParser(identifier.ReportParser);
@@ -49,6 +51,8 @@ namespace OpenTabletDriver
         {
             lock (_detectSync)
             {
+                DeviceStringCache = []; // reset cache on redetect
+
                 bool success = false;
 
                 Log.Write("Detect", "Searching for tablets...");
@@ -176,24 +180,32 @@ namespace OpenTabletDriver
                    where identifier.InputReportLength == null || identifier.InputReportLength == device.InputReportLength
                    where identifier.OutputReportLength == null || identifier.OutputReportLength == device.OutputReportLength
                    where identifier.FeatureReportLength == null || identifier.FeatureReportLength == device.FeatureReportLength
-                   where DeviceMatchesStrings(device, identifier.DeviceStrings)
+                   where DeviceMatchesStrings(device, identifier.DeviceStrings, DeviceStringCache)
                    where DeviceMatchesAttribute(device, identifier.Attributes, configuration.Attributes)
                    select device;
         }
 
-        private static bool DeviceMatchesStrings(IDeviceEndpoint device, Dictionary<byte, string>? deviceStrings)
+        private static bool DeviceMatchesStrings(IDeviceEndpoint device, Dictionary<byte, string>? deviceStrings, Dictionary<IDeviceEndpoint, Dictionary<byte, string>> stringCache)
         {
             if (deviceStrings == null || deviceStrings.Count == 0)
                 return true;
 
+            // Iterate through each device string, if one doesn't match then its the wrong configuration.
             foreach (var matchQuery in deviceStrings)
             {
                 try
                 {
-                    // Iterate through each device string, if one doesn't match then its the wrong configuration.
-                    var input = device.GetDeviceString(matchQuery.Key) ?? throw new IOException($"Unable to look up string index {matchQuery.Key}");
+                    string? deviceString = null;
+                    if (stringCache.TryGetValue(device, out var deviceCachedStrings) && deviceCachedStrings.TryGetValue(matchQuery.Key, out var cacheDeviceString))
+                        deviceString = cacheDeviceString;
+
+                    deviceString ??= device.GetDeviceString(matchQuery.Key) ?? throw new IOException($"Unable to look up string index {matchQuery.Key}");
+
+                    if (!stringCache.TryAdd(device, new Dictionary<byte, string>{{matchQuery.Key, deviceString}}))
+                        stringCache[device].TryAdd(matchQuery.Key, deviceString);
+
                     var pattern = matchQuery.Value;
-                    if (!Regex.IsMatch(input, pattern))
+                    if (!Regex.IsMatch(deviceString, pattern))
                         return false;
                 }
                 catch (Exception ex)


### PR DESCRIPTION
We probably shouldn't be blasting devices with hundreds of string requests.

Importantly caching the value here even if it fails to fetch so we don't end up requesting an inaccessible index over and over which can really slow down detection since it may have to wait for the timeout every single time.