### PR TITLE
Do not reset bindings delta when wheels computed delta = 0

### DIFF
--- a/OpenTabletDriver.Desktop/Binding/WheelBindings.cs
+++ b/OpenTabletDriver.Desktop/Binding/WheelBindings.cs
@@ -104,9 +104,6 @@ namespace OpenTabletDriver.Desktop.Binding
                     CounterClockwiseRotation?.Invoke(tablet, report, counts * _stepsPerTick);
                     ClockwiseRotation?.Reset();
                     break;
-                case 0:
-                    Reset();
-                    break;
             }
         }
 


### PR DESCRIPTION
Found out while troubleshooting issues with proper wheel support in #5005 that the deltas in bindings are being reset when wheels report a delta of 0, which is not proper behavior for multiple reasons : 

- Being static with an absolute wheel or a wheel with few steps may result in delta being reset, and wheel bindings not being triggered properly.
- Some relative wheels could not use an often > 1 delta converted in degrees.

In the example for a relative wheel from the Veikk 850 : 

- Tablet reports wheel delta = 1
- Tablet immediately reports wheel delta = 0 (Which i thought was referring to "idle" for relative wheels, but that's incorrect)
- Accumulated delta get reset, even if the wheel is still in use.