### PR TITLE
Add support for veikk vk850

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/VK850.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/VK850.json
@@ -13,7 +13,13 @@
     },
     "AuxiliaryButtons": {
       "ButtonCount": 10
-    }
+    },
+    "Wheels": [
+      {
+        "RelativeWheelSteps": 24,
+        "ButtonCount": 0
+      }
+    ]
   },
   "DigitizerIdentifiers": [
     {

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/VK850.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/VK850.json
@@ -8,7 +8,7 @@
       "MaxY": 25400
     },
     "Pen": {
-      "MaxPressure": 16384,
+      "MaxPressure": 16383,
       "ButtonCount": 2
     },
     "AuxiliaryButtons": {

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/VK850.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/VK850.json
@@ -1,0 +1,35 @@
+{
+  "Name": "VEIKK VK850",
+  "Specifications": {
+    "Digitizer": {
+      "Width": 203.2,
+      "Height": 127.0,
+      "MaxX": 40640,
+      "MaxY": 25400
+    },
+    "Pen": {
+      "MaxPressure": 16384,
+      "ButtonCount": 2
+    },
+    "AuxiliaryButtons": {
+      "ButtonCount": 10
+    }
+  },
+  "DigitizerIdentifiers": [
+    {
+      "VendorID": 12267,
+      "ProductID": 32,
+      "InputReportLength": 13,
+      "OutputReportLength": 9,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.Veikk.VeikkTiltReportParser",
+      "OutputInitReport": [
+        "CQEE",
+        "CQIC",
+        "CQMC"
+      ]
+    }
+  ],
+  "Attributes": {
+    "libinputoverride": "1"
+  }
+}

--- a/OpenTabletDriver.Configurations/Configurations/VEIKK/VK850.json
+++ b/OpenTabletDriver.Configurations/Configurations/VEIKK/VK850.json
@@ -3,7 +3,7 @@
   "Specifications": {
     "Digitizer": {
       "Width": 203.2,
-      "Height": 127.0,
+      "Height": 127,
       "MaxX": 40640,
       "MaxY": 25400
     },

--- a/OpenTabletDriver.Configurations/Parsers/Veikk/VeikkTiltReportParser.cs
+++ b/OpenTabletDriver.Configurations/Parsers/Veikk/VeikkTiltReportParser.cs
@@ -12,6 +12,7 @@ namespace OpenTabletDriver.Configurations.Parsers.Veikk
             {
                 0x41 when report[2] is 0xC0 => new OutOfRangeReport(report),
                 0x41 => new VeikkTiltTabletReport(report),
+                0x42 when report[2] is 0x03 => new VeikkRelativeWheelReport(report),
                 0x42 => new VeikkAuxReport(report),
                 0x43 => new DeviceReport(report),// touchpad report not supported yet
                 _ => new DeviceReport(report),

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -317,6 +317,7 @@
 | VEIKK Voila (VO1060)               |  Missing Features | Wheel is not yet supported.
 | VEIKK VK1060PRO                    |  Missing Features | Wheels not yet supported.
 | VEIKK VK2200PRO                    |  Missing Features | Wheels not yet supported, tablet buttons may be mapped incorrectly.
+| VEIKK VK850                        |  Missing Features | Wheel is not yet supported.
 | Wacom CTE-450                      |  Missing Features | Wheel is not yet supported.
 | Wacom CTE-650                      |  Missing Features | Wheel is not yet supported.
 | Wacom CTH-300                      |  Missing Features | Touch is not yet supported.

--- a/TABLETS.md
+++ b/TABLETS.md
@@ -97,6 +97,7 @@
 | VEIKK VK430                        |     Supported     |
 | VEIKK VK430 V2                     |     Supported     |
 | VEIKK VK640                        |     Supported     |
+| VEIKK VK850                        |     Supported     |
 | ViewSonic Woodpad PF0730           |     Supported     |
 | ViewSonic Woodpad PF1030           |     Supported     |
 | Wacom CTC-4110WL                   |     Supported     |
@@ -317,7 +318,6 @@
 | VEIKK Voila (VO1060)               |  Missing Features | Wheel is not yet supported.
 | VEIKK VK1060PRO                    |  Missing Features | Wheels not yet supported.
 | VEIKK VK2200PRO                    |  Missing Features | Wheels not yet supported, tablet buttons may be mapped incorrectly.
-| VEIKK VK850                        |  Missing Features | Wheel is not yet supported.
 | Wacom CTE-450                      |  Missing Features | Wheel is not yet supported.
 | Wacom CTE-650                      |  Missing Features | Wheel is not yet supported.
 | Wacom CTH-300                      |  Missing Features | Touch is not yet supported.


### PR DESCRIPTION
Added support for the VEIKK VK850.

Verified with my own tablet.

Maxes at the bottom right corner:
<img width="1171" height="739" alt="image" src="https://github.com/user-attachments/assets/17cadc82-4df1-410a-95f9-bd327f6cfe36" />

Diagnostics:
[Diagnostics-067 VEIKK VK850.json](https://github.com/user-attachments/files/31613829/Diagnostics-067.VEIKK.VK850.json)
