### PR TITLE
Recheck configuration directory on detect button press

### DIFF
--- a/OpenTabletDriver.Daemon/Program.cs
+++ b/OpenTabletDriver.Daemon/Program.cs
@@ -33,9 +33,9 @@ namespace OpenTabletDriver.Daemon
             var cmdLineOptions = ParseCmdLineOptions(args);
 
             if (!string.IsNullOrWhiteSpace(cmdLineOptions.AppDataDirectory?.FullName))
-                AppInfo.Current.AppDataDirectory = cmdLineOptions.AppDataDirectory.FullName;
+                AppInfo.Current.CommandLineAppDataDirectory = cmdLineOptions.AppDataDirectory.FullName;
             if (!string.IsNullOrWhiteSpace(cmdLineOptions.ConfigurationDirectory?.FullName))
-                AppInfo.Current.ConfigurationDirectory = cmdLineOptions.ConfigurationDirectory.FullName;
+                AppInfo.Current.CommandLineConfigurationDirectory = cmdLineOptions.ConfigurationDirectory.FullName;
 
             await StartDaemon();
         }

--- a/OpenTabletDriver.Desktop/AppInfo.cs
+++ b/OpenTabletDriver.Desktop/AppInfo.cs
@@ -65,6 +65,23 @@ namespace OpenTabletDriver.Desktop
 
         public static PresetManager PresetManager { set; get; } = new PresetManager();
 
+        public string? CommandLineAppDataDirectory {
+            set {
+                field = value;
+                if (value != null)
+                    this.AppDataDirectory = value;
+            }
+            get;
+        }
+        public string? CommandLineConfigurationDirectory {
+            set {
+                field = value;
+                if (value != null)
+                    this.ConfigurationDirectory = value;
+            }
+            get;
+        }
+
         public required string AppDataDirectory { set; get; }
 
         [AllowNull]

--- a/OpenTabletDriver.Desktop/AppInfo.cs
+++ b/OpenTabletDriver.Desktop/AppInfo.cs
@@ -65,16 +65,20 @@ namespace OpenTabletDriver.Desktop
 
         public static PresetManager PresetManager { set; get; } = new PresetManager();
 
-        public string? CommandLineAppDataDirectory {
-            set {
+        public string? CommandLineAppDataDirectory
+        {
+            set
+            {
                 field = value;
                 if (value != null)
                     this.AppDataDirectory = value;
             }
             get;
         }
-        public string? CommandLineConfigurationDirectory {
-            set {
+        public string? CommandLineConfigurationDirectory
+        {
+            set
+            {
                 field = value;
                 if (value != null)
                     this.ConfigurationDirectory = value;

--- a/OpenTabletDriver.Desktop/AppInfo.cs
+++ b/OpenTabletDriver.Desktop/AppInfo.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using OpenTabletDriver.Desktop.Reflection;
@@ -46,7 +47,6 @@ namespace OpenTabletDriver.Desktop
                 },
                 PluginPlatform.Linux => new AppInfo
                 {
-                    ConfigurationDirectory = GetExistingPath(Path.Join(UnixXdgPath.DataHome, "OpenTabletDriver/Configurations")),
                     AppDataDirectory = GetExistingPathOrLast(Path.Join(ProgramDirectory, "userdata"), Path.Join(UnixXdgPath.ConfigHome, "OpenTabletDriver")),
                     TemporaryDirectory = GetPath(Path.Join(UnixXdgPath.RuntimeDir, "OpenTabletDriver")),
                     CacheDirectory = GetPath(Path.Join(UnixXdgPath.CacheHome, "OpenTabletDriver")),
@@ -156,11 +156,20 @@ namespace OpenTabletDriver.Desktop
 
         public static string ProgramDirectory => AppContext.BaseDirectory;
 
-        private string GetDefaultConfigurationDirectory() => GetExistingPathOrLast(
-            Path.Join(AppDataDirectory, "Configurations"),
-            Path.Join(ProgramDirectory, "Configurations"),
-            Path.Join(Environment.CurrentDirectory, "Configurations")
-        );
+        private string GetDefaultConfigurationDirectory()
+        {
+            List<string> paths = [
+                Path.Join(AppDataDirectory, "Configurations"),
+                Path.Join(ProgramDirectory, "Configurations"),
+                Path.Join(Environment.CurrentDirectory, "Configurations")
+            ];
+            if (SystemInterop.CurrentPlatform == PluginPlatform.Linux)
+                paths.Insert(0, Path.Join(UnixXdgPath.DataHome, "OpenTabletDriver/Configurations"));
+            if (CommandLineConfigurationDirectory != null)
+                paths.Insert(0, CommandLineConfigurationDirectory);
+
+            return GetExistingPathOrLast([.. paths]);
+        }
 
         private string GetDefaultSettingsFile() => Path.Join(AppDataDirectory, "settings.json");
         private string GetDefaultPluginDirectory() => Path.Join(AppDataDirectory, "Plugins");

--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -275,7 +275,11 @@ namespace OpenTabletDriver.UX
             openPresetsDirectory.Executed += async (sender, e) => DesktopInterop.OpenFolder(AppInfo.Current.PresetDirectory);
 
             var detectTablet = new Command { MenuText = "Detect tablet", Shortcut = Application.Instance.CommonModifier | Keys.D };
-            detectTablet.Executed += async (sender, e) => await DetectTablet();
+            detectTablet.Executed += async (sender, e) =>
+            {
+                AppInfo.Current.ConfigurationDirectory = null; // force recheck on next access
+                await DetectTablet();
+            };
 
             var showTabletDebugger = new Command { MenuText = "Tablet debugger..." };
             showTabletDebugger.Executed += (sender, e) => App.Current.DebuggerWindow.Show();


### PR DESCRIPTION
Making users restart the daemon is inconvenient here. Particularly an issue for Linux users.

Also did some cleanup. Some bits were all over the place.

The daemon setting `AppDataDirectory` and `ConfigurationDirectory` directly on startup if there were args without any way of knowing later that the daemon did this. There's `GetDefaultConfigurationDirectory` but then `ConfigurationDirectory` could get set by the getter of `AppInfo Current` instead.

Now `GetDefaultConfigurationDirectory` covers everything for getting the configuration directory.