### PR TITLE
UX: Open load settings dialog in settings directory

### DIFF
--- a/OpenTabletDriver.UX/MainForm.cs
+++ b/OpenTabletDriver.UX/MainForm.cs
@@ -511,7 +511,7 @@ namespace OpenTabletDriver.UX
         {
             var fileDialog = Extensions.OpenFileDialog(
                 "Load OpenTabletDriver settings...",
-                Eto.EtoEnvironment.GetFolderPath(Eto.EtoSpecialFolder.Documents),
+                Path.GetDirectoryName(AppInfo.Current.SettingsFile),
                 [new FileFilter("OpenTabletDriver Settings (*.json)", ".json")]
             );
 


### PR DESCRIPTION
Changes the initial directory for File -> Load settings... from the user's Documents folder to the directory containing OpenTabletDriver's active settings.json.\n\nThis uses AppInfo.Current.SettingsFile rather than hardcoding a platform-specific configuration path, so custom app-data locations continue to work.\n\nTested on Linux with the GTK frontend and with a locally built package. The dialog now opens directly in the directory containing the active settings.json.