### PR TITLE
Fix display offsets causing incorrect positioning when using `Set to display`

### DIFF
--- a/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
@@ -298,6 +298,13 @@ namespace OpenTabletDriver.UX.Controls.Output
                 var displays = DesktopInterop.VirtualScreen?.Displays.ToArray()
                     ?? throw new InvalidOperationException("Could not get VirtualScreen");
 
+                // account for monitor layouts with negative offsets (e.g. Wayland supports this)
+                // skip IVirtualScreen's as these tend to be normalized to 0,0, which may confuse these methods
+                float xOffset = displays.Where(d => d is not IVirtualScreen).MinBy(d => d.Position.X)?.Position.X
+                    ?? throw new InvalidOperationException("Unable to look up X offset");
+                float yOffset = displays.Where(d => d is not IVirtualScreen).MinBy(d => d.Position.Y)?.Position.Y
+                    ?? throw new InvalidOperationException("Unable to look up Y offset");
+
                 foreach (var display in displays)
                 {
                     subMenu.Items.Add(
@@ -319,8 +326,8 @@ namespace OpenTabletDriver.UX.Controls.Output
                                 else
                                 {
                                     virtualScreen = DesktopInterop.VirtualScreen;
-                                    this.Area.X = display.Position.X + virtualScreen.Position.X + (display.Width / 2);
-                                    this.Area.Y = display.Position.Y + virtualScreen.Position.Y + (display.Height / 2);
+                                    this.Area.X = display.Position.X - xOffset + (display.Width / 2);
+                                    this.Area.Y = display.Position.Y - yOffset + (display.Height / 2);
                                 }
                             }
                         }

--- a/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Output/AbsoluteModeEditor.cs
@@ -298,13 +298,6 @@ namespace OpenTabletDriver.UX.Controls.Output
                 var displays = DesktopInterop.VirtualScreen?.Displays.ToArray()
                     ?? throw new InvalidOperationException("Could not get VirtualScreen");
 
-                // account for monitor layouts with negative offsets (e.g. Wayland supports this)
-                // skip IVirtualScreen's as these tend to be normalized to 0,0, which may confuse these methods
-                float xOffset = displays.Where(d => d is not IVirtualScreen).MinBy(d => d.Position.X)?.Position.X
-                    ?? throw new InvalidOperationException("Unable to look up X offset");
-                float yOffset = displays.Where(d => d is not IVirtualScreen).MinBy(d => d.Position.Y)?.Position.Y
-                    ?? throw new InvalidOperationException("Unable to look up Y offset");
-
                 foreach (var display in displays)
                 {
                     subMenu.Items.Add(
@@ -326,8 +319,8 @@ namespace OpenTabletDriver.UX.Controls.Output
                                 else
                                 {
                                     virtualScreen = DesktopInterop.VirtualScreen;
-                                    this.Area.X = display.Position.X - xOffset + virtualScreen.Position.X + (display.Width / 2);
-                                    this.Area.Y = display.Position.Y - yOffset + virtualScreen.Position.Y + (display.Height / 2);
+                                    this.Area.X = display.Position.X + virtualScreen.Position.X + (display.Width / 2);
+                                    this.Area.Y = display.Position.Y + virtualScreen.Position.Y + (display.Height / 2);
                                 }
                             }
                         }


### PR DESCRIPTION
Fixes https://github.com/OpenTabletDriver/OpenTabletDriver/issues/4832

Contrary to the intended and listed effect, this appears to actually break negative monitor offsets on everything except Sway.

Tested on Debian 13 with Gnome 48 Wayland, Arch with KDE Plasma 6.7.2 Wayland, Arch with Xfce 4.20 (X11), and Windows 10. Notably, with or without this change it works on X11. (See: https://github.com/OpenTabletDriver/OpenTabletDriver/pull/4940#issuecomment-4960640398)

Havent tested on macos but I don't recall there being any reports of issues prior to this change on either platform and as the comment mentions it seems to be just for wayland.