### PR TITLE
Add baseline macos arm64 building

### DIFF
--- a/OpenTabletDriver.UX.MacOS/OpenTabletDriver.UX.MacOS.csproj
+++ b/OpenTabletDriver.UX.MacOS/OpenTabletDriver.UX.MacOS.csproj
@@ -3,16 +3,21 @@
   <PropertyGroup Label="Project Properties">
     <OutputType>Exe</OutputType>
     <TargetFramework>$(FrameworkBase)</TargetFramework>
-    <RuntimeIdentifiers>osx-x64</RuntimeIdentifiers>
     <AutoreleasePoolSupport>true</AutoreleasePoolSupport>
+    <UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup Label="NuGet Packages">
-    <PackageReference Include="Eto.Platform.Mac64" Version="2.5.10" />
+    <PackageReference Include="Eto.Platform.Mac64" Version="2.11.0" />
   </ItemGroup>
   
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\OpenTabletDriver.UX\OpenTabletDriver.UX.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Label="Project Resources">
+    <Content Include="../eng/bash/macos/Icon.icns" />
+    <None Include="../eng/bash/macos/Info.plist" />
   </ItemGroup>
   
 </Project>

--- a/README.md
+++ b/README.md
@@ -82,10 +82,13 @@ Run `PATH="$(brew --prefix coreutils)/libexec/gnubin:$PATH" $(brew --prefix)/bin
 
 | Package Format | Command |
 | --- | --- |
-| Unsigned Package | `./eng/bash/package.sh --runtime osx-x64 --package macos` |
-| Signed Package | `./eng/bash/package.sh --signed true --runtime osx-x64 --package macos` |
+| Unsigned x64 Package | `./eng/bash/package.sh --runtime osx-x64 --package macos` |
+| Signed x64 Package | `./eng/bash/package.sh --signed true --runtime osx-x64 --package macos` |
+| Signed arm64 Package | `./eng/bash/package.sh --signed true --runtime osx-arm64 --package macos` |
 
 Packaging signed MacOS builds on Linux or Windows requires `rcodesign`.
+
+As of [MacOS 11](https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11_0_1-universal-apps-release-notes/#Code-Signing), you **must** sign arm64 packages.
 
 # Features
 


### PR DESCRIPTION
Pulling in the csproj change from Aki (#4075) that allows the gui to work on macos arm64. And some simple packaging docs.

Verification: https://discord.com/channels/615607687467761684/723399607522033664/1527082880960823509

Excluding CI changes at the moment.