### PR TITLE
Add support for Parblo Ninos N10B

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N10B.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Ninos N10B.json
@@ -1,0 +1,33 @@
+{
+  "Name": "Parblo Ninos N10B",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 252,
+      "Height": 157.5,
+      "MaxX": 25200,
+      "MaxY": 15750
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 6
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 1155,
+      "ProductID": 41499,
+      "InputReportLength": 10,
+      "OutputReportLength": 8,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
+      "OutputInitReport": [
+        "ArAE"
+      ]
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -71,6 +71,7 @@
 | Parblo A609                        |     Supported     |
 | Parblo A610 Pro (Variant 2)        |     Supported     |
 | Parblo A640 V2                     |     Supported     |
+| Parblo Ninos N10B                  |     Supported     |
 | Parblo Ninos N4                    |     Supported     |
 | Parblo Ninos N7                    |     Supported     |
 | RobotPen T9A                       |     Supported     |


### PR DESCRIPTION
Verification: https://discord.com/channels/615607687467761684/1522948194009350326/1527451723877187635
Diag (undetected): [Diagnostics-067-48.json](https://github.com/user-attachments/files/30134694/Diagnostics-067-48.json)
Data (maxes): [tablet-data_1784242925.txt](https://github.com/user-attachments/files/30134670/tablet-data_1784242925.txt)
Data (aux): [tablet-data_1784287514.txt](https://github.com/user-attachments/files/30134672/tablet-data_1784287514.txt)
