### PR TITLE
Add mouse scroll support to the evdev virtual tablet (Artist Mode)

### DIFF
--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -8,13 +8,15 @@ using OpenTabletDriver.Plugin.Platform.Pointer;
 
 namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
 {
-    public class EvdevVirtualTablet : IPenActionHandler, IAbsolutePointer, IPressureHandler, ITiltHandler, IEraserHandler, IHoverDistanceHandler, ISynchronousPointer, IDisposable
+    public class EvdevVirtualTablet : IPenActionHandler, IAbsolutePointer, IPressureHandler, ITiltHandler, IEraserHandler, IHoverDistanceHandler, IMouseScrollHandler, ISynchronousPointer, IDisposable
     {
         private const int RESOLUTION = 1000; // subpixels per screen pixel
 
         private bool isEraser;
 
         private readonly EvdevDevice Device;
+
+        private readonly EvdevDevice ScrollDevice;
 
         private EventCode[] supportedEventCodes =
         [
@@ -94,6 +96,27 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
                     Log.WriteNotify("Evdev", $"Failed to initialize virtual pressure sensitive tablet. (error code {result})", LogLevel.Error);
                     break;
             }
+
+            // A separate virtual mouse is used for the touch ring/wheel scroll events.
+            // This keeps the pen tablet device free of relative axes, since compositors
+            // (libinput) do not route REL_WHEEL from a tablet-class device.
+            ScrollDevice = new EvdevDevice("OpenTabletDriver Virtual Scroll Mouse");
+            ScrollDevice.EnableTypeCodes(
+                EventType.EV_REL,
+                EventCode.REL_WHEEL,
+                EventCode.REL_WHEEL_HI_RES,
+                EventCode.REL_HWHEEL,
+                EventCode.REL_HWHEEL_HI_RES
+            );
+            ScrollDevice.EnableTypeCodes(
+                EventType.EV_KEY,
+                EventCode.BTN_LEFT,
+                EventCode.BTN_RIGHT,
+                EventCode.BTN_MIDDLE
+            );
+            var scrollResult = ScrollDevice.Initialize();
+            if (scrollResult != ERRNO.NONE)
+                Log.WriteNotify("Evdev", $"Failed to initialize virtual scroll mouse. (error code {scrollResult})", LogLevel.Error);
         }
 
         private const int MaxPressure = ushort.MaxValue;
@@ -136,6 +159,16 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
             Device.Write(EventType.EV_ABS, EventCode.ABS_DISTANCE, (int)distance);
         }
 
+        public void ScrollVertically(int amount)
+        {
+            ScrollDevice.Write(EventType.EV_REL, EventCode.REL_WHEEL_HI_RES, amount);
+        }
+
+        public void ScrollHorizontally(int amount)
+        {
+            ScrollDevice.Write(EventType.EV_REL, EventCode.REL_HWHEEL_HI_RES, amount);
+        }
+
         public void SetKeyState(EventCode eventCode, bool state)
         {
             Device.Write(EventType.EV_KEY, eventCode, state ? 1 : 0);
@@ -175,7 +208,10 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
             if (_isDisposed) return;
 
             if (disposing)
+            {
                 Device.Dispose();
+                ScrollDevice.Dispose();
+            }
 
             _isDisposed = true;
         }
@@ -183,6 +219,7 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
         public void Flush()
         {
             Device.Sync();
+            ScrollDevice.Sync();
         }
 
         public void Activate(PenAction action)


### PR DESCRIPTION
The Linux Artist Mode output only creates a virtual pen tablet, so mouse scroll bindings (touch ring/wheel) could not emit scroll events on Wayland: the binding's `[Resolved]` `IMouseScrollHandler` was null and the daemon logged `IMouseScrollHandler unavailable`.

This creates a separate evdev virtual mouse for scroll events and makes the virtual tablet implement `IMouseScrollHandler`, so wheel bindings work in Artist Mode alongside the pen tablet.

The scroll device enables the same REL codes (`REL_WHEEL`, `REL_WHEEL_HI_RES`, `REL_HWHEEL`, `REL_HWHEEL_HI_RES`) as the existing `EvdevAbsolutePointer`.

### Testing
Verified with a Gaomon M6 touch ring on Wayland (niri): scrolling works in Artist Mode, and the pen remains in tablet mode.