### PR TITLE
Add UCLogicAuxRelWheelReport to KamvasOffsetReportParser

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/Huion/KamvasOffsetReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Huion/KamvasOffsetReportParser.cs
@@ -11,6 +11,8 @@ namespace OpenTabletDriver.Configurations.Parsers.Huion
         {
             if (data[1] == 0xF1)
                 return new KamvasRelWheelReport(data);
+            if (data[1] == 0xF0)
+                return new UCLogicAuxRelWheelReport(data);
             if (data[1].IsBitSet(5) && data[1].IsBitSet(6))
                 return new UCLogicAuxReport(data);
             else


### PR DESCRIPTION
Mirrors #4788 but for the KamvasOffsetReportParser

Data recording of wheel 1 then wheel 2 back and forth on `Huion Kamvas 16 (Gen 3)` which is the only tablet using this parser: [tablet-data_1785356334.txt](https://github.com/user-attachments/files/30521117/tablet-data_1785356334.txt)

Verification: https://discord.com/channels/615607687467761684/723399565780189234/1532376845369086075