### PR TITLE
Add linux support for Bosto BT-12HD

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Bosto/BT-12HD.json
+++ b/OpenTabletDriver.Configurations/Configurations/Bosto/BT-12HD.json
@@ -22,6 +22,12 @@
         100,
         123
       ]
+    },
+    {
+      "VendorID": 3793,
+      "ProductID": 30753,
+      "InputReportLength": 10,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Bosto.BostoReportParser"
     }
   ],
   "Attributes": {


### PR DESCRIPTION
Diag: [2Diagnostics-067.json](https://github.com/user-attachments/files/29869854/2Diagnostics-067.json)

Diag shows it failing to detect from the tablet refusing a string init but once removed it did detect fine. It's possible the windows config doesnt need those init but windows may not care if the tablet refuses the string requests, unsure.

Verification: https://discord.com/channels/615607687467761684/723399565780189234/1524918004192645231