### PR TITLE
Set AppInfo.Version property to backing AppInfo.assemblyVersion static field

### DIFF
--- a/OpenTabletDriver.Desktop/AppInfo.cs
+++ b/OpenTabletDriver.Desktop/AppInfo.cs
@@ -13,6 +13,13 @@ namespace OpenTabletDriver.Desktop
 
     public class AppInfo
     {
+        /// <summary>
+        ///   The version of the currently executing assembly
+        /// </summary>
+        /// <remarks>
+        ///   This value is set at compile time, it will differ depending on whether the Daemon, the UX or some other code is using this field.
+        ///   You should rely on <see cref="Version"/> instead.
+        /// </remarks>
         private readonly static Version assemblyVersion = Assembly.GetExecutingAssembly().GetName().Version!;
 
         private string? configurationDirectory,

--- a/OpenTabletDriver.Desktop/AppInfo.cs
+++ b/OpenTabletDriver.Desktop/AppInfo.cs
@@ -13,7 +13,7 @@ namespace OpenTabletDriver.Desktop
 
     public class AppInfo
     {
-        private readonly static Version version = Assembly.GetExecutingAssembly().GetName().Version!;
+        private readonly static Version assemblyVersion = Assembly.GetExecutingAssembly().GetName().Version!;
 
         private string? configurationDirectory,
             settingsFile,
@@ -46,19 +46,16 @@ namespace OpenTabletDriver.Desktop
             {
                 PluginPlatform.Windows => new AppInfo
                 {
-                    Version = version,
                     AppDataDirectory = GetExistingPathOrLast(Path.Join(ProgramDirectory, "userdata"), "$LOCALAPPDATA\\OpenTabletDriver"),
                 },
                 PluginPlatform.Linux => new AppInfo
                 {
-                    Version = version,
                     AppDataDirectory = GetExistingPathOrLast(Path.Join(ProgramDirectory, "userdata"), Path.Join(UnixXdgPath.ConfigHome, "OpenTabletDriver")),
                     TemporaryDirectory = GetPath(Path.Join(UnixXdgPath.RuntimeDir, "OpenTabletDriver")),
                     CacheDirectory = GetPath(Path.Join(UnixXdgPath.CacheHome, "OpenTabletDriver")),
                 },
                 PluginPlatform.MacOS => new AppInfo()
                 {
-                    Version = version,
                     AppDataDirectory = GetExistingPathOrLast(Path.Join(ProgramDirectory, "userdata"), "~/Library/Application Support/OpenTabletDriver"),
                     TemporaryDirectory = GetPath("$TMPDIR/OpenTabletDriver"),
                     CacheDirectory = GetPath("~/Library/Caches/OpenTabletDriver"),
@@ -71,7 +68,7 @@ namespace OpenTabletDriver.Desktop
 
         public static PresetManager PresetManager { set; get; } = new PresetManager();
 
-        public required Version Version { set; get; }
+        public Version Version { set; get; } = assemblyVersion;
 
         public string? CommandLineAppDataDirectory
         {


### PR DESCRIPTION
Instead of only feeding the version when building `AppInfo.Current`, we can feed it directly to the property.
Also add some comments to warn developers about using the `assemblyVersion` static property.