### PR TITLE
Add support for Wacom Cintiq 27QHD (DTH-2700)

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTH-2700.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTH-2700.json
@@ -1,0 +1,26 @@
+{
+  "Name": "Wacom Cintiq 27QHD (DTH-2700)",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 600.7,
+      "Height": 339,
+      "MaxX": 120140,
+      "MaxY": 67800
+    },
+    "Pen": {
+      "MaxPressure": 2047,
+      "ButtonCount": 2
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 1386,
+      "ProductID": 811,
+      "InputReportLength": 192,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.CintiqV1.CintiqV1ReportParser",
+      "FeatureInitReport": [
+        "AgI="
+      ]
+    }
+  ]
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -321,6 +321,7 @@
 | Wacom Movink 13 (DTH-135)          |  Missing Features | Touch is not yet supported.
 | Wacom Cintiq 22HD Touch (DTH-2200) |  Missing Features | Touch is not yet supported.
 | Wacom Cintiq Pro 22 (DTH-227)      |  Missing Features | Touch is not yet supported.
+| Wacom Cintiq 27QHD (DTH-2700)      |  Missing Features | Touch is not yet supported.
 | Wacom Cintiq Pro 27 (DTH-271)      |  Missing Features | Aux buttons are not yet supported.
 | Wacom Cintiq 13HD Touch (DTH-1300) |  Missing Features | Center button is not yet supported.
 | Wacom Cintiq 13HD (DTK-1300)       |  Missing Features | Center button is not yet supported.


### PR DESCRIPTION
Verification: https://discord.com/channels/615607687467761684/1334474452276084736/1524857157093425262
Diag (detected): [Diagnostics-067 Wacom Cintiq 27QHD Tablet.json](https://github.com/user-attachments/files/29930478/Diagnostics-067.Wacom.Cintiq.27QHD.Tablet.json)

User mentioned the physical touch toggle is stuck at "off" on their tablet. It's possible touch could work but unknown so I've put it as missing features since that's most likely (I don't think `CintiqV1ReportParser` even supports touch currently).