### PR TITLE
Add support for huion KD200

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Huion/KD200.json
+++ b/OpenTabletDriver.Configurations/Configurations/Huion/KD200.json
@@ -1,0 +1,41 @@
+{
+  "Name": "Huion KD200",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 228.6,
+      "Height": 142.875,
+      "MaxX": 45720,
+      "MaxY": 28575
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 6
+    },
+    "Wheels": [
+      {
+        "RelativeWheelSteps": 24,
+        "ButtonCount": 0
+      }
+    ]
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 9580,
+      "ProductID": 109,
+      "InputReportLength": 12,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Huion.GianoReportParser",
+      "DeviceStrings": {
+        "201": "HUION_T197_\\d{6}$"
+      },
+      "InitializationStrings": [
+        200
+      ]
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -57,6 +57,7 @@
 | Huion Kamvas Pro 19 (4K)           |     Supported     |
 | Huion Kamvas Pro 24 (4K)           |     Supported     |
 | Huion Kamvas Pro 27                |     Supported     |
+| Huion KD200                        |     Supported     | Only 6 keys are auxiliary buttons.
 | Huion L310                         |     Supported     |
 | Huion L610                         |     Supported     |
 | Huion New 1060 Plus                |     Supported     |


### PR DESCRIPTION
Verification: https://discord.com/channels/615607687467761684/1179851852523765960/1531167497766834307

Diag (undetected): [Diagnostics-067 Huion KD200.json](https://github.com/user-attachments/files/30400065/Diagnostics-067.Huion.KD200.json)

String 201 (from a different user but matches this user's tablet too):
<img width="304" height="287" alt="image" src="https://github.com/user-attachments/assets/7a0294e2-79f9-4d87-b494-99ed8d2b2bad" />

Data is muddy since user had the pen on the tablet while getting the data.
Aux buttons and wheel data: [tablet-data_1785127454.txt](https://github.com/user-attachments/files/30400049/tablet-data_1785127454.txt)
Wheel data: [tablet-data_1785127660.txt](https://github.com/user-attachments/files/30400056/tablet-data_1785127660.txt)

The config creation thread for this tablet has some other users with a variant of this tablet that has pid 100 rather than 109. Not doing anything preemptive there.

Although this tablet has a note in tablets.md I'm not putting it in quirks since this is simply the intended behavior of the tablet. Note added since it's possible users could be confused about it. The tablet has half of a keyboard tacked onto the side of it and most of the keyboard simply acts as a regular keyboard device separate from the tablet. Keys K1-K5 and the profile switch key are the 6 keys that act as customizeable aux buttons.

[Huion says](https://www.huion.com/products/inspiroy-keydial-kd200) the tablet has "23 Standard keys, 5 Programmable Press Keys+Dial" but for some reason they dont count the profile switching button which reports as an aux key. So for OTD's purposes we have 6 aux buttons.

<img width="1250" height="625" alt="image" src="https://github.com/user-attachments/assets/e5da284f-1eea-497f-8fa7-de7d6d53e1ee" />
