### PR TITLE
Add support for Fansjoy FJ-S1

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Fansjoy/FJ-S1.json
+++ b/OpenTabletDriver.Configurations/Configurations/Fansjoy/FJ-S1.json
@@ -1,0 +1,33 @@
+{
+  "Name": "Fansjoy FJ-S1",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 152,
+      "Height": 95,
+      "MaxX": 15200,
+      "MaxY": 9500
+    },
+    "Pen": {
+      "MaxPressure": 8191,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 5
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 11648,
+      "ProductID": 12305,
+      "InputReportLength": 64,
+      "OutputReportLength": 0,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XENX.XENXReportParser",
+      "FeatureInitReport": [
+        "IAE="
+      ]
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -5,6 +5,7 @@
 | Adesso Cybertablet K8              |     Supported     |
 | Artisul D22S                       |     Supported     |
 | Artisul M0610                      |     Supported     |
+| Fansjoy FJ-S1                      |     Supported     | Rebranded XENX X1-640
 | Gaomon 1060 Pro                    |     Supported     |
 | Gaomon GM116HD                     |     Supported     |
 | Gaomon GM156HD                     |     Supported     |


### PR DESCRIPTION
Fansjoy FJ-S1 is a rebranded XENX X1 with same hardware, same VID and different PID.
All functions have been tested and work properly.
The product can be found at [https://www.fans-joy.com/s](https://www.fans-joy.com/s)