### PR TITLE
Move pressure rewriting to early filter

### DIFF
--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -417,13 +417,20 @@ namespace OpenTabletDriver.Daemon
         {
             string group = dev.Properties.Name;
 
+            var pressureRewriteFilter = new PressureRewriteFilter
+            {
+                TipPressureThreshold = profile.BindingSettings.TipActivationThreshold,
+                EraserPressureThreshold = profile.BindingSettings.EraserActivationThreshold,
+                MaxPenPressure = dev.Properties.Specifications.Pen.MaxPressure,
+            };
+
             var elements = (from store in profile.Filters
                             where store is { Enable: true }
                             let filter = store!.Construct<IPositionedPipelineElement<IDeviceReport>>(outputMode.Tablet)
                             where filter != null
                             select filter!).ToArray();
 
-            outputMode.Elements = elements.Append(bindingHandler).ToList();
+            outputMode.Elements = elements.Prepend(pressureRewriteFilter).Append(bindingHandler).ToList();
 
             foreach (var filter in elements)
             {
@@ -510,24 +517,21 @@ namespace OpenTabletDriver.Daemon
             var tip = bindingHandler.Tip = new ThresholdBindingState
             {
                 Binding = settings.TipButton?.Construct<IBinding>(bindingServiceProvider, tabletReference),
-
-                ActivationThreshold = settings.TipActivationThreshold
             };
 
             if (tip.Binding != null)
             {
-                Log.Write(group, $"Tip Binding: [{tip.Binding}]@{tip.ActivationThreshold}%");
+                Log.Write(group, $"Tip Binding: [{tip.Binding}]@{settings.TipActivationThreshold}%");
             }
 
             var eraser = bindingHandler.Eraser = new ThresholdBindingState
             {
                 Binding = settings.EraserButton?.Construct<IBinding>(bindingServiceProvider, tabletReference),
-                ActivationThreshold = settings.EraserActivationThreshold
             };
 
             if (eraser.Binding != null)
             {
-                Log.Write(group, $"Eraser Binding: [{eraser.Binding}]@{eraser.ActivationThreshold}%");
+                Log.Write(group, $"Eraser Binding: [{eraser.Binding}]@{settings.EraserActivationThreshold}%");
             }
 
             if (settings.PenButtons.Any(b => b?.Path != null))

--- a/OpenTabletDriver.Desktop/Binding/PressureRewriteFilter.cs
+++ b/OpenTabletDriver.Desktop/Binding/PressureRewriteFilter.cs
@@ -1,0 +1,48 @@
+using System;
+using OpenTabletDriver.Plugin.Attributes;
+using OpenTabletDriver.Plugin.Output;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Desktop.Binding
+{
+    [PluginIgnore]
+    public class PressureRewriteFilter : IPositionedPipelineElement<IDeviceReport>
+    {
+        public required float TipPressureThreshold
+        {
+            get;
+            init => field = value / 100;
+        }
+
+        public required float EraserPressureThreshold
+        {
+            get;
+            init => field = value / 100;
+        }
+
+        public required uint MaxPenPressure { get; init; }
+
+        public void Consume(IDeviceReport? report)
+        {
+            if (report is ITabletReport tabletReport && tabletReport.Pressure != MaxPenPressure)
+            {
+                float activationThreshold = report is IEraserReport ? EraserPressureThreshold : TipPressureThreshold;
+
+                float pressurePercent = tabletReport.Pressure / (float)MaxPenPressure;
+
+                if (pressurePercent > activationThreshold)
+                {
+                    tabletReport.Pressure =
+                        (uint)(MaxPenPressure * ((pressurePercent - activationThreshold) / (1f - activationThreshold)));
+                }
+                else
+                    tabletReport.Pressure = 0;
+            }
+
+            Emit?.Invoke(report);
+        }
+
+        public event Action<IDeviceReport?>? Emit;
+        public PipelinePosition Position => PipelinePosition.PreTransform;
+    }
+}

--- a/OpenTabletDriver.Desktop/Binding/ThresholdBindingState.cs
+++ b/OpenTabletDriver.Desktop/Binding/ThresholdBindingState.cs
@@ -1,43 +1,18 @@
+using System;
 using OpenTabletDriver.Plugin.Tablet;
 
 namespace OpenTabletDriver.Desktop.Binding
 {
     public class ThresholdBindingState : BindingState
     {
+        [Obsolete("Activation threshold responsibility has been moved to PressureRewriteFilter")]
         public float ActivationThreshold { set; get; }
-
-        // TODO: Maximum is magic number 100f because this type of binding is currently only exposed as a FloatSlider
-        //    Ideally this is fixed by telling the client the maximum value allowed for fields, somehow
-        private const float MaximumThreshold = 100f;
 
         public void Invoke(TabletReference tablet, IDeviceReport report, float value)
         {
-            bool newState = value > ActivationThreshold;
+            bool newState = value > 0;
 
-            // account for special case where threshold == max value
-            // ReSharper disable CompareOfFloatsByEqualityOperator
-            bool valueMaxed = ActivationThreshold == MaximumThreshold && value == MaximumThreshold;
-            // ReSharper restore CompareOfFloatsByEqualityOperator
-
-            bool meetsThreshold = newState || valueMaxed;
-
-            if (report is ITabletReport tabletReport)
-            {
-                if (meetsThreshold)
-                {
-                    uint maxPressure = tablet.Properties.Specifications.Pen.MaxPressure;
-
-                    if (valueMaxed)
-                        tabletReport.Pressure = maxPressure;
-                    else // remap pressure based on the amount we went above the activation threshold
-                        tabletReport.Pressure =
-                            (uint)(maxPressure * ((value - ActivationThreshold) / (MaximumThreshold - ActivationThreshold)));
-                }
-                else
-                    tabletReport.Pressure = 0;
-            }
-
-            base.Invoke(tablet, report, meetsThreshold);
+            base.Invoke(tablet, report, newState);
         }
     }
 }


### PR DESCRIPTION
The previous behavior seems to have been written in a way that expected the function parameters being passed around to behave like by-value, given that the tablet reports are structs, but as we're accessing the struct through interface types, we're actually getting a reference instead, so report clones don't exactly behave as it seems was intended.

This can be seen in OpenTabletDriver/OpenTabletDriver#4921 - basically, any async plugin that wasn't setting the reports `Pressure` on `Update()` _and_ threshold bindings were in use, especially on higher thresholds, users would experience the very annoying behavior of having their bindings repeatedly toggle, as the report to be `Consume()`d by the async filters would correctly be cloned, but the pressure value would be continuously be affected by the pressure rewrite as the report passed through the binding handler multiple times, leading to pressure values above the threshold (but not maxed) eventually having their pressure values rewritten to 0 as the now-incorrect pressure value was being compared with, leading to bindings being released even when they shouldn't have.

This commit then replaces this entire logic and moves it as early in the filter chain as possible, so that instead of the pressure being rewritten _after_ any plugins might have saved the reference to the report, the pressure is instead rewritten long before any plugins have a chance of seeing the report.

Fixes #4921