### PR TITLE
[WIP] Reduce null-supressing operator usage

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicV1WheelReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/UCLogic/UCLogicV1WheelReport.cs
@@ -1,4 +1,3 @@
-using OpenTabletDriver.Plugin.Tablet;
 using OpenTabletDriver.Plugin.Tablet.Wheel;
 
 namespace OpenTabletDriver.Configurations.Parsers.UCLogic

--- a/OpenTabletDriver.Configurations/ReportParserProvider.cs
+++ b/OpenTabletDriver.Configurations/ReportParserProvider.cs
@@ -39,7 +39,7 @@ namespace OpenTabletDriver.Configurations
             return assemblies.SelectMany(asm => asm.ExportedTypes)
                 .Where(t => t.IsAssignableTo(typeof(IReportParser<IDeviceReport>)))
                 .ToDictionary(
-                    t => t.FullName!,
+                    t => t.FullName!, // null-warning suppressed as the IsAssignableTo call indirectly forces FullName being available
                     GetConstructor
                 );
         }

--- a/OpenTabletDriver.Console/Program.Commands.cs
+++ b/OpenTabletDriver.Console/Program.Commands.cs
@@ -22,17 +22,19 @@ namespace OpenTabletDriver.Console
 
         private static async Task HasUpdate()
         {
-            if (!await EnsureDaemonReady()) return;
-            var hasUpdate = await Driver.Instance!.CheckForUpdates() is not null;
+            var daemon = await GetDaemon();
+            if (daemon is null) return;
+            var hasUpdate = await daemon.CheckForUpdates() is not null;
             await Out.WriteLineAsync(hasUpdate.ToString().ToLowerInvariant());
         }
 
         private static async Task InstallUpdate()
         {
-            if (!await EnsureDaemonReady()) return;
-            if (await Driver.Instance!.CheckForUpdates() is not null)
+            var daemon = await GetDaemon();
+            if (daemon is null) return;
+            if (await daemon.CheckForUpdates() is not null)
             {
-                await Driver.Instance.InstallUpdate();
+                await daemon.InstallUpdate();
             }
         }
 
@@ -61,7 +63,8 @@ namespace OpenTabletDriver.Console
 
         private static async Task ApplyPreset(string name)
         {
-            if (!await EnsureDaemonReady()) return;
+            var daemon = await GetDaemon();
+            if (daemon is null) return;
             GetAndRefreshPresetDirectory();
 
             var preset = AppInfo.PresetManager.FindPreset(name);
@@ -71,7 +74,8 @@ namespace OpenTabletDriver.Console
 
         private static async Task SavePreset(string name)
         {
-            if (!await EnsureDaemonReady()) return;
+            var daemon = await GetDaemon();
+            if (daemon is null) return;
             var presetDir = GetAndRefreshPresetDirectory();
 
             var file = new FileInfo(Path.Combine(presetDir.FullName, name + ".json"));
@@ -311,8 +315,9 @@ namespace OpenTabletDriver.Console
 
         private static async Task GetCurrentLog()
         {
-            if (!await EnsureDaemonReady()) return;
-            var log = await Driver.Instance!.GetCurrentLog();
+            var daemon = await GetDaemon();
+            if (daemon is null) return;
+            var log = await daemon.GetCurrentLog();
             foreach (var message in log)
                 await Out.WriteLineAsync(Log.GetStringFormat(message));
         }
@@ -406,23 +411,26 @@ namespace OpenTabletDriver.Console
 
         private static async Task Detect()
         {
-            if (!await EnsureDaemonReady()) return;
-            await Driver.Instance!.DetectTablets();
-            await Driver.Instance!.SetSettings(await Driver.Instance.GetSettings());
+            var daemon = await GetDaemon();
+            if (daemon is null) return;
+            await daemon.DetectTablets();
+            await daemon.SetSettings(await daemon.GetSettings());
         }
 
         private static async Task InstallPlugin(string filePath)
         {
-            if (!await EnsureDaemonReady()) return;
-            if (!await Driver.Instance!.InstallPlugin(filePath))
+            var daemon = await GetDaemon();
+            if (daemon is null) return;
+            if (!await daemon.InstallPlugin(filePath))
                 await Out.WriteLineAsync("Unable to install plugin");
         }
 
         private static async Task UninstallPlugin(string folderName)
         {
-            if (!await EnsureDaemonReady()) return;
+            var daemon = await GetDaemon();
+            if (daemon is null) return;
             var context = AppInfo.PluginManager.GetLoadedPlugins().First(x => x.Directory.Name == folderName);
-            await Driver.Instance!.UninstallPlugin(context.Directory.FullName);
+            await daemon.UninstallPlugin(context.Directory.FullName);
         }
 
         #endregion
@@ -431,8 +439,9 @@ namespace OpenTabletDriver.Console
 
         private static async Task GetString(int vid, int pid, int index)
         {
-            if (!await EnsureDaemonReady()) return;
-            var str = await Driver.Instance!.RequestDeviceString(vid, pid, index);
+            var daemon = await GetDaemon();
+            if (daemon is null) return;
+            var str = await daemon.RequestDeviceString(vid, pid, index);
             await Out.WriteLineAsync(str);
         }
 
@@ -470,7 +479,8 @@ namespace OpenTabletDriver.Console
 
         private static async Task ListPlugins()
         {
-            if (!await EnsureDaemonReady()) return;
+            var daemon = await GetDaemon();
+            if (daemon is null) return;
             foreach (var dir in AppInfo.PluginManager.PluginDirectory.EnumerateDirectories())
                 await Out.WriteLineAsync(dir.Name);
         }
@@ -550,10 +560,11 @@ namespace OpenTabletDriver.Console
 
         private static async Task GetDiagnostics()
         {
-            if (!await EnsureDaemonReady()) return;
+            var daemon = await GetDaemon();
+            if (daemon is null) return;
             try
             {
-                var diagnostics = await Driver.Instance!.GetDiagnosticInfo();
+                var diagnostics = await daemon.GetDiagnosticInfo();
                 await Out.WriteLineAsync(diagnostics.ToString());
             }
             catch (Exception ex)

--- a/OpenTabletDriver.Console/Program.Commands.cs
+++ b/OpenTabletDriver.Console/Program.Commands.cs
@@ -300,7 +300,7 @@ namespace OpenTabletDriver.Console
             await ModifyProfile(tablet, s =>
             {
                 foreach (var filterToReset in filtersToReset)
-                    s.Filters = new PluginSettingStoreCollection(s.Filters.Where(filter => filter?.Path != filterToReset)!);
+                    s.Filters = new PluginSettingStoreCollection(s.Filters.Where(filter => filter?.Path != filterToReset).Cast<PluginSettingStore>());
                 AppendPluginStoreSettingsCollectionByPaths<IPositionedPipelineElement<IDeviceReport>>(s.Filters, filtersToReset);
             });
         }

--- a/OpenTabletDriver.Console/Program.IPC.cs
+++ b/OpenTabletDriver.Console/Program.IPC.cs
@@ -12,16 +12,13 @@ namespace OpenTabletDriver.Console
         /// <summary>
         /// Connect to daemon if not already connected and ensure plugins are loaded
         /// </summary>
-        /// <returns><c>true</c> if connected successfully, <c>false</c> if daemon couldn't be found</returns>
-        /// <remarks>
-        /// <c>Driver.Instance</c> is guaranteed to be available after running this function.
-        /// </remarks>
-        public static async Task<bool> EnsureDaemonReady()
+        /// <returns>Driver instance if connected successfully, <c>null</c> if daemon couldn't be found</returns>
+        public static async Task<IDriverDaemon?> GetDaemon()
         {
             if (!Instance.Exists("OpenTabletDriver.Daemon"))
             {
                 System.Console.WriteLine("OpenTabletDriver Daemon not running");
-                return false;
+                return null;
             }
 
             if (!Driver.IsConnected)
@@ -33,7 +30,7 @@ namespace OpenTabletDriver.Console
                 AppInfo.PluginManager.Load();
             }
 
-            return true;
+            return Driver.Instance;
         }
 
     }

--- a/OpenTabletDriver.Console/Program.Misc.cs
+++ b/OpenTabletDriver.Console/Program.Misc.cs
@@ -16,15 +16,17 @@ namespace OpenTabletDriver.Console
 
         static async Task<Settings> GetSettings()
         {
-            if (!await EnsureDaemonReady())
+            var daemon = await GetDaemon();
+            if (daemon is null)
                 throw new InvalidOperationException("Cannot get settings without a daemon");
-            return await Driver.Instance!.GetSettings();
+            return await daemon.GetSettings();
         }
 
         static async Task ApplySettings(Settings settings)
         {
-            if (!await EnsureDaemonReady()) return;
-            await Driver.Instance!.SetSettings(settings);
+            var daemon = await GetDaemon();
+            if (daemon is null) return;
+            await daemon.SetSettings(settings);
         }
 
         static async Task ModifySettings(Action<Settings> func)
@@ -45,7 +47,8 @@ namespace OpenTabletDriver.Console
 
         static async Task<Profile> GetProfile(string profileName, Settings? settings = null)
         {
-            if (!await EnsureDaemonReady())
+            var daemon = await GetDaemon();
+            if (daemon is null)
                 throw new InvalidOperationException("Cannot get a profile without a daemon");
 
             const StringComparison comparer = StringComparison.InvariantCultureIgnoreCase;
@@ -54,7 +57,7 @@ namespace OpenTabletDriver.Console
             var profile = settings.Profiles.FirstOrDefault(p => p.Tablet.Equals(profileName, comparer));
             if (profile == null)
             {
-                var tablets = await Driver.Instance!.GetTablets();
+                var tablets = await daemon.GetTablets();
                 var tablet = tablets.FirstOrDefault(t => t.Properties.Name.Equals(profileName, comparer));
                 if (tablet != null)
                     profile = Profile.GetDefaults(tablet);
@@ -65,7 +68,8 @@ namespace OpenTabletDriver.Console
 
         static async Task ListTypes<T>(Func<Type, bool>? predicate = null)
         {
-            if (!await EnsureDaemonReady()) return;
+            var daemon = await GetDaemon();
+            if (daemon is null) return;
             var types = AppInfo.PluginManager.GetChildTypes<T>();
             if (types.Count == 0)
             {

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -429,11 +429,14 @@ namespace OpenTabletDriver.Daemon
                 MaxPenPressure = dev.Properties.Specifications.Pen.MaxPressure,
             };
 
-            var elements = (from store in profile.Filters
-                            where store is { Enable: true }
-                            let filter = store!.Construct<IPositionedPipelineElement<IDeviceReport>>(outputMode.Tablet)
+            var elements = (
+                            from store in
+                                from innerStore in profile.Filters
+                                where innerStore is { Enable: true }
+                                select innerStore
+                            let filter = store.Construct<IPositionedPipelineElement<IDeviceReport>>(outputMode.Tablet)
                             where filter != null
-                            select filter!).ToArray();
+                            select filter).ToArray();
 
             outputMode.Elements = elements.Prepend(pressureRewriteFilter).Append(bindingHandler).ToList();
 

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -659,9 +659,9 @@ namespace OpenTabletDriver.Daemon
             }
         }
 
-        public Task<Settings> GetSettings()
+        public Task<Settings?> GetSettings()
         {
-            return Task.FromResult(Settings!);
+            return Task.FromResult(Settings);
         }
 
         public Task<IEnumerable<SerializedDeviceEndpoint>> GetDevices()

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -137,7 +137,7 @@ namespace OpenTabletDriver.Daemon
         public event EventHandler? Resynchronize;
 
         public Driver Driver { get; }
-        private Settings? Settings { set; get; }
+        private Settings Settings { set; get; }
         private Collection<ITool> Tools { set; get; } = new Collection<ITool>();
         private readonly IUpdater? Updater = DesktopInterop.Updater;
         private readonly ISleepDetector? SleepDetector = new SleepDetector();
@@ -365,6 +365,7 @@ namespace OpenTabletDriver.Daemon
         private async Task LoadUserSettings()
         {
             AppInfo.PluginManager.Clean();
+            this.Settings ??= null!; // avoid CS8774, now don't you dare run this method non-awaited!
             await LoadPlugins();
             await DetectTablets();
 
@@ -642,24 +643,21 @@ namespace OpenTabletDriver.Daemon
                 runningTool.Dispose();
             Tools.Clear();
 
-            if (Settings != null)
+            foreach (var store in Settings.Tools)
             {
-                foreach (var store in Settings.Tools)
-                {
-                    if (store is not { Enable: true })
-                        continue;
+                if (store is not { Enable: true })
+                    continue;
 
-                    var tool = store.Construct<ITool>();
+                var tool = store.Construct<ITool>();
 
-                    if (tool?.Initialize() ?? false)
-                        Tools.Add(tool);
-                    else
-                        Log.Write("Tool", $"Failed to initialize {store.Name} tool.", LogLevel.Error);
-                }
+                if (tool?.Initialize() ?? false)
+                    Tools.Add(tool);
+                else
+                    Log.Write("Tool", $"Failed to initialize {store.Name} tool.", LogLevel.Error);
             }
         }
 
-        public Task<Settings?> GetSettings()
+        public Task<Settings> GetSettings()
         {
             return Task.FromResult(Settings);
         }

--- a/OpenTabletDriver.Daemon/DriverDaemon.cs
+++ b/OpenTabletDriver.Daemon/DriverDaemon.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -212,6 +213,7 @@ namespace OpenTabletDriver.Daemon
             return await GetTablets();
         }
 
+        [MemberNotNull(nameof(Settings))]
         public Task SetSettings(Settings? settings)
         {
             try
@@ -306,6 +308,7 @@ namespace OpenTabletDriver.Daemon
                 $"Pressure: {(profile.BindingSettings.DisablePressure ? "Disabled" : "Enabled")}");
         }
 
+        [MemberNotNull(nameof(Settings))]
         private void RecoverSettings(Settings? settings)
         {
             var recoveredSettings = Settings.GetDefaults();
@@ -352,11 +355,13 @@ namespace OpenTabletDriver.Daemon
             SetSettings(recoveredSettings);
         }
 
+        [MemberNotNull(nameof(Settings))]
         public async Task ResetSettings()
         {
             await SetSettings(Settings.GetDefaults());
         }
 
+        [MemberNotNull(nameof(Settings))]
         private async Task LoadUserSettings()
         {
             AppInfo.PluginManager.Clean();
@@ -396,7 +401,7 @@ namespace OpenTabletDriver.Daemon
                 await ResetSettings();
 
                 // only save fresh settings if a tablet was configured
-                if (Settings!.Profiles.Any())
+                if (Settings.Profiles.Any())
                     Settings.Serialize(settingsFile);
             }
         }

--- a/OpenTabletDriver.Desktop/Binding/MouseBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/MouseBinding.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Attributes;
 using OpenTabletDriver.Plugin.DependencyInjection;

--- a/OpenTabletDriver.Desktop/Binding/MouseBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/MouseBinding.cs
@@ -42,8 +42,9 @@ namespace OpenTabletDriver.Desktop.Binding
         }
 
         private static IEnumerable<string>? validButtons;
+
         public static IEnumerable<string> ValidButtons =>
-            validButtons ??= Enum.GetValues<MouseButton>().Select(Enum.GetName)!;
+            validButtons ??= Enum.GetNames<MouseButton>();
 
         public override string ToString() => $"{PLUGIN_NAME}: {Button}";
     }

--- a/OpenTabletDriver.Desktop/Binding/MouseScrollBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/MouseScrollBinding.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Attributes;
 using OpenTabletDriver.Plugin.DependencyInjection;

--- a/OpenTabletDriver.Desktop/Binding/MouseScrollBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/MouseScrollBinding.cs
@@ -113,8 +113,9 @@ namespace OpenTabletDriver.Desktop.Binding
         }
 
         private static IEnumerable<string>? validDirections;
+
         public static IEnumerable<string> ValidDirections =>
-            validDirections ??= Enum.GetValues<ScrollDirection>().Select(Enum.GetName)!;
+            validDirections ??= Enum.GetNames<ScrollDirection>();
 
         public override string ToString() => $"{PLUGIN_NAME}: Direction: {Direction}, Amount: {Amount}, Interval: {Interval}";
     }

--- a/OpenTabletDriver.Desktop/Contracts/IDriverDaemon.cs
+++ b/OpenTabletDriver.Desktop/Contracts/IDriverDaemon.cs
@@ -31,7 +31,7 @@ namespace OpenTabletDriver.Desktop.Contracts
         Task<IEnumerable<TabletReference>> DetectTablets();
 
         Task SetSettings(Settings settings);
-        Task<Settings?> GetSettings();
+        Task<Settings> GetSettings();
         Task ResetSettings();
 
         Task<AppInfo> GetApplicationInfo();

--- a/OpenTabletDriver.Desktop/Contracts/IDriverDaemon.cs
+++ b/OpenTabletDriver.Desktop/Contracts/IDriverDaemon.cs
@@ -31,7 +31,7 @@ namespace OpenTabletDriver.Desktop.Contracts
         Task<IEnumerable<TabletReference>> DetectTablets();
 
         Task SetSettings(Settings settings);
-        Task<Settings> GetSettings();
+        Task<Settings?> GetSettings();
         Task ResetSettings();
 
         Task<AppInfo> GetApplicationInfo();

--- a/OpenTabletDriver.Desktop/Converters/VersionConverter.cs
+++ b/OpenTabletDriver.Desktop/Converters/VersionConverter.cs
@@ -7,7 +7,7 @@ namespace OpenTabletDriver.Desktop.Converters
     {
         public override Version? ReadJson(JsonReader reader, Type objectType, Version? existingValue, bool hasExistingValue, JsonSerializer serializer)
         {
-            return reader.TokenType == JsonToken.String ? Version.Parse((string)reader.Value!) : null;
+            return reader.TokenType == JsonToken.String ? Version.Parse((string)reader.Value!) : null; // null-warning suppressed as string JSON token means the value exists in some capacity
         }
 
         public override void WriteJson(JsonWriter writer, Version? value, JsonSerializer serializer)

--- a/OpenTabletDriver.Desktop/DesktopDeviceConfigurationProvider.cs
+++ b/OpenTabletDriver.Desktop/DesktopDeviceConfigurationProvider.cs
@@ -29,8 +29,8 @@ namespace OpenTabletDriver.Desktop
                         ? $"{files.Count} configurations exist in '{AppInfo.Current.ConfigurationDirectory}'. Built-in configurations may be overridden if the Name matches exactly."
                         : $"Configuration overrides specified as '{AppInfo.Current.ConfigurationDirectory}' but folder is empty.");
 
-                jsonConfigurations = files.Select(path => Serialization.Deserialize<TabletConfiguration>(File.OpenRead(path))).Where(x => x != null)
-                    .Select(jsonConfig => (ConfigurationSource.File, jsonConfig))!;
+                jsonConfigurations = files.Select(path => Serialization.Deserialize<TabletConfiguration>(File.OpenRead(path)))
+                    .SelectNotNull(jsonConfig => (ConfigurationSource.File, jsonConfig));
             }
 
             return _inAssemblyConfigurationProvider.TabletConfigurations

--- a/OpenTabletDriver.Desktop/DesktopDeviceConfigurationProvider.cs
+++ b/OpenTabletDriver.Desktop/DesktopDeviceConfigurationProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using OpenTabletDriver.Configurations;
@@ -49,8 +50,11 @@ namespace OpenTabletDriver.Desktop
                     if (jsonConfig != null && asmConfig != null)
                         Log.Write("Detect", $"Overriding tablet configuration '{jsonConfig.Name}'");
 
-                    return jsonConfig ?? asmConfig!;
-                });
+                    Debug.Assert(jsonConfig != null || asmConfig != null,
+                        "Both tablet config variants unexpectedly null. Function is expected to find at least 1 non-null value");
+
+                    return jsonConfig ?? asmConfig;
+                }).Cast<TabletConfiguration>();
         }
 
         private enum ConfigurationSource

--- a/OpenTabletDriver.Desktop/Extensions.cs
+++ b/OpenTabletDriver.Desktop/Extensions.cs
@@ -24,6 +24,12 @@ namespace OpenTabletDriver.Desktop
                    select type;
         }
 
+        extension<T>(IEnumerable<T?> o) where T : class
+        {
+            public IEnumerable<T> WhereNotNull() => o.Where(x => x != null)!;
+            public IEnumerable<TResult> SelectNotNull<TResult>(Func<T, TResult> fun) => o.WhereNotNull().Select(fun);
+        }
+
         /// <summary>
         /// Check if provided assembly is loadable.
         /// Useful to check whether an OpenTabletDriver plugin is valid or not.

--- a/OpenTabletDriver.Desktop/Extensions.cs
+++ b/OpenTabletDriver.Desktop/Extensions.cs
@@ -26,7 +26,7 @@ namespace OpenTabletDriver.Desktop
 
         extension<T>(IEnumerable<T?> o) where T : class
         {
-            public IEnumerable<T> WhereNotNull() => o.Where(x => x != null)!;
+            public IEnumerable<T> WhereNotNull() => o.Where(x => x != null).Cast<T>();
             public IEnumerable<TResult> SelectNotNull<TResult>(Func<T, TResult> fun) => o.WhereNotNull().Select(fun);
         }
 

--- a/OpenTabletDriver.Desktop/Extensions.cs
+++ b/OpenTabletDriver.Desktop/Extensions.cs
@@ -24,12 +24,6 @@ namespace OpenTabletDriver.Desktop
                    select type;
         }
 
-        extension<T>(IEnumerable<T?> o) where T : class
-        {
-            public IEnumerable<T> WhereNotNull() => o.Where(x => x != null).Cast<T>();
-            public IEnumerable<TResult> SelectNotNull<TResult>(Func<T, TResult> fun) => o.WhereNotNull().Select(fun);
-        }
-
         /// <summary>
         /// Check if provided assembly is loadable.
         /// Useful to check whether an OpenTabletDriver plugin is valid or not.

--- a/OpenTabletDriver.Desktop/Interop/SleepDetector.cs
+++ b/OpenTabletDriver.Desktop/Interop/SleepDetector.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -58,7 +59,10 @@ namespace OpenTabletDriver.Desktop.Interop
                 if (task == null)
                     return;
 
-                cts!.Cancel();
+                Debug.Assert(cts != null,
+                    "Internal code error. Cancellation token source null when trying to stop sleep detector");
+
+                cts.Cancel();
 #pragma warning disable VSTHRD002
                 task.Wait();
 #pragma warning restore VSTHRD002

--- a/OpenTabletDriver.Desktop/Interop/Timer/MacOSTimer.cs
+++ b/OpenTabletDriver.Desktop/Interop/Timer/MacOSTimer.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using OpenTabletDriver.Native.Linux;
@@ -24,7 +26,17 @@ namespace OpenTabletDriver.Desktop.Interop.Timer
 
         }
 
-        public bool Enabled { private set; get; }
+        [MemberNotNullWhen(true, nameof(thread))]
+        public bool Enabled
+        {
+            get
+            {
+                if (field)
+                    Debug.Assert(thread != null, "Timer should not be reporting enabled with a null thread");
+                return field;
+            }
+            private set;
+        }
 
         public float Interval { get; set; } = 1;
 
@@ -71,7 +83,7 @@ namespace OpenTabletDriver.Desktop.Interop.Timer
 
                     thread = new Thread(ThreadMain);
                     thread.IsBackground = true;
-                    thread!.Start();
+                    thread.Start();
                     Enabled = true;
                 }
             }
@@ -84,7 +96,7 @@ namespace OpenTabletDriver.Desktop.Interop.Timer
                 if (Enabled)
                 {
                     SendCancelEvent();
-                    thread!.Join();
+                    thread.Join();
                     Close(kqueue);
                     Enabled = false;
                 }

--- a/OpenTabletDriver.Desktop/Profiles/BindingSettings.cs
+++ b/OpenTabletDriver.Desktop/Profiles/BindingSettings.cs
@@ -177,6 +177,8 @@ namespace OpenTabletDriver.Desktop.Profiles
                 var wheelBinding = WheelBindings[i];
                 wheelBinding.StepSize = GetDegreesPerStep(tabletSpecifications, i);
 
+                // null-warning suppressed as 'i' is based on the amount of wheels in the tablet specifications, or 0 if none
+                // therefore, if we're at 0 or no defined wheels then we should never be in this spot of the code
                 int buttonCountForWheel = (int)tabletSpecifications.Wheels![i].ButtonCount;
                 wheelBinding.WheelButtons.SetExpectedCount(buttonCountForWheel);
 
@@ -235,7 +237,7 @@ namespace OpenTabletDriver.Desktop.Profiles
             ArgumentNullException.ThrowIfNull(spec);
 
             if (spec.Wheels != null && spec.Wheels.Count >= wheelIndex && spec.Wheels[wheelIndex].StepCount != null)
-                return 360d / spec.Wheels[wheelIndex].StepCount!.Value;
+                return 360d / spec.Wheels[wheelIndex].StepCount!.Value; // null-warning suppressed as we've just null checked it
 
             throw new InvalidOperationException("Provided TabletSpecifications does not define wheel step count for this wheel");
         }

--- a/OpenTabletDriver.Desktop/RPC/RpcClient.cs
+++ b/OpenTabletDriver.Desktop/RPC/RpcClient.cs
@@ -25,9 +25,11 @@ namespace OpenTabletDriver.Desktop.RPC
             this.pipeName = pipeName;
         }
 
+        [MemberNotNull(nameof(Instance))]
         public async Task Connect()
         {
             this.stream = GetStream();
+            this.Instance ??= null!; // avoid CS8774, now don't you dare run this method non-awaited!
             await this.stream.ConnectAsync();
 
             rpc = new JsonRpc(this.stream);

--- a/OpenTabletDriver.Desktop/Reflection/DesktopPluginContext.cs
+++ b/OpenTabletDriver.Desktop/Reflection/DesktopPluginContext.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -43,11 +44,17 @@ namespace OpenTabletDriver.Desktop.Reflection
             }
             else
             {
+                var entryAssembly = Assembly.GetEntryAssembly();
+                Debug.Assert(entryAssembly != null, $"Cannot {nameof(GetMetadata)}() without an entry assembly!");
+
+                var version = entryAssembly.GetName().Version;
+                Debug.Assert(version != null, $"Cannot {nameof(GetMetadata)}() without entry assembly containing a version (compile-time bug?)");
+
                 return new PluginMetadata
                 {
                     Name = FriendlyName,
                     Owner = "<unknown>",
-                    SupportedDriverVersion = Assembly.GetEntryAssembly()!.GetName().Version!, // TODO: require plugin manifest to ensure compatibility?
+                    SupportedDriverVersion = version, // TODO: require plugin manifest to ensure compatibility?
                     Installed = true,
                 };
             }

--- a/OpenTabletDriver.Desktop/Reflection/IServiceManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/IServiceManager.cs
@@ -4,7 +4,7 @@ namespace OpenTabletDriver.Desktop.Reflection
 {
     public interface IServiceManager : IServiceProvider
     {
-        bool AddService<T>(Func<T> value);
+        bool AddService<T>(Func<T> value) where T : class?;
         void ResetServices();
     }
 }

--- a/OpenTabletDriver.Desktop/Reflection/PluginManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginManager.cs
@@ -91,9 +91,9 @@ namespace OpenTabletDriver.Desktop.Reflection
         public virtual IReadOnlyCollection<TypeInfo> GetChildTypes<T>()
         {
             var children = (from type in PluginTypes
-                           where typeof(T).IsAssignableFrom(type)
-                           where !IsPluginIgnored(type)
-                           select type).ToArray();
+                            where typeof(T).IsAssignableFrom(type)
+                            where !IsPluginIgnored(type)
+                            select type).ToArray();
 
             Debug.Assert(children.All(x => !string.IsNullOrEmpty(x.FullName)),
                 "Tried returning Type with null or empty FullName");

--- a/OpenTabletDriver.Desktop/Reflection/PluginManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/PluginManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using OpenTabletDriver.Plugin;
@@ -89,12 +90,15 @@ namespace OpenTabletDriver.Desktop.Reflection
 
         public virtual IReadOnlyCollection<TypeInfo> GetChildTypes<T>()
         {
-            var children = from type in PluginTypes
+            var children = (from type in PluginTypes
                            where typeof(T).IsAssignableFrom(type)
                            where !IsPluginIgnored(type)
-                           select type;
+                           select type).ToArray();
 
-            return children.ToArray();
+            Debug.Assert(children.All(x => !string.IsNullOrEmpty(x.FullName)),
+                "Tried returning Type with null or empty FullName");
+
+            return children;
         }
 
         public virtual string? GetFriendlyName(string path)

--- a/OpenTabletDriver.Desktop/Reflection/ServiceManager.cs
+++ b/OpenTabletDriver.Desktop/Reflection/ServiceManager.cs
@@ -5,7 +5,7 @@ namespace OpenTabletDriver.Desktop.Reflection
 {
     public class ServiceManager : IServiceManager
     {
-        private readonly Dictionary<Type, Func<object>> services = new();
+        private readonly Dictionary<Type, Func<object?>> services = new();
 
         /// <summary>
         /// Adds a retrieval method for a service type.
@@ -13,9 +13,9 @@ namespace OpenTabletDriver.Desktop.Reflection
         /// <param name="value">The method in which returns the required service type.</param>
         /// <typeparam name="T">The type in which is returned by the constructor.</typeparam>
         /// <returns>True if adding the service was successful, otherwise false.</returns>
-        public bool AddService<T>(Func<T> value)
+        public bool AddService<T>(Func<T> value) where T : class?
         {
-            return services.TryAdd(typeof(T), (value as Func<object>)!);
+            return services.TryAdd(typeof(T), value);
         }
 
         /// <summary>

--- a/OpenTabletDriver.Desktop/Settings.cs
+++ b/OpenTabletDriver.Desktop/Settings.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
@@ -64,7 +65,9 @@ namespace OpenTabletDriver.Desktop
         private static ProfileCollection GetDefaultProfiles()
         {
             // nullable warning suppressed because IDriver should always be provided by DI
-            return new ProfileCollection(AppInfo.PluginManager.GetService<IDriver>()!.Tablets);
+            var iDriver = AppInfo.PluginManager.GetService<IDriver>();
+            Debug.Assert(iDriver != null, "Internal program error. IDriver not injected?");
+            return new ProfileCollection(iDriver.Tablets);
         }
 
         #region Custom Serialization

--- a/OpenTabletDriver.Desktop/UnixXdgPath.cs
+++ b/OpenTabletDriver.Desktop/UnixXdgPath.cs
@@ -44,6 +44,7 @@ namespace OpenTabletDriver.Desktop
             string? pathFromEnvVar = Environment.GetEnvironmentVariable(pathRecord.EnvVar);
             bool found = !string.IsNullOrEmpty(pathFromEnvVar);
 
+            // null-warning suppressed as we've just null-checked the associated variable
             string rv = FileUtilities.InjectEnvironmentVariables(found ? pathFromEnvVar! : pathRecord.FallbackPath);
 
             Log.Debug(nameof(UnixXdgPath),

--- a/OpenTabletDriver.Desktop/Updater/GitHubUpdater.cs
+++ b/OpenTabletDriver.Desktop/Updater/GitHubUpdater.cs
@@ -28,7 +28,8 @@ namespace OpenTabletDriver.Desktop.Updater
             try
             {
                 var release = await _github.Repository.Release.GetLatest("OpenTabletDriver", "OpenTabletDriver");
-                var version = new Version(release!.TagName[1..]); // remove `v` from `vW.X.Y.Z
+
+                var version = new Version(release.TagName[1..]); // remove `v` from `vW.X.Y.Z
 
                 return new UpdateInfo(async () => await Download(release, version))
                 {

--- a/OpenTabletDriver.Desktop/Updater/Updater.cs
+++ b/OpenTabletDriver.Desktop/Updater/Updater.cs
@@ -16,6 +16,7 @@ namespace OpenTabletDriver.Desktop.Updater
             "Presets"
         ];
 
+        // null-warning suppressed as this should always succeed?
         protected static readonly Version AssemblyVersion = typeof(IUpdater).Assembly.GetName().Version!;
 
         protected Updater(Version currentVersion, string binaryDir, string appDataDir, string rollbackDir)

--- a/OpenTabletDriver.Desktop/ViewModels/TabletDebuggerViewModel.cs
+++ b/OpenTabletDriver.Desktop/ViewModels/TabletDebuggerViewModel.cs
@@ -132,9 +132,9 @@ public sealed class TabletDebuggerViewModel : ViewModel, IDisposable
 
             if (dataObject is IAbsoluteWheelReport absoluteWheelReport)
                 for (int i = 0; i < absoluteWheelReport.AnalogPositions.Length; i++)
-                    if (absoluteWheelReport.AnalogPositions[i].HasValue)
+                    if (absoluteWheelReport.AnalogPositions[i] is { } analogPosition)
                         AdditionalStatistics[$"Abs. Wheel {i} Position"]
-                            .SaveMinMax(absoluteWheelReport.AnalogPositions[i]!.Value);
+                            .SaveMinMax(analogPosition);
 
             if (dataObject is IRelativeWheelReport relativeWheelReport)
                 for (int i = 0; i < relativeWheelReport.AnalogDeltas.Length; i++)

--- a/OpenTabletDriver.Desktop/ViewModels/Utility/Statistics.cs
+++ b/OpenTabletDriver.Desktop/ViewModels/Utility/Statistics.cs
@@ -152,7 +152,7 @@ namespace OpenTabletDriver.Desktop.ViewModels.Utility
         public Statistic SaveMinMax(Vector2 source, string? unit = null, int precision = 0) => SaveMinMax(source, Vector2.Min, Vector2.Max, unit, precision);
         public Statistic SaveMinMax(TouchPoint?[] touchPoints)
         {
-            var validTouchPoints = touchPoints.Where(x => x != null).Select(x => x!.Position).ToArray();
+            var validTouchPoints = touchPoints.SelectNotNull(x => x.Position).ToArray();
             if (validTouchPoints.Length == 0) return this;
 
             // Vector2 doesn't implement IComparable, do naive method:

--- a/OpenTabletDriver.Desktop/ViewModels/Utility/Statistics.cs
+++ b/OpenTabletDriver.Desktop/ViewModels/Utility/Statistics.cs
@@ -165,10 +165,10 @@ namespace OpenTabletDriver.Desktop.ViewModels.Utility
         private Statistic SaveMinMax<T>(T source, Func<T, T, T> minFunc, Func<T, T, T> maxFunc, string? unit, int? precision)
         {
             var min = this[StatisticSubGroup.Min];
-            min.Value = minFunc(source, (T)(min.Value ?? source)!);
+            min.Value = minFunc(source, min.Value is T minValue ? minValue : source);
             min.Unit = unit;
             var max = this[StatisticSubGroup.Max];
-            max.Value = maxFunc(source, (T)(max.Value ?? source)!);
+            max.Value = maxFunc(source, max.Value is T maxValue ? maxValue : source);
             max.Unit = unit;
 
             if (precision != null)

--- a/OpenTabletDriver.Plugin/Attributes/PropertyValidatedAttribute.cs
+++ b/OpenTabletDriver.Plugin/Attributes/PropertyValidatedAttribute.cs
@@ -23,8 +23,8 @@ namespace OpenTabletDriver.Plugin.Attributes
 
         public T? GetValue<T>(PropertyInfo property)
         {
-            var sourceType = property.ReflectedType;
-            var member = sourceType!.GetMember(MemberName).First();
+            var sourceType = property.ReflectedType ?? throw new InvalidOperationException("Property does not have a reflected type");
+            var member = sourceType.GetMember(MemberName).First();
             try
             {
                 return member.MemberType switch

--- a/OpenTabletDriver.Plugin/Attributes/PropertyValidatedAttribute.cs
+++ b/OpenTabletDriver.Plugin/Attributes/PropertyValidatedAttribute.cs
@@ -29,6 +29,8 @@ namespace OpenTabletDriver.Plugin.Attributes
             {
                 return member.MemberType switch
                 {
+                    // the following null-suppressing operators are present as being here
+                    // in the member.MemberType switch case implicitly means those return values can't be null
                     MemberTypes.Property => (T?)sourceType.GetProperty(MemberName)!.GetValue(null),
                     MemberTypes.Field => (T?)sourceType.GetField(MemberName)!.GetValue(null),
                     MemberTypes.Method => (T?)sourceType.GetMethod(MemberName)!.Invoke(null, null),

--- a/OpenTabletDriver.Plugin/Log.cs
+++ b/OpenTabletDriver.Plugin/Log.cs
@@ -19,7 +19,10 @@ namespace OpenTabletDriver.Plugin
             {
                 if (_output == null && value != null)
                 {
-                    foreach (var message in _backlog!)
+                    System.Diagnostics.Debug.Assert(_backlog != null,
+                        "Backlog may not be null when no output events are present and one is being added");
+
+                    foreach (var message in _backlog)
                         value.Invoke(null, message);
                     _backlog = null;
                     _logAction = WriteLog;
@@ -125,12 +128,16 @@ namespace OpenTabletDriver.Plugin
 
         private static void WriteBacklog(LogMessage message)
         {
-            _backlog!.Add(message);
+            System.Diagnostics.Debug.Assert(_backlog != null,
+                "Writing to backlog without a backlog doesn't make sense. You should likely be writing to the normal log instead.");
+            _backlog.Add(message);
         }
 
         private static void WriteLog(LogMessage message)
         {
-            _output?.Invoke(null, message);
+            System.Diagnostics.Debug.Assert(_output != null,
+                "Writing to log output without any output events doesn't make sense. You should likely be writing to the backlog instead.");
+            _output.Invoke(null, message);
         }
     }
 }

--- a/OpenTabletDriver.UX/App.cs
+++ b/OpenTabletDriver.UX/App.cs
@@ -184,9 +184,9 @@ namespace OpenTabletDriver.UX
         {
             try
             {
-                var exception = e.ExceptionObject as Exception;
+                var exception = (Exception)e.ExceptionObject;
                 Log.Exception(exception);
-                exception!.ShowMessageBox();
+                exception.ShowMessageBox();
             }
             catch (Exception ex)
             {

--- a/OpenTabletDriver.UX/App.cs
+++ b/OpenTabletDriver.UX/App.cs
@@ -139,14 +139,16 @@ namespace OpenTabletDriver.UX
 
         public static App Current { get; } = new App();
 
-        public const string WikiUrl = "https://opentabletdriver.net/Wiki";
+        // null silencing operators allowed as it'll be very obvious to even carefree developers if anything breaks here (GUI won't start)
         public static readonly string Version = Assembly.GetEntryAssembly()!.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
+        public static Bitmap Logo { get; } = new Bitmap(Assembly.GetExecutingAssembly().GetManifestResourceStream("OpenTabletDriver.UX.Assets.otd.png")!);
+        public static string License { get; } = new StreamReader(Assembly.GetExecutingAssembly().GetManifestResourceStream("OpenTabletDriver.UX.LICENSE")!).ReadToEnd();
+        // end of allowing null silencing operators
+
+        public const string WikiUrl = "https://opentabletdriver.net/Wiki";
+        public static Uri Website { get; } = new Uri(@"https://github.com/OpenTabletDriver/OpenTabletDriver");
 
         public static DaemonRpcClient Driver { get; } = new DaemonRpcClient("OpenTabletDriver.Daemon");
-        public static Bitmap Logo { get; } = new Bitmap(Assembly.GetExecutingAssembly().GetManifestResourceStream("OpenTabletDriver.UX.Assets.otd.png")!);
-
-        public static Uri Website { get; } = new Uri(@"https://github.com/OpenTabletDriver/OpenTabletDriver");
-        public static string License { get; } = new StreamReader(Assembly.GetExecutingAssembly().GetManifestResourceStream("OpenTabletDriver.UX.LICENSE")!).ReadToEnd();
 
         private Settings? settings;
         public Settings Settings

--- a/OpenTabletDriver.UX/App.cs
+++ b/OpenTabletDriver.UX/App.cs
@@ -153,7 +153,7 @@ namespace OpenTabletDriver.UX
         private Settings? settings;
         public Settings Settings
         {
-            set => this.RaiseAndSetIfChanged(ref this.settings!, value);
+            set => this.RaiseAndSetIfChanged(ref this.settings, value);
             get => this.settings ?? throw new InvalidOperationException("Settings cannot be null");
         }
 

--- a/OpenTabletDriver.UX/Controls/Bindings/AuxiliaryBindingEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/AuxiliaryBindingEditor.cs
@@ -30,7 +30,7 @@ namespace OpenTabletDriver.UX.Controls.Bindings
                 }
             };
 
-            auxButtons.ItemSourceBinding.Bind(SettingsBinding.Child(c => (IList<PluginSettingStore>)c.AuxButtons)!);
+            auxButtons.ItemSourceBinding.Bind(SettingsBinding.Child(c => (IList<PluginSettingStore?>?)c.AuxButtons));
         }
 
         private BindingDisplayList auxButtons;

--- a/OpenTabletDriver.UX/Controls/Bindings/MouseBindingEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/MouseBindingEditor.cs
@@ -55,7 +55,7 @@ namespace OpenTabletDriver.UX.Controls.Bindings
                 }
             };
 
-            mouseButtons.ItemSourceBinding.Bind(SettingsBinding.Child(c => (IList<PluginSettingStore>)c.MouseButtons)!);
+            mouseButtons.ItemSourceBinding.Bind(SettingsBinding.Child(c => (IList<PluginSettingStore?>?)c.MouseButtons));
             scrollUp.StoreBinding.Bind(SettingsBinding.Child(c => c.MouseScrollUp));
             scrollDown.StoreBinding.Bind(SettingsBinding.Child(c => c.MouseScrollDown));
         }

--- a/OpenTabletDriver.UX/Controls/Bindings/PenBindingEditor.cs
+++ b/OpenTabletDriver.UX/Controls/Bindings/PenBindingEditor.cs
@@ -128,7 +128,7 @@ namespace OpenTabletDriver.UX.Controls.Bindings
             eraserButton.StoreBinding.Bind(SettingsBinding.Child(c => c.EraserButton));
             tipThreshold.ValueBinding.Bind(SettingsBinding.Child(c => c.TipActivationThreshold));
             eraserThreshold.ValueBinding.Bind(SettingsBinding.Child(c => c.EraserActivationThreshold));
-            penButtons.ItemSourceBinding.Bind(SettingsBinding.Child(c => (IList<PluginSettingStore>)c.PenButtons)!);
+            penButtons.ItemSourceBinding.Bind(SettingsBinding.Child(c => (IList<PluginSettingStore?>?)c.PenButtons));
             disablePressure.CheckedBinding.Cast<bool>().Bind(SettingsBinding.Child(c => c.DisablePressure));
             disableTilt.CheckedBinding.Cast<bool>().Bind(SettingsBinding.Child(c => c.DisableTilt));
             enableDragBindings.CheckedBinding.Cast<bool>().Bind(SettingsBinding.Child(c => c.EnableDragBindings));

--- a/OpenTabletDriver.UX/Controls/Generic/Reflection/Extensions.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/Reflection/Extensions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using OpenTabletDriver.Desktop;
@@ -16,7 +17,11 @@ namespace OpenTabletDriver.UX.Controls.Generic.Reflection
             if (FriendlyNameCache.TryGetValue(type, out string? value))
                 return value;
 
-            return FriendlyNameCache[type] = type.GetCustomAttribute<PluginNameAttribute>()?.Name ?? type.FullName!;
+            string? rv = type.GetCustomAttribute<PluginNameAttribute>()?.Name ?? type.FullName;
+
+            Debug.Assert(rv is not null, "Tried caching a null string");
+
+            return FriendlyNameCache[type] = rv;
         }
 
         public static bool RemoveFromFriendlyNameCache(TypeInfo typeInfo) => FriendlyNameCache.Remove(typeInfo);

--- a/OpenTabletDriver.UX/Controls/Generic/Reflection/TypeDropDown.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/Reflection/TypeDropDown.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using Eto.Forms;

--- a/OpenTabletDriver.UX/Controls/Generic/Reflection/TypeDropDown.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/Reflection/TypeDropDown.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using Eto.Forms;
@@ -7,6 +8,8 @@ using OpenTabletDriver.Desktop;
 
 namespace OpenTabletDriver.UX.Controls.Generic.Reflection
 {
+    // null-warning suppression allowed here for TypeInfo.FullName
+    // as it's "guaranteed" to be non-null from the data source we're using
     public class TypeDropDown<T> : DropDown<TypeInfo> where T : class
     {
         public TypeDropDown()

--- a/OpenTabletDriver.UX/Controls/Generic/Reflection/TypeListBox.cs
+++ b/OpenTabletDriver.UX/Controls/Generic/Reflection/TypeListBox.cs
@@ -7,6 +7,8 @@ using OpenTabletDriver.Desktop;
 
 namespace OpenTabletDriver.UX.Controls.Generic.Reflection
 {
+    // null-warning suppression allowed here for TypeInfo.FullName
+    // as it's "guaranteed" to be non-null from the data source we're using
     public class TypeListBox<T> : ListBox<TypeInfo> where T : class
     {
         public TypeListBox()

--- a/OpenTabletDriver/Devices/DeviceReader.cs
+++ b/OpenTabletDriver/Devices/DeviceReader.cs
@@ -108,6 +108,8 @@ namespace OpenTabletDriver.Devices
                 Connected = true;
                 while (Connected)
                 {
+                    // null-suppressing operator allowed as this is fastest (and has implicitly been this way for years)
+                    // maybe a later rewrite can ensure that `Connected` also means that we have a non-null ReportStream
                     var data = ReportStream!.Read();
                     if (Parser.Parse(data) is T report)
                         OnReport(report);

--- a/OpenTabletDriver/Devices/RootHub.cs
+++ b/OpenTabletDriver/Devices/RootHub.cs
@@ -55,7 +55,7 @@ namespace OpenTabletDriver.Devices
             if (serviceProvider == null)
                 throw new InvalidOperationException("Cannot instantiate device hubs without a service provider");
 
-            ConnectDeviceHub(ActivatorUtilities.CreateInstance<T>(serviceProvider!));
+            ConnectDeviceHub(ActivatorUtilities.CreateInstance<T>(serviceProvider));
         }
 
         public void ConnectDeviceHub(IDeviceHub rootHub)

--- a/OpenTabletDriver/Devices/WinUSB/WinUSBInterface.cs
+++ b/OpenTabletDriver/Devices/WinUSB/WinUSBInterface.cs
@@ -124,7 +124,7 @@ namespace OpenTabletDriver.Devices.WinUSB
         private int referenceCount;
         private SafeFileHandle? activeFileHandle;
         private SafeWinUsbInterfaceHandle? activeWinUsbHandle;
-        private byte[] _reportDescriptor = null!;
+        private byte[] _reportDescriptor = null!; // null-silencing operator allowed as it is actually initialized in the constructor (trust)
 
         internal int InterfaceNum { get; private set; }
         internal byte? InputPipe { get; private set; }

--- a/OpenTabletDriver/Devices/WinUSB/WinUSBInterface.cs
+++ b/OpenTabletDriver/Devices/WinUSB/WinUSBInterface.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using HidSharp.Reports;
@@ -226,7 +227,8 @@ namespace OpenTabletDriver.Devices.WinUSB
                     throw new IOException("Failed to initialize WinUSB interface");
             }
 
-            return activeWinUsbHandle!;
+            Debug.Assert(activeWinUsbHandle != null, "Unexpectedly tried to return a null WinUSB Handle");
+            return activeWinUsbHandle;
         }
 
         // Take reference, so we may easily add multiple interface support in the future

--- a/OpenTabletDriver/Extensions.cs
+++ b/OpenTabletDriver/Extensions.cs
@@ -1,11 +1,13 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using OpenTabletDriver.Plugin;
 
 namespace OpenTabletDriver
 {
-    internal static class Extensions
+    public static class Extensions
     {
         public static bool TryGet<TSource, TValue>(this TSource source, Func<TSource, TValue> predicate, [NotNullWhen(true)] out TValue? value)
         {
@@ -25,5 +27,11 @@ namespace OpenTabletDriver
 
         public static TValue SafeGet<TSource, TValue>(this TSource source, Func<TSource, TValue> predicate, TValue fallback) =>
             source.TryGet(predicate, out var value) ? value : fallback;
+
+        extension<T>(IEnumerable<T?> o) where T : class
+        {
+            public IEnumerable<T> WhereNotNull() => o.Where(x => x != null).Cast<T>();
+            public IEnumerable<TResult> SelectNotNull<TResult>(Func<T, TResult> fun) => o.WhereNotNull().Select(fun);
+        }
     }
 }

--- a/OpenTabletDriver/SystemDrivers/DriverInfo.cs
+++ b/OpenTabletDriver/SystemDrivers/DriverInfo.cs
@@ -50,9 +50,8 @@ namespace OpenTabletDriver.SystemDrivers
 
             // Remove "UC Logic" duplicates
             return providers.Select(provider => provider.GetDriverInfo())
-                .Where(i => i != null)
-                .GroupBy(i => i!.Name)
-                .Select(g => g.First()).Cast<DriverInfo>();
+                .WhereNotNull().GroupBy(i => i.Name)
+                .Select(g => g.First());
         }
 
         internal static Process[] SystemProcesses { get; private set; } = [];


### PR DESCRIPTION
Warnings are good, why suppress them?

This PR tries to rewrite every line in the codebase containing a null-suppressing operator

Based on the regex `(?<!\()!(?!=)`, which notably has a few false-positives - please give me a better regex if this one misses anything.

(v2 regex: `(?<!\()!(?![=a-zA-Z0-9\(\"])` to remove negated checks)

## Skipped changes

- Benchmarks project
  - Will be immediately obvious if things don't work, and it's not a user-facing project, so not as necessary
- Internal CLI program handling for parameters
  - I didn't look a whole lot into this but as far as I can tell these can truly not be null with the way we're using the templates.
  - [ ] This should probably be commented somewhere in the CLI codebase before merge
- `MacOSVirtualMouse` `pendingY!.Value` usage
  - IIRC this was intentionally done this way to avoid TOCTOU changes. This should probably be changed to a floating vector internally down the line to ensure that this is actually never null.
- Tests
  - Tests are run for every PR so it'll be pretty obvious if something breaks here. I don't need to think we need to change anything here.

## Missing Coverage

UX, WIP