### PR TITLE
XP-Pen Deco Pro Medium: add support for the second wheel within the trackpad

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro Medium.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro Medium.json
@@ -13,7 +13,13 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 8
-    }
+    },
+    "Wheels": [
+      {
+        "RelativeWheelSteps": 24,
+        "ButtonCount": 0
+      }
+    ]
   },
   "DigitizerIdentifiers": [
     {

--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro Medium.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco Pro Medium.json
@@ -18,6 +18,10 @@
       {
         "RelativeWheelSteps": 24,
         "ButtonCount": 0
+      },
+      {
+        "RelativeWheelSteps": 24,
+        "ButtonCount": 0
       }
     ]
   },
@@ -27,7 +31,7 @@
       "ProductID": 2308,
       "InputReportLength": 10,
       "OutputReportLength": 10,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParserV2",
       "OutputInitReport": [
         "ArAE"
       ]

--- a/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenAuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenAuxReport.cs
@@ -5,7 +5,7 @@ namespace OpenTabletDriver.Configurations.Parsers.XP_Pen
 {
     public struct XP_PenAuxReport : IAuxReport, IRelativeWheelReport
     {
-        public XP_PenAuxReport(byte[] report, int auxIndex = 2, int wheelIndex = 7)
+        public XP_PenAuxReport(byte[] report, int auxIndex = 2, int wheelIndex = 7, int secondWheelBitOffset = 0)
         {
             Raw = report;
 
@@ -35,10 +35,11 @@ namespace OpenTabletDriver.Configurations.Parsers.XP_Pen
 
             // 0x01 for 1st wheel clockwise, 0x02 for counterclockwise, verified on XP Pen Artist 13.3 Pro V2
             // 0x10 for 2nd wheel clockwise, 0x20 for counterclockwise, verified on XP Pen Artist 22R Pro
+            // 0x04 for 2nd wheel clockwise, 0x08 for counterclockwise, verified on XP Pen Deco Pro Medium
             AnalogDeltas =
             [
                 report[wheelIndex].IsBitSet(0) ? 1 : report[wheelIndex].IsBitSet(1) ? -1 : 0,
-                report[wheelIndex].IsBitSet(4) ? 1 : report[wheelIndex].IsBitSet(5) ? -1 : 0,
+                report[wheelIndex].IsBitSet(4 + secondWheelBitOffset) ? 1 : report[wheelIndex].IsBitSet(5 + secondWheelBitOffset) ? -1 : 0,
             ];
         }
 

--- a/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenReportParserV2.cs
+++ b/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenReportParserV2.cs
@@ -1,0 +1,29 @@
+using System.Diagnostics.CodeAnalysis;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.XP_Pen
+{
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    public class XP_PenReportParserV2 : IReportParser<IDeviceReport>
+    {
+        public IDeviceReport Parse(byte[] report)
+        {
+            if (report[1] == 0xC0)
+                return new OutOfRangeReport(report);
+
+            // The tablet throw inits sent its way back to us, we ignore them.
+            if (report[1] == 0xB4)
+                return new DeviceReport(report);
+
+            if (report[1].IsBitSet(4))
+                return new XP_PenAuxReport(report, secondWheelBitOffset: -2);
+
+            if (report.Length >= 12)
+                return new XP_PenTabletOverflowReport(report);
+            else if (report.Length >= 10)
+                return new XP_PenTabletReport(report);
+            else
+                return new TabletReport(report);
+        }
+    }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -346,7 +346,7 @@
 | XP-Pen Artist Pro 19 (Gen2)        |  Missing Features | Scroll Wheel on Pen is not yet supported
 | XP-Pen Deco 02                     |  Missing Features | Wheel is not yet supported.
 | XP-Pen Deco mini7W V2              |  Missing Features | Wireless is not yet supported.
-| XP-Pen Deco Pro Medium             |  Missing Features | Trackpad is not yet supported.
+| XP-Pen Deco Pro Medium             |  Missing Features | Trackpad as a mouse is not yet supported.
 | XP-Pen Deco Pro Small              |  Missing Features | Trackpad is not yet supported.
 | XP-Pen Deco Pro SW                 |  Missing Features | Wheel is not yet supported.
 | XP-Pen Deco Pro MW                 |  Missing Features | Touch wheel and physical wheel are not yet supported.

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -346,7 +346,7 @@
 | XP-Pen Artist Pro 19 (Gen2)        |  Missing Features | Scroll Wheel on Pen is not yet supported
 | XP-Pen Deco 02                     |  Missing Features | Wheel is not yet supported.
 | XP-Pen Deco mini7W V2              |  Missing Features | Wireless is not yet supported.
-| XP-Pen Deco Pro Medium             |  Missing Features | Tilt and wheel are not yet supported.
+| XP-Pen Deco Pro Medium             |  Missing Features | Trackpad is not yet supported.
 | XP-Pen Deco Pro Small              |  Missing Features | Trackpad is not yet supported.
 | XP-Pen Deco Pro SW                 |  Missing Features | Wheel is not yet supported.
 | XP-Pen Deco Pro MW                 |  Missing Features | Touch wheel and physical wheel are not yet supported.


### PR DESCRIPTION
This is basically a copy of what is there for the XP-Pen Deco Pro Small, as it's effectively the same thing but bigger. Works just fine with my device.

While doing this I realised there are a few other tablets with wheels but no explicit support for them in the config file, such as the "Deco Pro MW Gen2"; is there a particular reason for this, given the parsing code is already there? This was just an example, by the way, I only own the Deco Pro M.

PS.: are there plans/is it within OTD's scope to add trackpad support? Or, if it already exists, what steps do I need to take in regards to the configuration file?