### PR TITLE
Core: Log bytes of throwing reports

### DIFF
--- a/OpenTabletDriver/Devices/DeviceReader.cs
+++ b/OpenTabletDriver/Devices/DeviceReader.cs
@@ -103,12 +103,13 @@ namespace OpenTabletDriver.Devices
 
         protected void Main()
         {
+            byte[]? data = null;
             try
             {
                 Connected = true;
                 while (Connected)
                 {
-                    var data = ReportStream!.Read();
+                    data = ReportStream!.Read();
                     if (Parser.Parse(data) is T report)
                         OnReport(report);
 
@@ -132,6 +133,9 @@ namespace OpenTabletDriver.Devices
             catch (Exception ex)
             {
                 Log.Exception(ex);
+
+                string formattedTabletData = data != null ? Extensions.PrettyPrintHex(data) : "<null>";
+                Log.Write("Device", $"Last report read from tablet: {formattedTabletData}");
             }
             finally
             {

--- a/OpenTabletDriver/Extensions.cs
+++ b/OpenTabletDriver/Extensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using OpenTabletDriver.Plugin;
 
 namespace OpenTabletDriver
@@ -25,5 +26,27 @@ namespace OpenTabletDriver
 
         public static TValue SafeGet<TSource, TValue>(this TSource source, Func<TSource, TValue> predicate, TValue fallback) =>
             source.TryGet(predicate, out var value) ? value : fallback;
+
+        /// <summary>
+        /// Converts a byte span to a hex-value pretty-printed string
+        /// </summary>
+        /// <param name="data">Bytes to pretty print</param>
+        /// <param name="wrap">If <c>true</c>, wrap string in curly braces</param>
+        /// <returns>A pretty-printed string, e.g. <c>"{ 00 02 F0 }"</c></returns>
+        public static string PrettyPrintHex(ReadOnlySpan<byte> data, bool wrap = true)
+        {
+            var sb = new StringBuilder(data.Length * 3 + (wrap ? 3 : 0));
+            foreach (byte b in data)
+                sb.Append($"{b:X2} ");
+
+            if (wrap)
+            {
+                sb.Insert(0, "{ ");
+                sb.Append('}');
+            }
+            else sb.Remove(sb.Length - 1, 1);
+
+            return sb.ToString();
+        }
     }
 }


### PR DESCRIPTION
This should help debug instances of tablets sending sporadic weird reports that the parser throws an exception on.

Issues like #4942 are easier to debug with this.