### PR TITLE
Issue Template/Bug: Discourage 'tablet not detected' users

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: Create a bug report to help fix issues with OpenTabletDriver
+description: Create a bug report to help fix issues with OpenTabletDriver. If your tablet isn't detected, please make a support request instead.
 labels: ["bug"]
 body:
   - type: markdown


### PR DESCRIPTION
After getting rid of the support request template for issues, users have started to use the bug report template to get support request instead. Hopefully this wording should encourage some of these users to use the discussion template instead.

Wording can almost definitely be improved and other changes in a similar vein are welcome to supersede this.