### PR TITLE
Fix Genius i405X report parser: wrong byte offsets and tip flag bit

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/Genius/GeniusReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Genius/GeniusReportParser.cs
@@ -10,7 +10,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Genius
         {
             return data[0] switch
             {
-                0x10 => new TabletReport(data),
+                0x10 => new GeniusTabletReport(data),
                 0x11 => new GeniusMouseReport(data),
                 _ => new DeviceReport(data)
             };

--- a/OpenTabletDriver.Configurations/Parsers/Genius/GeniusTabletReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Genius/GeniusTabletReport.cs
@@ -12,15 +12,15 @@ namespace OpenTabletDriver.Configurations.Parsers.Genius
 
             Position = new Vector2
             {
-                X = Unsafe.ReadUnaligned<ushort>(ref report[1]),
-                Y = Unsafe.ReadUnaligned<ushort>(ref report[3])
+                X = Unsafe.ReadUnaligned<ushort>(ref report[2]),
+                Y = Unsafe.ReadUnaligned<ushort>(ref report[4])
             };
-            Pressure = report[5].IsBitSet(2) ? Unsafe.ReadUnaligned<ushort>(ref report[6]) : 0u;
+            Pressure = report[1].IsBitSet(0) ? Unsafe.ReadUnaligned<ushort>(ref report[6]) : 0u;
 
             PenButtons =
             [
-                report[5].IsBitSet(3),
-                report[5].IsBitSet(4),
+                report[1].IsBitSet(3),
+                report[1].IsBitSet(4),
             ];
         }
 


### PR DESCRIPTION
## What this fixes

The `GeniusTabletReport` parser has had incorrect byte offsets and the wrong flag bit for tip detection since it was written. This means **pressure has never worked on the Genius i405X with OpenTabletDriver** — on any platform. Position was also being misread.

Additionally, `GeniusReportParser` was dispatching report ID `0x10` to the generic `TabletReport` instead of `GeniusTabletReport`, so the pressure-aware parser was never invoked at all.

## How the correct layout was determined

The byte layout was discovered by reverse engineering raw HID reports directly from the device using `IOHIDDeviceRegisterInputReportCallback` on macOS. We captured hundreds of reports at varying pressure levels and confirmed each byte offset and flag bit through direct observation — not assumption or documentation.

Real i405X report layout (8 bytes, report ID included in buffer):

```
[0]   0x10  report ID
[1]   flags: bit0=tip contact, bit3=btn1, bit4=btn2, bit7=in-range
[2-3] X position LE uint16 (max 14050)
[4-5] Y position LE uint16 (max 10240)
[6-7] pressure LE uint16 (max 1023, valid when bit0 set)
```

## Changes

**`GeniusTabletReport.cs`**
- X: `report[1]` → `report[2]`
- Y: `report[3]` → `report[4]`
- Tip: `report[5].IsBitSet(2)` → `report[1].IsBitSet(0)`
- Buttons: `report[5].IsBitSet(3/4)` → `report[1].IsBitSet(3/4)`

**`GeniusReportParser.cs`**
- `0x10 => new TabletReport(data)` → `0x10 => new GeniusTabletReport(data)`

## Testing

Verified on macOS arm64 (Apple Silicon) with OTD built from source. Pressure ranges 0–1023, tip detection correct, both pen buttons working. Position tracking confirmed accurate across the full tablet surface.

## Co-authorship note

This fix was developed collaboratively with [Claude Code](https://claude.ai/code) (Anthropic's AI coding assistant). We want to be transparent about that — but this is not AI-generated slop. The byte layout was determined empirically through systematic hardware testing before any code was written. The AI assisted with writing and iterating the diagnostic tooling, interpreting the captured data, and implementing the fix — but every claim about the byte layout is backed by direct measurement from the actual device.

The diagnostic scripts used to discover this layout are available at https://github.com/JohnnyFoulds/genius-i405x-macos.

Co-authored-by: Claude Code (Anthropic) <noreply@anthropic.com>