### PR TITLE
Add support for LetSketch WP9620C and rename existing LetSketch WP9620C to LetSketch WP9622C

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/LetSketch/WP9622C.json
+++ b/OpenTabletDriver.Configurations/Configurations/LetSketch/WP9622C.json
@@ -1,14 +1,14 @@
 {
-  "Name": "LetSketch WP9620C",
+  "Name": "LetSketch WP9622C",
   "Specifications": {
     "Digitizer": {
-      "Width": 254,
-      "Height": 158.75,
-      "MaxX": 50800,
-      "MaxY": 31750
+      "Width": 269.445,
+      "Height": 167.955,
+      "MaxX": 53889,
+      "MaxY": 33591
     },
     "Pen": {
-      "MaxPressure": 8192,
+      "MaxPressure": 8191,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {
@@ -22,12 +22,11 @@
       "InputReportLength": 12,
       "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicTiltReportParser",
       "DeviceStrings": {
-        "2": "LetSketch",
-        "32": "LetSketch",
+        "2": "LetSketch Technology",
+        "32": "LetSketch Technology Co\\. , LTD\\.",
         "201": "Vision_V201_\\d{6}"
       },
       "InitializationStrings": [
-        250,
         200
       ]
     }

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -70,6 +70,7 @@
 | Huion WH1409                       |     Supported     |
 | Huion WH1409 V2                    |     Supported     |
 | LetSketch WP9620C                  |     Supported     |
+| LetSketch WP9622C                  |     Supported     |
 | Parblo A609                        |     Supported     |
 | Parblo A610 Pro (Variant 2)        |     Supported     |
 | Parblo A640 V2                     |     Supported     |


### PR DESCRIPTION
Verification: https://discord.com/channels/615607687467761684/615611007951306863/1530330823037816912, (max positions) https://discord.com/channels/615607687467761684/615611007951306863/1530327163159580846, (max pressure) https://discord.com/channels/615607687467761684/615611007951306863/1530327434258415780

**The 8192 pressure max is not a mistake.**

Manufacturer driver pcap: [capture.zip](https://github.com/user-attachments/files/30363513/capture.zip)
Requests the following strings: (`5`, `5`, `6`, `200`, `201`, `202`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`, `10`, `11`, `12`, `13`, `14`, `15`, `16`, `17`, `18`, `19`, `20`, `21`, `22`, `23`, `24`, `25`, `26`, `27`, `28`, `29`, `30`, `31`, `32`, `33`, `34`, `35`, `36`, `37`, `38`, `39`, `40`, `41`, `42`, `43`, `44`, `45`, `46`, `47`, `48`, `49`, `50`, `51`, `52`, `53`, `54`, `55`, `56`, `57`, `58`, `59`, `60`, `61`, `62`, `63`, `64`, `65`, `66`, `67`, `68`, `69`, `70`, `71`, `72`, `73`, `74`, `75`, `76`, `77`, `78`, `79`, `80`, `81`, `82`, `83`, `84`, `85`, `86`, `87`, `88`, `89`, `90`, `91`, `92`, `93`, `94`, `95`, `96`, `97`, `98`, `99`, `100`, `101`, `102`, `103`, `104`, `105`, `106`, `107`, `108`, `109`, `110`, `111`, `112`, `113`, `114`, `115`, `116`, `117`, `118`, `119`, `120`, `121`, `122`, `123`, `124`, `125`, `126`, `127`, `128`, `129`, `130`, `131`, `132`, `133`, `134`, `135`, `136`, `137`, `138`, `139`, `140`, `141`, `142`, `143`, `144`, `145`, `146`, `147`, `148`, `149`, `150`, `151`, `152`, `153`, `154`, `155`, `156`, `157`, `158`, `159`, `160`, `161`, `162`, `163`, `164`, `165`, `166`, `167`, `168`, `169`, `170`, `171`, `172`, `173`, `174`, `175`, `176`, `177`, `178`, `179`, `180`, `181`, `182`, `183`, `184`, `185`, `186`, `187`, `188`, `189`, `190`, `191`, `192`, `193`, `194`, `195`, `196`, `197`, `198`, `199`, `200`, `201`, `202`, `203`, `204`, `205`, `206`, `207`, `208`, `209`, `210`, `211`, `212`, `213`, `214`, `215`, `216`, `217`, `218`, `219`, `220`, `221`, `222`, `223`, `224`, `225`, `226`, `227`, `228`, `229`, `230`, `231`, `232`, `233`, `234`, `235`, `236`, `237`, `238`, `239`, `240`, `241`, `242`, `243`, `244`, `245`, `246`, `247`, `248`, `249`, `250`, `100`, `200`)
But narrowed this down to only needing `250` and `200`. Also has a featureinit `0x00` which was not required.

String dump: [string-dump_24929-19733.txt](https://github.com/user-attachments/files/30363531/string-dump_24929-19733.txt)

Reference string dump for `LetSketch WP9622C` from #4550: [letsketch-wp9620c-strings-2.txt](https://github.com/user-attachments/files/30363539/letsketch-wp9620c-strings-2.txt)

Verification that previous user did not have `LetSketch WP9620C` and instead had `LetSketch WP9622C`: https://discord.com/channels/615607687467761684/1472556607056646216/1472652533812957349
Verification that current user has `LetSketch WP9620C`: https://discord.com/channels/615607687467761684/615611007951306863/1530328195944022076