### PR TITLE
MainForm: Reduce self-repeating code in `ResetSettings()`

### DIFF
--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -489,7 +489,7 @@ namespace OpenTabletDriver.UX
         {
             Debug.Assert(App.Driver.IsConnected);
             await App.Driver.Instance.ResetSettings();
-            App.Current.Settings = await App.Driver.Instance.GetSettings();
+            await SyncSettings();
         }
 
         private static async Task ResetSettingsDialog()


### PR DESCRIPTION
Now `ResetSettings()` calls `SyncSettings()` as it has the same end result, and should the sync call change later then there's a good chance whatever else goes into that function will be interesting to also have here.

(you can expand the diff downwards to find `SyncSettings()`)