### PR TITLE
Added GaomonM6 ProductId 100 wheel support, and corrected its max pressure.

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/M6.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/M6.json
@@ -8,19 +8,26 @@
       "MaxY": 31750
     },
     "Pen": {
-      "MaxPressure": 8191,
+      "MaxPressure": 16383,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {
       "ButtonCount": 13
-    }
+    },
+    "Wheels": [
+      {
+        "AbsoluteWheelMax": 11,
+        "AngleOfZeroReading": 0.0,
+        "ButtonCount": 0
+      }
+    ]
   },
   "DigitizerIdentifiers": [
     {
       "VendorID": 9580,
       "ProductID": 100,
       "InputReportLength": 12,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicV2ReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Gaomon.GaomonM6ReportParser",
       "DeviceStrings": {
         "201": "(OEM02_T183|GM001_T223)_\\d{6}$"
       },

--- a/OpenTabletDriver.Configurations/Parsers/Gaomon/GaomonM6ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Gaomon/GaomonM6ReportParser.cs
@@ -12,7 +12,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Gaomon
             return data[1] switch
             {
                 0xe0 => new UCLogicAuxReport(data),
-                // 0xf0 is for wheel data, reported in data[5]
+                // 0xf0 is wheel mode, data[5] contains absolute position (1~12)
                 0xf0 => new GaomonM6WheelReport(data),
                 _ => new TiltTabletReport(data)
             };

--- a/OpenTabletDriver.Configurations/Parsers/Gaomon/GaomonM6ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Gaomon/GaomonM6ReportParser.cs
@@ -1,0 +1,21 @@
+using System.Diagnostics.CodeAnalysis;
+using OpenTabletDriver.Configurations.Parsers.UCLogic;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Gaomon
+{
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    public class GaomonM6ReportParser : IReportParser<IDeviceReport>
+    {
+        public IDeviceReport Parse(byte[] data)
+        {
+            return data[1] switch
+            {
+                0xe0 => new UCLogicAuxReport(data),
+                // 0xf0 is for wheel data, reported in data[5]
+                0xf0 => new GaomonM6WheelReport(data),
+                _ => new TiltTabletReport(data)
+            };
+        }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Gaomon/GaomonM6WheelReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Gaomon/GaomonM6WheelReport.cs
@@ -1,0 +1,17 @@
+using OpenTabletDriver.Plugin.Tablet.Wheel;
+
+namespace OpenTabletDriver.Configurations.Parsers.Gaomon
+{
+    public struct GaomonM6WheelReport : IAbsoluteWheelReport
+    {
+        public GaomonM6WheelReport(byte[] data)
+        {
+            Raw = data;
+            byte wheelData = data[5];
+            AnalogPositions = [wheelData != 0 ? wheelData-1u : null];
+        }
+
+        public byte[] Raw { get; set; }
+        public uint?[] AnalogPositions { get; set; }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Gaomon/GaomonM6WheelReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Gaomon/GaomonM6WheelReport.cs
@@ -8,6 +8,8 @@ namespace OpenTabletDriver.Configurations.Parsers.Gaomon
         {
             Raw = data;
             byte wheelData = data[5];
+            // Map hardware range 1~12 to framework range 0~11 for AbsoluteWheelMax: 11.
+            // null means no touch on ring.
             AnalogPositions = [wheelData != 0 ? wheelData-1u : null];
         }
 

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -272,7 +272,7 @@
 | Gaomon M10K Pro                    |  Missing Features | Wheel is not yet supported.
 | Gaomon M1220                       |  Missing Features | Wheel is not yet supported.
 | Gaomon M1230                       |  Missing Features | Touch bar is not yet supported.
-| Gaomon M6                          |  Missing Features | Wheel and touch bar are not yet supported.
+| Gaomon M6                          |  Missing Features | Touch bar is not yet supported.
 | Gaomon M8                          |  Missing Features | Wheel is not yet supported.
 | Gaomon M8 (Variant 2)              |  Missing Features | Wheel is not yet supported.
 | Gaomon PD156 Pro                   |  Missing Features | Wheel is not yet supported.

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -272,7 +272,7 @@
 | Gaomon M10K Pro                    |  Missing Features | Wheel is not yet supported.
 | Gaomon M1220                       |  Missing Features | Wheel is not yet supported.
 | Gaomon M1230                       |  Missing Features | Touch bar is not yet supported.
-| Gaomon M6                          |  Missing Features | Touch bar is not yet supported.
+| Gaomon M6                          |  Missing Features | Touch bar is not yet supported; PID 109 wheel is not yet supported.
 | Gaomon M8                          |  Missing Features | Wheel is not yet supported.
 | Gaomon M8 (Variant 2)              |  Missing Features | Wheel is not yet supported.
 | Gaomon PD156 Pro                   |  Missing Features | Wheel is not yet supported.


### PR DESCRIPTION
**Changes:**
- Added wheel support (hardware 1–12 → framework 0–11) for Gaomon M6 (PID 100)~
- Corrected pen pressure from 8191 to 16383!
- Updated TABLETS.md

**Verification:**
- Device tested on my own Gaomon M6 (PID 100). Diagnostics export and debugger screenshot attached.
- All `dotnet test` checks passed.

**Limitations:**
- I only have PID 100, so PID 109 remains using the default parser... (QwQ)
- Touch bar is not yet supported on any PID!

<img width="1313" height="1374" alt="debugger screenshot" src="https://github.com/user-attachments/assets/4d86f92c-f3cb-4b48-981b-075eb18cf83e" />

[Diagnostics-067 Gaomon M6.json](https://github.com/user-attachments/files/30710013/Diagnostics-067.Gaomon.M6.json)

OvO
