### PR TITLE
(minor) Remove superfluous nullable preprocessor directives

### DIFF
--- a/OpenTabletDriver.Desktop/Binding/DeltaThresholdBindingState.cs
+++ b/OpenTabletDriver.Desktop/Binding/DeltaThresholdBindingState.cs
@@ -1,7 +1,5 @@
 using OpenTabletDriver.Plugin.Tablet;
 
-#nullable enable
-
 namespace OpenTabletDriver.Desktop.Binding
 {
     /// <summary>

--- a/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModePadBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModePadBinding.cs
@@ -7,8 +7,6 @@ using OpenTabletDriver.Plugin.DependencyInjection;
 using OpenTabletDriver.Plugin.Platform.Keyboard;
 using OpenTabletDriver.Plugin.Tablet;
 
-#nullable enable
-
 namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
 {
     [PluginName(_PLUGIN_NAME), SupportedPlatform(PluginPlatform.Linux)]

--- a/OpenTabletDriver.Desktop/Binding/MouseScrollBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/MouseScrollBinding.cs
@@ -8,8 +8,6 @@ using OpenTabletDriver.Plugin.Platform.Pointer;
 using OpenTabletDriver.Plugin.Tablet;
 using OpenTabletDriver.Plugin.Timers;
 
-#nullable enable
-
 namespace OpenTabletDriver.Desktop.Binding
 {
     [PluginName(PLUGIN_NAME)]

--- a/OpenTabletDriver.Desktop/Binding/WheelBindings.cs
+++ b/OpenTabletDriver.Desktop/Binding/WheelBindings.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using OpenTabletDriver.Plugin.Tablet;
 
-#nullable enable
-
 namespace OpenTabletDriver.Desktop.Binding
 {
     /// <summary>

--- a/OpenTabletDriver.Desktop/Profiles/WheelBindingSettings.cs
+++ b/OpenTabletDriver.Desktop/Profiles/WheelBindingSettings.cs
@@ -1,8 +1,6 @@
 using Newtonsoft.Json;
 using OpenTabletDriver.Desktop.Reflection;
 
-#nullable enable
-
 namespace OpenTabletDriver.Desktop.Profiles
 {
     /// <summary>

--- a/OpenTabletDriver.Desktop/UnixXdgPath.cs
+++ b/OpenTabletDriver.Desktop/UnixXdgPath.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/OpenTabletDriver.Desktop/ViewModels/TabletDebuggerViewModel.cs
+++ b/OpenTabletDriver.Desktop/ViewModels/TabletDebuggerViewModel.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/OpenTabletDriver.Desktop/ViewModels/Utility/Statistics.cs
+++ b/OpenTabletDriver.Desktop/ViewModels/Utility/Statistics.cs
@@ -8,8 +8,6 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using OpenTabletDriver.Plugin.Tablet.Touch;
 
-#nullable enable
-
 namespace OpenTabletDriver.Desktop.ViewModels.Utility
 {
     public static class StatisticSubGroup

--- a/OpenTabletDriver.Plugin/Tablet/IAbsoluteAnalogReport.cs
+++ b/OpenTabletDriver.Plugin/Tablet/IAbsoluteAnalogReport.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace OpenTabletDriver.Plugin.Tablet
 {
     public interface IAbsoluteAnalogReport : IDeviceReport

--- a/OpenTabletDriver.Plugin/Tablet/IRelativeAnalogReport.cs
+++ b/OpenTabletDriver.Plugin/Tablet/IRelativeAnalogReport.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace OpenTabletDriver.Plugin.Tablet
 {
     public interface IRelativeAnalogReport : IDeviceReport

--- a/OpenTabletDriver.Plugin/Tablet/WheelSpecifications.cs
+++ b/OpenTabletDriver.Plugin/Tablet/WheelSpecifications.cs
@@ -2,8 +2,6 @@ using System;
 using System.ComponentModel.DataAnnotations;
 using Newtonsoft.Json;
 
-#nullable enable
-
 namespace OpenTabletDriver.Plugin.Tablet
 {
     /// <summary>


### PR DESCRIPTION
The projects already have nullable enabled, so these do nothing.

I can't find a .NET analyzer setting for this, only ReSharper, and it is already defaulted to a warning: https://www.jetbrains.com/help/rider/RedundantNullableDirective.html - so no accompanying `.editorconfig` change here.