### PR TITLE
Add menu item for opening presets directory

### DIFF
--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -317,8 +317,8 @@ namespace OpenTabletDriver.UX
                             resetSettings,
                             applySettings,
                             new SeparatorMenuItem(),
-                            refreshPresets,
                             savePreset,
+                            refreshPresets,
                             openPresetsDirectory,
                             new ButtonMenuItem
                             {

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -271,6 +271,9 @@ namespace OpenTabletDriver.UX
             var savePreset = new Command { MenuText = "Save as preset..." };
             savePreset.Executed += async (sender, e) => await SavePresetDialog();
 
+            var openPresetsDirectory = new Command { MenuText = "Open presets directory..." };
+            openPresetsDirectory.Executed += async (sender, e) => DesktopInterop.OpenFolder(AppInfo.Current.PresetDirectory);
+
             var detectTablet = new Command { MenuText = "Detect tablet", Shortcut = Application.Instance.CommonModifier | Keys.D };
             detectTablet.Executed += async (sender, e) => await DetectTablet();
 
@@ -316,6 +319,7 @@ namespace OpenTabletDriver.UX
                             new SeparatorMenuItem(),
                             refreshPresets,
                             savePreset,
+                            openPresetsDirectory,
                             new ButtonMenuItem
                             {
                                 Text = "Presets",


### PR DESCRIPTION
If a user wants to delete a preset or rename a preset theyre kinda just on their own to figure it out which is not great. We should at least have a way to easily open the directory to help out there.

Also small change to the order of menu items here:
<img width="247" height="392" alt="image" src="https://github.com/user-attachments/assets/a63802a3-ee7b-41c6-8c25-6952b2c97966" />

Save, Refresh, Open > Refresh, Save, Open. A bit nicer imo and also roughly matches what we do in plugin manager (Install, Refresh, Alt source, Open). The first thing a user will need to do is save the preset, not refresh their presets.