### PR TITLE
Add new Gaomon S830 variant

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/Gaomon/S830.json
+++ b/OpenTabletDriver.Configurations/Configurations/Gaomon/S830.json
@@ -27,6 +27,18 @@
       "InitializationStrings": [
         200
       ]
+    },
+    {
+      "VendorID": 9580,
+      "ProductID": 111,
+      "InputReportLength": 12,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.UCLogic.UCLogicReportParser",
+      "DeviceStrings": {
+        "201": "GM001_T204_\\d{6}$"
+      },
+      "InitializationStrings": [
+        200
+      ]
     }
   ],
   "Attributes": {

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -230,7 +230,7 @@
 | FlooGoo FMA100                     |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 1. Might also need to change the configuration depending on the tablet used.
 | Gaomon S56K                        |    Has Quirks     | Windows: Might need Zadig's WinUSB to be installed on interface 0 or 1
 | Gaomon S630                        |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed on interface 0
-| Gaomon S830                        |    Has Quirks     | User may have to replug their tablet until it is detected.
+| Gaomon S830                        |    Has Quirks     | Some variants may require user replugging their tablet until it is detected.
 | Genius G-Pen F509                  |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed
 | Genius i405x                       |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed
 | Genius i608x                       |    Has Quirks     | Windows: Requires Zadig's WinUSB to be installed


### PR DESCRIPTION
Diag (undetected): [Diagnostics-067-58.json](https://github.com/user-attachments/files/31575428/Diagnostics-067-58.json)
String 201: `GM001_T204_220627`
Confirmation it doesnt do weird bs with strings: https://discord.com/channels/615607687467761684/615611007951306863/1543000181488885760
Data recording: [tablet-data_1787950627.txt](https://github.com/user-attachments/files/31575418/tablet-data_1787950627.txt)

This tablet does not have the same weird thing where it would roll its strings after they're requested so we can be normal and use string 201 here.