### PR TITLE
Add support for detecting renamed Digimend tablet driver

### DIFF
--- a/OpenTabletDriver/SystemDrivers/DriverInfo.cs
+++ b/OpenTabletDriver/SystemDrivers/DriverInfo.cs
@@ -39,6 +39,7 @@ namespace OpenTabletDriver.SystemDrivers
                 new GaomonDriverInfoProvider(),
                 new HuionDriverInfoProvider(),
                 new XPPenDriverInfoProvider(),
+                new RenamedDigimendDriverInfoProvider(),
                 new VeikkDriverInfoDriver(),
                 new OpenTabletDriverInfoProvider(),
                 new TabletDriverInfoProvider()

--- a/OpenTabletDriver/SystemDrivers/InfoProviders/RenamedDigimendDriverInfoProvider.cs
+++ b/OpenTabletDriver/SystemDrivers/InfoProviders/RenamedDigimendDriverInfoProvider.cs
@@ -1,0 +1,24 @@
+namespace OpenTabletDriver.SystemDrivers.InfoProviders
+{
+    /// <summary>
+    /// Detects <c>hid_digimend_uclogic</c>
+    /// <para/>
+    /// The Digimend driver has had <c>hid_digimend_</c> prefixed to its modules on some distributions,
+    /// e.g. see Debian's <c>digimend-dkms 13-3</c> changelog:
+    /// <a href="https://tracker.debian.org/media/packages/d/digimend-dkms/changelog-13-4">
+    /// digimend-dkms (13-4) changelog
+    /// </a>
+    /// </summary>
+    internal class RenamedDigimendDriverInfoProvider : ProcessModuleQueryableDriverInfoProvider
+    {
+        protected override string FriendlyName => "Digimend";
+
+        protected override string LinuxFriendlyName => "Digimend UC Logic";
+
+        protected override string LinuxModuleName => "hid_digimend_uclogic";
+
+        protected override string[] WinProcessNames => [];
+
+        protected override string[] Heuristics { get; } = [];
+    }
+}


### PR DESCRIPTION
On at least Debian, the driver is now named `hid_digimend_uclogic`

Fixes #4954