### PR TITLE
Add support for Wacom Cintiq 32 Pro (DTH-3220)

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTH-3220.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTH-3220.json
@@ -1,0 +1,27 @@
+{
+  "Name": "Wacom Cintiq Pro 32 Touch (DTH-3220)",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 701.92,
+      "Height": 396.58,
+      "MaxX": 140384,
+      "MaxY": 79316
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ButtonCount": 2
+    }
+    
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 1386,
+      "ProductID": 850,
+      "InputReportLength": 192,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Wacom.IntuosV2.IntuosV2ReportParser",
+      "FeatureInitReport": [
+        "AgI="
+      ]
+    }
+  ]
+}

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTH-3220.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTH-3220.json
@@ -11,7 +11,6 @@
       "MaxPressure": 8191,
       "ButtonCount": 2
     }
-    
   },
   "DigitizerIdentifiers": [
     {

--- a/OpenTabletDriver.Configurations/Configurations/Wacom/DTH-3220.json
+++ b/OpenTabletDriver.Configurations/Configurations/Wacom/DTH-3220.json
@@ -1,5 +1,5 @@
 {
-  "Name": "Wacom Cintiq Pro 32 Touch (DTH-3220)",
+  "Name": "Wacom Cintiq Pro 32 (DTH-3220)",
   "Specifications": {
     "Digitizer": {
       "Width": 701.92,

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -327,6 +327,7 @@
 | Wacom Cintiq 22HD Touch (DTH-2200) |  Missing Features | Touch is not yet supported.
 | Wacom Cintiq Pro 22 (DTH-227)      |  Missing Features | Touch is not yet supported.
 | Wacom Cintiq Pro 27 (DTH-271)      |  Missing Features | Aux buttons are not yet supported.
+| Wacom Cintiq Pro 32 (DTH-3220)     |  Missing Features | Touch is not yet supported.
 | Wacom Cintiq 13HD Touch (DTH-1300) |  Missing Features | Center button is not yet supported.
 | Wacom Cintiq 13HD (DTK-1300)       |  Missing Features | Center button is not yet supported.
 | Wacom Cintiq 21UX (DTZ-2100)       |  Missing Features | Touch bars are not yet supported.


### PR DESCRIPTION
Added DTH-3220.json to configurations
Updated TABLETS.md

USER NOTES:
- Touch is not supported. 
- User will require using a calibration plugin so that pointer pointer and pen tip are aligned

DEVNOTES: 
- Kuuube walked me through config creation process
- Screenshot of max position attached
- Diagnostics attached

<img width="528" height="405" alt="image" src="https://github.com/user-attachments/assets/daeec063-5fc2-4c01-b5f9-14aa75a0adb8" />

[Diagnostics-067 Wacom Cintiq Pro 32 Touch (DTH-3220).json](https://github.com/user-attachments/files/30639686/Diagnostics-067.Wacom.Cintiq.Pro.32.Touch.DTH-3220.json)

