### PR TITLE
Ignore init report, idle & wireless ON signal reports

### DIFF
--- a/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenGen2ReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenGen2ReportParser.cs
@@ -10,10 +10,27 @@ namespace OpenTabletDriver.Configurations.Parsers.XP_Pen
         {
             if (report[1] == 0xC0)
                 return new OutOfRangeReport(report);
+
+            // The tablet throw inits sent its way back to us, we ignore them.
+            if (report[1] == 0xB4)
+                return new DeviceReport(report);
+
+            // Ignore idle reports, as they were parsed as aux reports previously.
+            // see https://github.com/OpenTabletDriver/OpenTabletDriver/issues/4988 for more details
+            if (report[1] == 0xF2)
+                return new DeviceReport(report);
+
+            // Ignore ON report when toggling ON tablets using the wireless dongle from XP-Pen.
+            // see https://github.com/OpenTabletDriver/OpenTabletDriver/issues/4988 for more details
+            if (report[1] == 0xF8)
+                return new DeviceReport(report);
+
             if (report[1] == 0xF0)
                 return new XP_PenAuxReport(report);
+
             if ((report[1] & 0xF0) == 0xA0)
                 return new XP_PenTabletGen2Report(report);
+
             return new DeviceReport(report);
         }
     }

--- a/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenOffsetPressureReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenOffsetPressureReportParser.cs
@@ -23,7 +23,7 @@ namespace OpenTabletDriver.Configurations.Parsers.XP_Pen
             // Ignore ON report when toggling ON tablets using the wireless dongle from XP-Pen.
             // see https://github.com/OpenTabletDriver/OpenTabletDriver/issues/4988 for more details
             if (report[1] == 0xF8)
-                return new XP_PenAuxReport(report);
+                return new DeviceReport(report);
 
             if (report[1].IsBitSet(4))
                 return new XP_PenAuxReport(report);

--- a/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenOffsetPressureReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenOffsetPressureReportParser.cs
@@ -11,6 +11,20 @@ namespace OpenTabletDriver.Configurations.Parsers.XP_Pen
             if (report[1] == 0xC0)
                 return new OutOfRangeReport(report);
 
+            // The tablet throw inits sent its way back to us, we ignore them.
+            if (report[1] == 0xB4)
+                return new DeviceReport(report);
+
+            // Ignore idle reports, as they were parsed as aux reports previously.
+            // see https://github.com/OpenTabletDriver/OpenTabletDriver/issues/4988 for more details
+            if (report[1] == 0xF2)
+                return new DeviceReport(report);
+
+            // Ignore ON report when toggling ON tablets using the wireless dongle from XP-Pen.
+            // see https://github.com/OpenTabletDriver/OpenTabletDriver/issues/4988 for more details
+            if (report[1] == 0xF8)
+                return new XP_PenAuxReport(report);
+
             if (report[1].IsBitSet(4))
                 return new XP_PenAuxReport(report);
 

--- a/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenReportParser.cs
@@ -23,7 +23,7 @@ namespace OpenTabletDriver.Configurations.Parsers.XP_Pen
             // Ignore ON report when toggling ON tablets using the wireless dongle from XP-Pen.
             // see https://github.com/OpenTabletDriver/OpenTabletDriver/issues/4988 for more details
             if (report[1] == 0xF8)
-                return new XP_PenAuxReport(report);
+                return new DeviceReport(report);
 
             if (report[1].IsBitSet(4))
                 return new XP_PenAuxReport(report);

--- a/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenReportParser.cs
@@ -11,6 +11,15 @@ namespace OpenTabletDriver.Configurations.Parsers.XP_Pen
             if (report[1] == 0xC0)
                 return new OutOfRangeReport(report);
 
+            // The tablet throw inits sent its way back to us, we ignore them.
+            if (report[1] == 0xB4)
+                return new DeviceReport(report);
+
+            // Ignore idle reports, as they were parsed as aux reports previously.
+            // see https://github.com/OpenTabletDriver/OpenTabletDriver/issues/4988 for more details
+            if (report[1] == 0xF2)
+                return new DeviceReport(report);
+
             if (report[1].IsBitSet(4))
                 return new XP_PenAuxReport(report);
 

--- a/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/XP_Pen/XP_PenReportParser.cs
@@ -20,6 +20,11 @@ namespace OpenTabletDriver.Configurations.Parsers.XP_Pen
             if (report[1] == 0xF2)
                 return new DeviceReport(report);
 
+            // Ignore ON report when toggling ON tablets using the wireless dongle from XP-Pen.
+            // see https://github.com/OpenTabletDriver/OpenTabletDriver/issues/4988 for more details
+            if (report[1] == 0xF8)
+                return new XP_PenAuxReport(report);
+
             if (report[1].IsBitSet(4))
                 return new XP_PenAuxReport(report);
 


### PR DESCRIPTION
XP-Pen sends multiple problematic reports : 

- Init reports : The report we ourselves, send, are inteprated as aux reports. (0xB4, where bit index 4 is set)
- Idle reports : These reports as 0xF2, which means that bit index 4 is set, bad.

Fixes #4988

Verification : https://discord.com/channels/615607687467761684/723399565780189234/1537209759248289833