### PR TITLE
Deco MW: Add identifier for 12/64 firmware variant

### DIFF
--- a/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco MW.json
+++ b/OpenTabletDriver.Configurations/Configurations/XP-Pen/Deco MW.json
@@ -25,6 +25,16 @@
       "OutputInitReport": [
         "ArAE"
       ]
+    },
+    {
+      "VendorID": 10429,
+      "ProductID": 2358,
+      "InputReportLength": 12,
+      "OutputReportLength": 64,
+      "ReportParser": "OpenTabletDriver.Configurations.Parsers.XP_Pen.XP_PenOffsetPressureReportParser",
+      "OutputInitReport": [
+        "ArAE"
+      ]
     }
   ],
   "Attributes": {


### PR DESCRIPTION
Adds a second digitizer identifier (in=12, out=64) for the XP-Pen Deco MW (28bd:0936).

Reasoning: units with firmware ACD02-C_V1.1.2 expose input length 12 and output length 64 on the vendor interface (USB iface 2), so the existing 14/33 identifier never matches and the daemon reports 'No tablets were detected' despite the tablet being listed as supported. Verified on OTD v0.6.7: with this identifier the tablet is found, accepts init 02-B0-04, and pen input works (self-verified by owner).

Diagnostics: https://gist.github.com/DavidScann/551d23cbadff7d5d7e4909842d90a388
Related: #4691