### PR TITLE
Parblo Intangbo S: wheel support

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Intangbo S.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Intangbo S.json
@@ -13,7 +13,13 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 6
-    }
+    },
+    "Wheels": [
+      {
+        "RelativeWheelSteps": 24,
+        "ButtonCount": 1
+      }
+    ]
   },
   "DigitizerIdentifiers": [
     {
@@ -31,7 +37,7 @@
       "ProductID": 40980,
       "InputReportLength": 1101,
       "OutputReportLength": 1101,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenReportParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Parblo.ParbloIntangboSParser",
       "OutputInitReport": [
         "ArAE"
       ]

--- a/OpenTabletDriver.Configurations/Configurations/Parblo/Intangbo S.json
+++ b/OpenTabletDriver.Configurations/Configurations/Parblo/Intangbo S.json
@@ -37,7 +37,7 @@
       "ProductID": 40980,
       "InputReportLength": 1101,
       "OutputReportLength": 1101,
-      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Parblo.ParbloIntangboSParser",
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Parblo.ParbloIntangboSReportParser",
       "OutputInitReport": [
         "ArAE"
       ]

--- a/OpenTabletDriver.Configurations/Parsers/Parblo/ParbloIntangboSAuxReport.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Parblo/ParbloIntangboSAuxReport.cs
@@ -1,0 +1,60 @@
+using OpenTabletDriver.Plugin.Tablet;
+using OpenTabletDriver.Plugin.Tablet.Wheel;
+
+namespace OpenTabletDriver.Configurations.Parsers.Parblo
+{
+    public struct ParbloIntangboSAuxReport : IRelativeWheelReport, IWheelButtonReport, IAuxReport
+    {
+        public ParbloIntangboSAuxReport(byte[] report)
+        {
+            Raw = report;
+            int wheelDataIndex = 3;
+            int auxIndex = 2;
+            if (report[auxIndex] != 0 && report[wheelDataIndex] != 0)
+            {
+                AnalogDeltas =
+                [
+                    report[wheelDataIndex] switch
+                    {
+                        1 => 1,
+                        2 => -1,
+                        _ => 0,
+                    },
+                ];
+                WheelButtons =
+                [
+                    [
+                        report[wheelDataIndex] switch
+                        {
+                            3 => true,
+                            _ => false,
+                        },
+                    ],
+                ];
+                AuxButtons = [false, false, false, false, false, false];
+            }
+            else
+            {
+                AnalogDeltas = [0];
+                WheelButtons =
+                [
+                    [false],
+                ];
+                AuxButtons =
+                [
+                    report[auxIndex].IsBitSet(0),
+                    report[auxIndex].IsBitSet(1),
+                    report[auxIndex].IsBitSet(2),
+                    report[auxIndex].IsBitSet(3),
+                    report[auxIndex].IsBitSet(4),
+                    report[auxIndex].IsBitSet(5),
+                ];
+            }
+        }
+
+        public byte[] Raw { set; get; }
+        public int[] AnalogDeltas { get; set; }
+        public bool[][] WheelButtons { get; set; }
+        public bool[] AuxButtons { get; set; }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Parblo/ParbloIntangboSReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Parblo/ParbloIntangboSReportParser.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics.CodeAnalysis;
+using OpenTabletDriver.Configurations.Parsers.XP_Pen;
+using OpenTabletDriver.Plugin.Tablet;
+
+namespace OpenTabletDriver.Configurations.Parsers.Parblo
+{
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    public class ParbloIntangboSParser : IReportParser<IDeviceReport>
+    {
+        public IDeviceReport? Parse(byte[]? report)
+        {
+            if (report == null || report.Length == 0)
+                return null;
+            if (report[1] == 0xC0)
+                return new OutOfRangeReport(report);
+            if (report[1].IsBitSet(4))
+                return new ParbloIntangboSAuxReport(report);
+            if (report.Length >= 12)
+                return new XP_PenTabletOverflowReport(report);
+            else if (report.Length >= 10)
+                return new XP_PenTabletReport(report);
+            else
+                return new TabletReport(report);
+        }
+    }
+}

--- a/OpenTabletDriver.Configurations/Parsers/Parblo/ParbloIntangboSReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Parblo/ParbloIntangboSReportParser.cs
@@ -5,7 +5,7 @@ using OpenTabletDriver.Plugin.Tablet;
 namespace OpenTabletDriver.Configurations.Parsers.Parblo
 {
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
-    public class ParbloIntangboSParser : IReportParser<IDeviceReport>
+    public class ParbloIntangboSReportParser : IReportParser<IDeviceReport>
     {
         public IDeviceReport? Parse(byte[]? report)
         {

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -75,6 +75,7 @@
 | Parblo A609                        |     Supported     |
 | Parblo A610 Pro (Variant 2)        |     Supported     |
 | Parblo A640 V2                     |     Supported     |
+| Parblo Intangbo S                  |     Supported     |
 | Parblo Ninos N10B                  |     Supported     |
 | Parblo Ninos N4                    |     Supported     |
 | Parblo Ninos N7                    |     Supported     |
@@ -305,7 +306,6 @@
 | Monoprice MP1060-HA60              |  Missing Features | Tablet buttons are not yet supported. Windows: Requires Zadig's WinUSB to be installed on interface 0
 | Parblo A640                        |  Missing Features | Aux buttons are not yet supported.
 | Parblo Intangbo M                  |  Missing Features | Wheel is not yet supported.
-| Parblo Intangbo S                  |  Missing Features | Wheel is not yet supported.
 | Parblo Intangbo SW                 |  Missing Features | Wheel and wireless are not yet supported.
 | UGEE M908                          |  Missing Features | Wheel is not yet supported.
 | UGEE UE16                          |  Missing Features | Wheel is not yet supported.


### PR DESCRIPTION
This PR adds wheel support for Parblo Intangbo S. 

Before, this tablet used a generic XP Pen parser and a config that did not describe wheel properties. This led to:
- No wheel settings in the UI;
- Wheel manipulation being confused with button presses by OTD;
- Wheel button not being recognized and confused with some other buttons as well.

### Reporting structure

I will omit the report types which are related to the digitizer input, because the generic XP reporters handle that part. That is, I will only describe the case when the tablet notifies about button press / wheel rotation. 

The way the report is structured is as follows:
When `report[1].IsBitSet(4)`, that is, the tablet reports about buttons/wheel, we get 10 bytes of leftover data. the 3rd byte is used for all the buttons, excluding the wheel button. In other words, 6 bits in 8th byte are used for auxillary buttons, a bit per button, and 2 bits left unused. 

When any button is released, *all* bytes starting from the 3rd are zeroed. When multiple buttons are pressed, the tablet would only set the bit that corresponds to the last pressed button. Those 2 quirks make it impossible to handle any multiple presses situation. 

The wheel report contains multiple set bits. First, the 3rd byte is set to 8, i.e. `report[2].isBitSet(3) == true`. Note that this bit also corresponds to the 4th aux button on the tablet. Second, the 4th byte is set to 1 or 0000 0001 (clockwise turn), 2  or 0000 0010 (counter-clockwise turn) or 3 or 0000 0011 (wheel button). Also note that button release leads to same result as with aux buttons - all bytes are zeros starting from the 3rd.

#### Some examples of raw tablet data

| What I do | What tablet says |
| ------ | ------ |
| Nothing pressed | `02 F0 00 00 00 00 00 00 00 00` |
| Button 1 pressed | `02 F0 01 00 00 00 00 00 00 00` |
| Button 3 pressed | `02 F0 04 00 00 00 00 00 00 00` |
| Button 3 pressed before button 1 is released | `02 F0 04 00 00 00 00 00 00 00` |
| Button 4 pressed | `02 F0 08 00 00 00 00 00 00 00` |
| Button 6 pressed | `02 F0 20 00 00 00 00 00 00 00` |
|Any button released| `02 F0 00 00 00 00 00 00 00 00` |
| Wheel - turn clockwise |  `02 F0 08 01 00 00 00 00 00 00` |
| Wheel - turn counterclockwise |  `02 F0 08 02 00 00 00 00 00 00` |
| Wheel button pressed |  `02 F0 08 03 00 00 00 00 00 00` |
### Implementation details

I moved the decision on whether the report is about wheel & wheel button or about aux buttons to the reporter, away from parser, for a reason. As mentioned before, the button release report data is identical regardless of what button has been released. So to zero out all the buttons, i.e. both the aux buttons and the center wheel button, when zeros are received, I added every aux feature to one report, couldn't come up with more elegant solution :). If anyone has a better idea, please let me know, I'd be happy to improve the code here. It's not that I have much experience with C# or USB or OTD tbh.

I ran `dotnet format` and `dotnet test` before pushing so those things should be OK, although `dotnet format` found a file out of scope of my changes that has some formatting issues, some other config for another tablet. I removed the changes to that file.

The docs suggest that I might want to follow some sort of convention regarding commit messages and references commits page of that github repo, although I didn't really find that there is any unified style for that. So I tried to get the average idea, hope it's OK. 

### Testing

This works on NixOS 26.11. I didn't test it anywhere else.