### PR TITLE
Logging: Avoid potential race condition while adding log outputs

### DIFF
--- a/OpenTabletDriver.Plugin/Log.cs
+++ b/OpenTabletDriver.Plugin/Log.cs
@@ -19,10 +19,10 @@ namespace OpenTabletDriver.Plugin
             {
                 if (_output == null && value != null)
                 {
+                    _logAction = WriteLog;
                     foreach (var message in _backlog!)
                         value.Invoke(null, message);
                     _backlog = null;
-                    _logAction = WriteLog;
                 }
 
                 _output += value;


### PR DESCRIPTION
The log action was previously first changed after the backlog was cleared (and made unavailable), so there is a potential chance of a log event happening during this transition.

This commit reorders the initialization process so that the chance of backlogs being missed (or NRE'd) is greatly reduced, however little the chance was to begin with.

Honestly not even sure if this is a problem to begin with (as in not being possible due to some C# intrinsics I'm not aware of) but I think this way makes the intent more obvious as well as reduces the chance of this being wrong.