### PR TITLE
Add support for Artisul M0610 (non-pro)

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Artisul/M0610.json
+++ b/OpenTabletDriver.Configurations/Configurations/Artisul/M0610.json
@@ -1,0 +1,36 @@
+{
+  "Name": "Artisul M0610",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 254.25,
+      "Height": 152.65,
+      "MaxX": 25425,
+      "MaxY": 15265
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 8
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 21827,
+      "ProductID": 129,
+      "ReportParser": "OpenTabletDriver.Plugin.Tablet.TabletReportParser",
+      "DeviceStrings": {
+        "201": "F610_MAS-\\d{6}$"
+      },
+      "InitializationStrings": [
+        123,
+        100
+      ]
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1",
+    "Interface": "0"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -4,6 +4,7 @@
 | Acepen AP1060                      |     Supported     |
 | Adesso Cybertablet K8              |     Supported     |
 | Artisul D22S                       |     Supported     |
+| Artisul M0610                      |     Supported     |
 | Gaomon 1060 Pro                    |     Supported     |
 | Gaomon GM116HD                     |     Supported     |
 | Gaomon GM156HD                     |     Supported     |


### PR DESCRIPTION
Diag : [Diagnostics-067 (7).json](https://github.com/user-attachments/files/30168291/Diagnostics-067.7.json)
Packet capture from the Manufacturer drivers on Windows : https://discord.com/channels/615607687467761684/1528040367138537502/1528428353827242084
Verification : 
https://discord.com/channels/615607687467761684/1528040367138537502/1528436115453902918
https://discord.com/channels/615607687467761684/1528040367138537502/1528440512451838022

Order for the init seems to be specific, as found using the manufacturer drivers.

Interface 1 (PNP) does not work on Linux, only Windows.
Fortunately, this tablet has a vendor interface on Interface 0.